### PR TITLE
Fix our select2 bindings to work with callback refs

### DIFF
--- a/imports/client/components/PuzzleComponents.jsx
+++ b/imports/client/components/PuzzleComponents.jsx
@@ -247,7 +247,7 @@ const TagEditor = React.createClass({
 
   componentDidMount() {
     // Focus the input when mounted - the user just clicked on the button-link.
-    const input = this.inputNode;
+    const input = this.selectNode;
     jQuery(input).select2('open')
       .on('select2:close', this.onBlur)
       .on('select2:select', () => {
@@ -270,7 +270,7 @@ const TagEditor = React.createClass({
     return (
       <span>
         <ReactSelect2
-          ref={(node) => { this.inputNode = node; }}
+          selectRef={(node) => { this.selectNode = node; }}
           style={{ minWidth: '100px' }}
           data={[''].concat(_.pluck(this.data.allTags, 'name'))}
           options={{ tags: true }}

--- a/imports/client/components/ReactSelect2.jsx
+++ b/imports/client/components/ReactSelect2.jsx
@@ -36,6 +36,7 @@ const ReactSelect2 = React.createClass({
     events: PropTypes.array,
     options: PropTypes.object,
     multiple: PropTypes.bool,
+    selectRef: PropTypes.func,
     onOpen: PropTypes.func,
     onClose: PropTypes.func,
     onSelect: PropTypes.func,
@@ -80,12 +81,20 @@ const ReactSelect2 = React.createClass({
 
   render() {
     const remaining = _.omit(this.props,
-      'value', 'data', 'options', 'events', 'onOpen',
+      'value', 'data', 'options', 'events', 'selectRef', 'onOpen',
       'onClose', 'onSelect', 'onChange', 'onUnselect'
     );
 
     return (
-      <select ref={(node) => { this.node = node; }} {...remaining}>
+      <select
+        ref={(node) => {
+          this.node = node;
+          if (this.props.selectRef) {
+            this.props.selectRef(node);
+          }
+        }}
+        {...remaining}
+      >
         {this.props.data.map((item, k) => {
           if (typeof item === 'string' ||
               ((!!item && typeof item === 'object') &&


### PR DESCRIPTION
React itself takes the `ref=` parameter, but then the node it refers to is the `<ReactSelect2/>`, not the `<select/>` element contained within.  So we'll do like react-bootstrap here and provide another optional prop for letting the caller get at the underlying DOM element.