### PR TITLE
Implement chat for puzzles

### DIFF
--- a/client/components/00TextAreaAutosize.jsx
+++ b/client/components/00TextAreaAutosize.jsx
@@ -1,0 +1,346 @@
+/* Adapted from Andrey Popp's react-textarea-autosize:
+ * https://github.com/andreypopp/react-textarea-autosize/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2013 Andrey Popp
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+/**
+ * <TextareaAutosize />
+ */
+
+const emptyFunction = function() {};
+
+TextareaAutosize = React.createClass({
+
+  propTypes: {
+    /**
+     * Current textarea value.
+     */
+    value: React.PropTypes.string,
+
+    /**
+     * Callback on value change.
+     */
+    onChange: React.PropTypes.func,
+
+    /**
+     * Callback on height changes.
+     */
+    onHeightChange: React.PropTypes.func,
+
+    /**
+     * Try to cache DOM measurements performed by component so that we don't
+     * touch DOM when it's not needed.
+     *
+     * This optimization doesn't work if we dynamically style <textarea />
+     * component.
+     */
+    useCacheForDOMMeasurements: React.PropTypes.bool,
+
+    /**
+     * Minimal numbder of rows to show.
+     */
+    rows: React.PropTypes.number,
+
+    /**
+     * Alias for `rows`.
+     */
+    minRows: React.PropTypes.number,
+
+    /**
+     * Maximum number of rows to show.
+     */
+    maxRows: React.PropTypes.number,
+  },
+
+  getDefaultProps() {
+    return {
+      onChange: emptyFunction,
+      onHeightChange: emptyFunction,
+      useCacheForDOMMeasurements: false,
+    };
+  },
+
+  getInitialState() {
+    this._onNextFrameActionId = null;
+    this._rootDOMNode = null;
+    return {
+      height: null,
+      minHeight: -Infinity,
+      maxHeight: Infinity,
+    };
+  },
+
+  render() {
+    let {valueLink, onChange, ...props} = this.props;
+    props = {...props};
+    if (typeof valueLink === 'object') {
+      props.value = this.props.valueLink.value;
+    }
+
+    props.style = {
+      ...props.style,
+      height: this.state.height,
+    };
+    let maxHeight = Math.max(
+      props.style.maxHeight ? props.style.maxHeight : Infinity,
+      this.state.maxHeight);
+    if (maxHeight < this.state.height) {
+      props.style.overflow = 'hidden';
+    }
+
+    return (
+      <textarea
+        {...props}
+        onChange={this._onChange}
+        ref={this._onRootDOMNode}
+        />
+    );
+  },
+
+  componentDidMount() {
+    this._resizeComponent();
+    window.addEventListener('resize', this._resizeComponent);
+  },
+
+  componentWillReceiveProps() {
+    // Re-render with the new content then recalculate the height as required.
+    this._clearNextFrame();
+    this._onNextFrameActionId = onNextFrame(this._resizeComponent);
+  },
+
+  componentDidUpdate(prevProps, prevState) {
+    // Invoke callback when old height does not equal to new one.
+    if (this.state.height !== prevState.height) {
+      this.props.onHeightChange(this.state.height);
+    }
+  },
+
+  componentWillUnmount() {
+    // Remove any scheduled events to prevent manipulating the node after it's
+    // been unmounted.
+    this._clearNextFrame();
+    window.removeEventListener('resize', this._resizeComponent);
+  },
+
+  _clearNextFrame() {
+    if (this._onNextFrameActionId) {
+      clearNextFrameAction(this._onNextFrameActionId);
+    }
+  },
+
+  _onRootDOMNode(node) {
+    this._rootDOMNode = node;
+  },
+
+  _onChange(e) {
+    this._resizeComponent();
+    let {valueLink, onChange} = this.props;
+    if (valueLink) {
+      valueLink.requestChange(e.target.value);
+    } else {
+      onChange(e);
+    }
+  },
+
+  _resizeComponent() {
+    let {useCacheForDOMMeasurements} = this.props;
+    this.setState(calculateNodeHeight(
+      this._rootDOMNode,
+      useCacheForDOMMeasurements,
+      this.props.rows || this.props.minRows,
+      this.props.maxRows));
+  },
+
+  /**
+   * Put focus on a <textarea /> DOM element.
+   */
+  focus() {
+    this._rootDOMNode.focus();
+  },
+
+  /**
+   * Shifts focus away from a <textarea /> DOM element.
+   */
+  blur() {
+    this._rootDOMNode.blur();
+  },
+});
+
+function onNextFrame(cb) {
+  if (window.requestAnimationFrame) {
+    return window.requestAnimationFrame(cb);
+  }
+
+  return window.setTimeout(cb, 1);
+}
+
+function clearNextFrameAction(nextFrameId) {
+  if (window.cancelAnimationFrame) {
+    window.cancelAnimationFrame(nextFrameId);
+  } else {
+    window.clearTimeout(nextFrameId);
+  }
+}
+
+/**
+ * calculateNodeHeight(uiTextNode, useCache = false)
+ */
+
+const HIDDEN_TEXTAREA_STYLE = `
+  min-height:none !important;
+  max-height:none !important;
+  height:0 !important;
+  visibility:hidden !important;
+  overflow:hidden !important;
+  position:absolute !important;
+  z-index:-1000 !important;
+  top:0 !important;
+  right:0 !important
+`;
+
+const SIZING_STYLE = [
+  'letter-spacing',
+  'line-height',
+  'padding-top',
+  'padding-bottom',
+  'font-family',
+  'font-weight',
+  'font-size',
+  'text-rendering',
+  'text-transform',
+  'width',
+  'padding-left',
+  'padding-right',
+  'border-width',
+  'box-sizing',
+];
+
+let computedStyleCache = {};
+let hiddenTextarea;
+
+function calculateNodeHeight(uiTextNode, useCache = false, minRows = null, maxRows = null) {
+  if (!hiddenTextarea) {
+    hiddenTextarea = document.createElement('textarea');
+    document.body.appendChild(hiddenTextarea);
+  }
+
+  // Copy all CSS properties that have an impact on the height of the content in
+  // the textbox
+  let {
+    paddingSize, borderSize,
+    boxSizing, sizingStyle,
+  } = calculateNodeStyling(uiTextNode, useCache);
+
+  // Need to have the overflow attribute to hide the scrollbar otherwise
+  // text-lines will not calculated properly as the shadow will technically be
+  // narrower for content
+  hiddenTextarea.setAttribute('style', sizingStyle + ';' + HIDDEN_TEXTAREA_STYLE);
+  hiddenTextarea.value = uiTextNode.value || uiTextNode.placeholder || '';
+
+  let minHeight = -Infinity;
+  let maxHeight = Infinity;
+  let scrollHeight = hiddenTextarea.scrollHeight;
+  let height = scrollHeight;
+
+  if (boxSizing === 'border-box') {
+    // border-box: add border, since height = content + padding + border
+    height = height + borderSize;
+  } else if (boxSizing === 'content-box') {
+    // remove padding, since height = content
+    height = height - paddingSize;
+  }
+
+  if (minRows !== null || maxRows !== null) {
+    // measure height of a textarea with a single row
+    hiddenTextarea.value = '';
+    let singleRowHeight = scrollHeight - paddingSize;
+    if (minRows !== null) {
+      minHeight = singleRowHeight * minRows;
+
+      if (boxSizing === 'border-box') {
+        minHeight = minHeight + paddingSize + borderSize;
+      }
+
+      height = Math.max(minHeight, height);
+    }
+
+    if (maxRows !== null) {
+      maxHeight = singleRowHeight * maxRows;
+
+      if (boxSizing === 'border-box') {
+        maxHeight = maxHeight + paddingSize + borderSize;
+      }
+
+      height = Math.min(maxHeight, height);
+    }
+  }
+
+  return {height, minHeight, maxHeight};
+}
+
+function calculateNodeStyling(node, useCache = false) {
+  let nodeRef = (
+    node.getAttribute('id') ||
+    node.getAttribute('data-reactid') ||
+    node.getAttribute('name')
+  );
+
+  if (useCache && computedStyleCache[nodeRef]) {
+    return computedStyleCache[nodeRef];
+  }
+
+  let style = window.getComputedStyle(node);
+
+  let boxSizing = (
+    style.getPropertyValue('box-sizing') ||
+    style.getPropertyValue('-moz-box-sizing') ||
+    style.getPropertyValue('-webkit-box-sizing')
+  );
+
+  let paddingSize = (
+    parseFloat(style.getPropertyValue('padding-bottom')) +
+    parseFloat(style.getPropertyValue('padding-top'))
+  );
+
+  let borderSize = (
+    parseFloat(style.getPropertyValue('border-bottom-width')) +
+    parseFloat(style.getPropertyValue('border-top-width'))
+  );
+
+  let sizingStyle = SIZING_STYLE
+    .map(name => `${name}:${style.getPropertyValue(name)}`)
+    .join(';');
+
+  let nodeInfo = {
+    sizingStyle,
+    paddingSize,
+    borderSize,
+    boxSizing,
+  };
+
+  if (useCache && nodeRef) {
+    computedStyleCache[nodeRef] = nodeInfo;
+  }
+
+  return nodeInfo;
+}

