### PR TITLE
Log failed logins directly, not through ansible

### DIFF
--- a/server/accounts.js
+++ b/server/accounts.js
@@ -3,6 +3,7 @@ import { check } from 'meteor/check';
 import { Accounts } from 'meteor/accounts-base';
 import { _ } from 'meteor/underscore';
 import Ansible from '/imports/ansible.js';
+import logfmt from 'logfmt';
 
 const summaryFromLoginInfo = function (info) {
   switch (info.methodName) {
@@ -51,12 +52,14 @@ Accounts.onLoginFailure((info) => {
     info.methodArguments[0] &&
     info.methodArguments[0].user &&
     info.methodArguments[0].user.email;
-  Ansible.log('Failed login attempt', {
+  const data = {
     user: info.user && info.user._id,
     email,
     ip: info.connection.clientAddress,
     error: info.error.reason,
-  });
+  };
+  // eslint-disable-next-line no-console
+  console.log(`Failed login attempt: ${logfmt.stringify(data)}`);
 });
 
 Accounts.urls.enrollAccount = (token) => Meteor.absoluteUrl(`enroll/${token}`);


### PR DESCRIPTION
The onLoginFailure hook gets called in a client-initiated
context (i.e. `this.connection` is set), which means that Ansible
rejects it (since the user isn't logged in, obviously - the login just
failed).

We could solve this by making the Ansible interface a bit more flexible,
but realistically it's not worth the effort, so just splat things out in
place.

r? @zarvox 