### PR TITLE
Upgrade react-bootstrap to 0.30.7, fix searchbar autofocus

### DIFF
--- a/imports/client/components/PuzzleListPage.jsx
+++ b/imports/client/components/PuzzleListPage.jsx
@@ -440,7 +440,7 @@ const PuzzleListView = React.createClass({
             <BS.FormControl
               id="jr-puzzle-search"
               type="text"
-              ref={(node) => { this.searchBarNode = node; }}
+              inputRef={(node) => { this.searchBarNode = node; }}
               placeholder="search by title, answer, or tag"
               value={this.state.searchString}
               onChange={this.onSearchStringChange}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -510,9 +510,9 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.0.0.tgz"
     },
     "keycode": {
-      "version": "2.1.4",
+      "version": "2.1.8",
       "from": "keycode@>=2.1.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.1.8.tgz"
     },
     "lodash": {
       "version": "2.4.2",
@@ -662,9 +662,9 @@
       "resolved": "https://registry.npmjs.org/react-addons-pure-render-mixin/-/react-addons-pure-render-mixin-15.3.0.tgz"
     },
     "react-bootstrap": {
-      "version": "0.30.2",
-      "from": "react-bootstrap@>=0.30.2 <0.31.0",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.30.2.tgz",
+      "version": "0.30.7",
+      "from": "react-bootstrap@>=0.30.7 <0.31.0",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.30.7.tgz",
       "dependencies": {
         "warning": {
           "version": "3.0.0",
@@ -684,9 +684,9 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-15.3.0.tgz"
     },
     "react-overlays": {
-      "version": "0.6.6",
-      "from": "react-overlays@>=0.6.6 <0.7.0",
-      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.6.6.tgz",
+      "version": "0.6.10",
+      "from": "react-overlays@>=0.6.10 <0.7.0",
+      "resolved": "https://registry.npmjs.org/react-overlays/-/react-overlays-0.6.10.tgz",
       "dependencies": {
         "warning": {
           "version": "3.0.0",
@@ -850,9 +850,9 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.10.tgz"
     },
     "uncontrollable": {
-      "version": "4.0.1",
+      "version": "4.0.3",
       "from": "uncontrollable@>=4.0.1 <5.0.0",
-      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-4.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-4.0.3.tgz"
     },
     "url": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "moment": "^2.14.1",
     "react": "^15.2.1",
     "react-addons-pure-render-mixin": "^15.2.1",
-    "react-bootstrap": "^0.30.2",
+    "react-bootstrap": "^0.30.7",
     "react-document-title": "^2.0.2",
     "react-dom": "^15.2.1",
     "react-router": "^2.5.2",


### PR DESCRIPTION
In particular, I want us to be able to use this commit [1] so I can autofocus
an underlying input node with callback refs (which it appears I broke in 78a09a78599676d913d84cea14e411ab58fa7484).

[1] https://github.com/react-bootstrap/react-bootstrap/commit/3159b723f69e9f6f44350d751b9c2f2f744e3c93