--- a/lib/models/00index.js
+++ b/lib/models/00index.js
@@ -75,6 +75,7 @@ Transforms.Base = class Base {
 };
 
 const formatQuery = '@@formatQuery';
+Models.formatQuery = formatQuery;
 Models.Base = class Base extends Mongo.Collection {
   constructor(name, options={}) {
     let Klass = options.klass || Transforms.Base;

--- a/lib/models/chats.js
+++ b/lib/models/chats.js
@@ -1,0 +1,131 @@
+Schemas.ChatMetadata = new SimpleSchema([
+  Schemas.Base,
+  {
+    _id: {
+      // Matches the Puzzle's _id.
+      type: String,
+      regEx: SimpleSchema.RegEx.Id,
+    },
+    slackChannel: {
+      // The Slack channel ID that we want to bridge this puzzle's chat to.
+      type: String,
+    },
+    slackChannelState: {
+      // Tracks the state of this channel referenced, so we don't try to send
+      // messages to archived or deleted channels.
+      type: String,
+      allowedValues: ['unjoined', 'active', 'archived', 'deleted'],
+    },
+  },
+]);
+
+Models.ChatMetadata = new Models.Base('chatmetadata');
+Models.ChatMetadata.attachSchema(Schemas.ChatMetadata);
+
+Schemas.SlackMessageInfo = new SimpleSchema({
+  userId: {
+    type: String,
+  },
+  channelId: {
+    type: String,
+  },
+  direction: {
+    // Indicates which direction this message originates from - did we initially send it to slack,
+    // or did we learn about it from slack?
+    type: String,
+    allowedValues: ['sent-to-slack', 'received-from-slack'],
+  },
+  state: {
+    // If 'sending', we've sent or are sending the request to Slack to post this message.
+    // If 'acknowledged', Slack has acknowledged the message and hopefully given us a message ID.
+    type: String,
+    allowedValues: ['sending', 'acknowledged', 'failed'],
+  },
+  timestamp: {
+    // Only present if state === 'acknowledged'.
+    // Slack's timestamps look like "1451774094.000005" - to the left of the . is a UNIX timestamp;
+    // to the right is an incrementing sequence number.
+    type: String,
+    optional: true,
+  },
+});
+
+// A single chat message
+Schemas.ChatMessages = new SimpleSchema([
+
+  // Note that we don't inherit from Schemas.Base because we don't care about supporting message
+  // deletion, and we need to be able to create records for chat messages from external sources that
+  // were not created by any particular member of Meteor.users.
+  {
+    puzzleId: {
+      // The puzzle to which this chat was sent.
+      type: String,
+      regEx: SimpleSchema.RegEx.Id,
+    },
+    text: {
+      // The message body.  Plain text.
+      type: String,
+    },
+    sender: {
+      // Optional.  If present: userId of the user who sent this message.
+      // This may be omitted for messages that come from an external source,
+      // e.g. slack bots that do not have Jolly Roger accounts.
+      type: String,
+      optional: true,
+      regEx: SimpleSchema.RegEx.Id,
+    },
+    timestamp: {
+      // The date this message was sent.  Used for ordering chats in the log.
+      type: Date,
+    },
+    slackInfo: {
+      // Information about the external service this message is bridged to.
+      type: Schemas.SlackMessageInfo,
+      optional: true,
+    },
+  },
+]);
+
+class ChatMessages extends Mongo.Collection {
+  // Some basic helpers are copied from Models.Base, but not all of them,
+  // since we need to be able to receive chat messages from Slack with no
+  // attached userId.
+  constructor(options={}) {
+    let Klass = Transforms.Base;
+    super('jr_chatmessages', _.extend({
+      transform: doc => { return new Klass(this, doc); },
+    }, options));
+
+    if (Meteor.isServer) {
+      const _this = this;
+      Meteor.publish('mongo.chatmessages', function(q={}) {
+        check(q, Match.Optional(Object));
+        if (this.userId) {
+          return _this.find(q);
+        } else {
+          return [];
+        }
+      });
+    }
+
+    this.attachRoles('mongo.chatmessages');
+  }
+
+  [Models.formatQuery](selector) {
+    if (typeof selector === 'string' || selector instanceof Mongo.ObjectID) {
+      return {_id: selector};
+    } else {
+      return selector;
+    }
+  }
+
+  find(selector={}, options={}) {
+    return super.find(this[Models.formatQuery](selector), options);
+  }
+
+  findOne(selector={}, options={}) {
+    return super.find(this[Models.formatQuery](selector), options);
+  }
+};
+Models.ChatMessages = new ChatMessages();
+Models.ChatMessages.attachSchema(Schemas.ChatMessages);

--- a/lib/models/slackuserinfo.js
+++ b/lib/models/slackuserinfo.js
@@ -1,0 +1,30 @@
+// Stores a Slack API token associated with a user and other context from Slack about that user.
+Schemas.SlackUserInfo = new SimpleSchema({
+  _id: {
+    // _id should match that of the Meteor.user this document is related to.
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  token: {
+    // Slack API token.  Secret, so we must avoid publishing it in the collection.
+    type: String,
+  },
+  slackUserId: {
+    // The Slack userId (e.g. "U03CQBG33") that this token acts as.
+    type: String,
+  },
+  handle: {
+    // The Slack handle associated with the above Slack userId.
+    // Useful for displaying profile information.
+    type: String,
+  },
+  displayName: {
+    // The Slack display name associated with the above Slack userId.
+    // Useful for displaying profile information.
+    type: String,
+  },
+});
+
+// We can't just publish everything since that would give away everyone's Slack tokens to everyone.
+//Models.SlackUserInfo = new Models.Base('slackuserinfo');
+//Models.SlackUserInfo.attachSchema(Schemas.SlackUserInfo);

--- a/server/chat.js
+++ b/server/chat.js
@@ -1,0 +1,33 @@
+Meteor.methods({
+  sendChatMessage(puzzleId, message) {
+    check(this.userId, String);
+    check(puzzleId, String);
+    check(message, String);
+
+    /* TODO: implement Slack bridging
+    let slackInfo = {
+      // TODO: look up slack userId from this.userId's Profile, if available.
+      userId:
+      // TODO: look up Slack channelId from this puzzleId's ChatMetadata, if available.
+      channelId:
+      direction: 'sent-to-slack',
+      state: 'sending'
+    };
+    */
+
+    Models.ChatMessages.insert({
+      puzzleId: puzzleId,
+      text: message,
+      sender: this.userId,
+      timestamp: new Date(),
+      /* TODO: implement Slack bridge
+      slackInfo: {
+      },
+      */
+    });
+
+    // TODO: Fire off a request to Slack to post this message there, too.
+    // If we have a Slack API key for this user, use that - otherwise,
+    // send as the globally-configured jolly-roger/deathfromdata bot.
+  },
+});


### PR DESCRIPTION
This commit adds an internal chat implementation, suitable for working on
puzzles and tracking user activity.  Future work may support bridging to Slack.

Some UI things remain to be worked out:
- desirable magic like autohyperlinking text that looks like a link
- sorting out display name if there's no userId on the message (more an issue once messages can come from Slack)
- assigning appropriate amounts of space to the related puzzles section vs. the chat section of the
  left sidebar
- autoscroll chat after receiving new message (set scrollHeight in
  componentDidUpdate probably?)
- do we want to distinguish who said what by color?
- how do we want to display message timestamps?  I mimicked Etherpad for now.
