### PR TITLE
Try to shrink the image by better managing dependencies

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .git
 .meteor/local
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,37 +2,13 @@ FROM ubuntu:14.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update && \
-  apt-key adv --keyserver keyserver.ubuntu.com --recv-key D1CD49BDD30B677273A75C66E4EE62700D8A9E8F && \
-  echo "deb http://debathena.mit.edu/apt trusty debathena debathena-config debathena-system" > /etc/apt/sources.list.d/debathena.list && \
-  apt-get update && \
-  apt-get install -y python-pip python-dev debathena-moira-clients kstart apt-transport-https curl && \
-  pip install credstash && \
-  apt-get remove -y python-dev && \
-  apt-get autoremove -y && \
-  apt-get clean
-
-# This needs to run as a separate step because the previous RUN
-# installs apt-transport-https
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280 && \
-  echo "deb https://deb.nodesource.com/node_4.x trusty main" > /etc/apt/sources.list.d/node.list && \
-  apt-get update && \
-  apt-get install -y nodejs && \
-  apt-get autoremove -y && \
-  apt-get clean
-
 COPY . /app
 WORKDIR /app
 
-RUN curl -sL https://install.meteor.com?release=1.4.0.1 | /bin/sh && \
-  npm i && \
-  meteor build --directory /built_app --server=http://localhost:3000 && \
-  meteor npm run lint && \
-  (cd /built_app/bundle/programs/server && npm i) && \
-  rm -rf ~/.meteor /app
+RUN ./build.sh
 
 ENV PORT 80
 EXPOSE 80
 
 WORKDIR /built_app/bundle
-CMD /app/scripts/run_jolly_roger.sh
+CMD /built_app/scripts/run_jolly_roger.sh

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eux
+set -o pipefail
+
+# Install apt https support for node
+apt-get update
+apt-get install --no-install-recommends -y apt-transport-https ca-certificates
+
+# Add debathena and node apt repos
+apt-key adv --keyserver keyserver.ubuntu.com --recv-key D1CD49BDD30B677273A75C66E4EE62700D8A9E8F
+echo "deb http://debathena.mit.edu/apt trusty debathena debathena-config debathena-system" > /etc/apt/sources.list.d/debathena.list
+apt-key adv --keyserver keyserver.ubuntu.com --recv-key 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280
+echo "deb https://deb.nodesource.com/node_4.x trusty main" > /etc/apt/sources.list.d/node.list
+
+# Install build deps
+apt-get update
+apt-get install --no-install-recommends -y python python-pip python-dev build-essential debathena-moira-clients kstart curl nodejs
+
+pip install credstash
+
+# Install meteor and build app
+METEOR_RELEASE="$(sed -e 's/.*@//g' .meteor/release)"
+curl -sL https://install.meteor.com?release=$METEOR_RELEASE | sh
+npm i
+meteor build --directory /built_app --server=http://localhost:3000
+meteor npm run lint
+(cd /built_app/bundle/programs/server && npm i)
+cp -a /app/scripts /built_app/scripts
+
+# Cleanup
+rm -rf ~/.meteor /app
+apt-get remove -y python-dev build-essential
+apt-get autoremove -y
+apt-get clean
+rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Consolidate entire build process into a single RUN instruction so that we can more thoroughly cleanup after ourselves, and push that instruction into a script so we can get nice things like comments.

On my laptop, at least, this change takes the docker image from 584M down to 442M.

The biggest drawback here is that it's now completely impossible to get any layer sharing across builds. In practice, though, that goal is almost completely contradictory with having small builds, and I don't think Docker Cloud actually maintains a layer cache across builds anyway, so I think it's moot.

r? @zarvox 
