### PR TITLE
Format chat messages as Slack-flavored Markdown

### DIFF
--- a/client/components/PuzzlePage.jsx
+++ b/client/components/PuzzlePage.jsx
@@ -33,6 +33,44 @@ RelatedPuzzleSection = React.createClass({
   },
 });
 
+ChatMessage = React.createClass({
+  mixins: [PureRenderMixin],
+  propTypes: {
+    message: React.PropTypes.shape(Schemas.ChatMessages.asReactPropTypes()).isRequired,
+    sender: React.PropTypes.shape(Schemas.Profiles.asReactPropTypes()).isRequired,
+  },
+
+  styles: {
+    message: {
+      // TODO: pick background color based on hashing userid or something?
+      backgroundColor: '#f8f8f8',
+      marginBottom: '1',
+      wordWrap: 'break-word',
+    },
+    time: {
+      float:'right',
+      fontStyle: 'italic',
+      marginRight: '2',
+    },
+  },
+
+  render() {
+    // TODO: consider how we want to format dates, if the day was yesterday, or many days ago.
+    // This is ugly, but moment.js is huge
+    let hours = this.props.message.timestamp.getHours();
+    let minutes = this.props.message.timestamp.getMinutes();
+    let ts = `${hours < 10 ? '0' + hours : '' + hours}:${minutes < 10 ? '0' + minutes : '' + minutes}`;
+
+    return (
+      <div style={this.styles.message}>
+        <span style={this.styles.time}>{ts}</span>
+        <strong>{this.props.sender.displayName}</strong>
+        <span dangerouslySetInnerHTML={{__html: marked(this.props.message.text, {sanitize: true})}}/>
+      </div>
+    );
+  },
+});
+
 ChatHistory = React.createClass({
   mixins: [PureRenderMixin],
   propTypes: {
@@ -49,17 +87,6 @@ ChatHistory = React.createClass({
     messagePane: {
       flex: 'auto',
       overflowY: 'auto',
-    },
-    message: {
-      // TODO: pick background color based on hashing userid or something?
-      backgroundColor: '#f8f8f8',
-      marginBottom: '1',
-      wordWrap: 'break-word',
-    },
-    time: {
-      float:'right',
-      fontStyle: 'italic',
-      marginRight: '2',
     },
   },
 
@@ -116,19 +143,8 @@ ChatHistory = React.createClass({
     let profiles = this.props.profiles;
     return (
       <div ref='messagePane' style={this.styles.messagePane} onScroll={this.onScroll}>
-        { this.props.chatMessages.length === 0 && <span key="no-message">No chatter yet. Say something?</span> }
-        { this.props.chatMessages.map((msg) => {
-          // TODO: consider how we want to format dates, if the day was yesterday, or many days ago.
-          // This is ugly, but moment.js is huge
-          let hours = msg.timestamp.getHours();
-          let minutes = msg.timestamp.getMinutes();
-          let ts = `${hours < 10 ? '0' + hours : '' + hours}:${minutes < 10 ? '0' + minutes : '' + minutes}`;
-
-          return <div key={msg._id} style={this.styles.message}>
-            <span style={this.styles.time}>{ ts }</span>
-            <strong>{profiles[msg.sender].displayName}</strong>: {msg.text}
-          </div>;
-        }) }
+        {this.props.chatMessages.length === 0 && <span key="no-message">No chatter yet. Say something?</span>}
+        {this.props.chatMessages.map((msg) => <ChatMessage key={msg._id} message={msg} sender={profiles[msg.sender]}/>)}
       </div>
     );
   },

--- a/client/lib/marked.js
+++ b/client/lib/marked.js
@@ -1,0 +1,2 @@
+marked.InlineLexer.rules.gfm.em = /^\b_((?:__|[^_])+?)_\b/;
+marked.InlineLexer.rules.gfm.strong = /^\b\*((?:\*\*|[^\*])+?)\*\b/;

--- a/packages/client-deps/.npm/package/npm-shrinkwrap.json
+++ b/packages/client-deps/.npm/package/npm-shrinkwrap.json
@@ -194,6 +194,9 @@
         }
       }
     },
+    "marked": {
+      "version": "http://registry.npmjs.org/marked/-/marked-0.3.5.tgz"
+    },
     "react": {
       "version": "http://registry.npmjs.org/react/-/react-0.14.6.tgz",
       "dependencies": {

--- a/packages/client-deps/app.browserify.js
+++ b/packages/client-deps/app.browserify.js
@@ -4,3 +4,5 @@ ReactRouter.history = require('history');
 ReactRouterBootstrap = require('react-router-bootstrap');
 
 classnames = require('classnames');
+
+marked = require('marked');

--- a/packages/client-deps/package.js
+++ b/packages/client-deps/package.js
@@ -9,10 +9,11 @@ Npm.depends({
   'react-bootstrap': '0.28.1',
   'react-router-bootstrap': '0.19.3',
   classnames: '2.2.3',
+  marked: '0.3.5',
 });
 
 Package.onUse(function(api) {
   api.use(['cosmos:browserify', 'react-runtime'], 'client');
   api.addFiles(['app.browserify.js', 'app.browserify.options.json'], 'client');
-  api.export(['ReactBootstrap', 'ReactRouter', 'ReactRouterBootstrap', 'classnames'], 'client');
+  api.export(['ReactBootstrap', 'ReactRouter', 'ReactRouterBootstrap', 'classnames', 'marked'], 'client');
 });


### PR DESCRIPTION
client/lib/marked.js is pretty terrible, but I can't override the
behavior of the InlineLexer because all of the other marked code
invokes it by reference, which I can't change.
