### PR TITLE
Improve PuzzleListPage perf

### DIFF
--- a/imports/client/components/PuzzleComponents.jsx
+++ b/imports/client/components/PuzzleComponents.jsx
@@ -75,7 +75,7 @@ const PuzzleModalForm = React.createClass({
   propTypes: {
     huntId: React.PropTypes.string.isRequired,
     puzzle: React.PropTypes.shape(Schemas.Puzzles.asReactPropTypes()),
-    tags: React.PropTypes.arrayOf(
+    tags: React.PropTypes.arrayOf( // All known tags for this hunt
       React.PropTypes.shape(Schemas.Tags.asReactPropTypes()).isRequired,
     ).isRequired,
     onSubmit: React.PropTypes.func.isRequired,
@@ -282,10 +282,11 @@ const Puzzle = React.createClass({
   displayName: 'Puzzle',
   propTypes: {
     puzzle: React.PropTypes.shape(puzzleShape).isRequired,
-    tags: React.PropTypes.arrayOf(React.PropTypes.shape(tagShape)).isRequired,
+    allTags: React.PropTypes.arrayOf(React.PropTypes.shape(tagShape)).isRequired, // All tags associated with the hunt.
     layout: React.PropTypes.string.isRequired,
+    canUpdate: React.PropTypes.bool.isRequired,
   },
-  mixins: [ReactMeteorData],
+  mixins: [PureRenderMixin],
 
   getInitialState() {
     return {
@@ -296,13 +297,6 @@ const Puzzle = React.createClass({
   onEdit(state, callback) {
     Ansible.log('Updating puzzle properties', { puzzle: this.props.puzzle._id, user: Meteor.userId(), state });
     Meteor.call('updatePuzzle', this.props.puzzle._id, state, callback);
-  },
-
-  getMeteorData() {
-    return {
-      allTags: Models.Tags.find().fetch(),
-      canUpdate: Roles.userHasPermission(Meteor.userId(), 'mongo.puzzles.update'),
-    };
   },
 
   styles: {
@@ -395,7 +389,7 @@ const Puzzle = React.createClass({
   },
 
   editButton() {
-    if (this.data.canUpdate) {
+    if (this.props.canUpdate) {
       return (
         <BS.Button onClick={this.showEditModal} bsStyle="default" bsSize="xs" title="Edit puzzle...">
           <BS.Glyphicon glyph="edit" />
@@ -408,8 +402,8 @@ const Puzzle = React.createClass({
   render() {
     // id, title, answer, tags
     const linkTarget = `/hunts/${this.props.puzzle.hunt}/puzzles/${this.props.puzzle._id}`;
-    const tagIndex = _.indexBy(this.props.tags, '_id');
-    const tags = this.props.puzzle.tags.map((tagId) => { return tagIndex[tagId]; });
+    const tagIndex = _.indexBy(this.props.allTags, '_id');
+    const ownTags = this.props.puzzle.tags.map((tagId) => { return tagIndex[tagId]; });
     const layoutStyles = {
       grid: this.styles.gridLayout,
       inline: this.styles.inlineLayout,
@@ -435,7 +429,7 @@ const Puzzle = React.createClass({
             }}
             puzzle={this.props.puzzle}
             huntId={this.props.puzzle.hunt}
-            tags={this.data.allTags}
+            tags={this.props.allTags}
             onSubmit={this.onEdit}
           /> :
           null
@@ -456,7 +450,7 @@ const Puzzle = React.createClass({
         <div className="puzzle-answer" style={layoutStyles.answer}>
           {this.props.puzzle.answer ? <PuzzleAnswer answer={this.props.puzzle.answer} /> : null}
         </div>
-        <TagList puzzleId={this.props.puzzle._id} tags={tags} />
+        <TagList puzzleId={this.props.puzzle._id} tags={ownTags} />
       </div>
     );
   },
@@ -465,9 +459,10 @@ const Puzzle = React.createClass({
 const PuzzleList = React.createClass({
   displayName: 'PuzzleList',
   propTypes: {
-    puzzles: React.PropTypes.arrayOf(React.PropTypes.shape(puzzleShape)).isRequired,
-    tags: React.PropTypes.arrayOf(React.PropTypes.shape(tagShape)).isRequired,
+    puzzles: React.PropTypes.arrayOf(React.PropTypes.shape(puzzleShape)).isRequired, // The puzzles to show in this list
+    allTags: React.PropTypes.arrayOf(React.PropTypes.shape(tagShape)).isRequired, // All tags for this hunt, including those not used by any puzzles
     layout: React.PropTypes.string.isRequired,
+    canUpdate: React.PropTypes.bool.isRequired,
   },
   mixins: [PureRenderMixin],
   render() {
@@ -477,7 +472,13 @@ const PuzzleList = React.createClass({
     const puzzles = [];
     for (let i = 0; i < this.props.puzzles.length; i++) {
       const puz = this.props.puzzles[i];
-      puzzles.push(<Puzzle key={puz._id} puzzle={puz} tags={this.props.tags} layout={this.props.layout} />);
+      puzzles.push(<Puzzle
+        key={puz._id}
+        puzzle={puz}
+        allTags={this.props.allTags}
+        layout={this.props.layout}
+        canUpdate={this.props.canUpdate}
+      />);
     }
 
     return (
@@ -804,6 +805,7 @@ const RelatedPuzzleGroup = React.createClass({
     allTags: React.PropTypes.arrayOf(React.PropTypes.shape(tagShape)).isRequired,
     includeCount: React.PropTypes.bool,
     layout: React.PropTypes.string.isRequired,
+    canUpdate: React.PropTypes.bool.isRequired,
   },
 
   getInitialState() {
@@ -848,7 +850,12 @@ const RelatedPuzzleGroup = React.createClass({
         </div>
         {this.state.collapsed ? null :
           <div style={this.styles.puzzleListWrapper}>
-            <PuzzleList puzzles={sortedPuzzles} tags={this.props.allTags} layout={this.props.layout} />
+            <PuzzleList
+              puzzles={sortedPuzzles}
+              allTags={this.props.allTags}
+              layout={this.props.layout}
+              canUpdate={this.props.canUpdate}
+            />
           </div>}
       </div>
     );
@@ -861,6 +868,7 @@ const RelatedPuzzleGroups = React.createClass({
     activePuzzle: React.PropTypes.shape(puzzleShape).isRequired,
     allPuzzles: React.PropTypes.arrayOf(React.PropTypes.shape(puzzleShape)).isRequired,
     allTags: React.PropTypes.arrayOf(React.PropTypes.shape(tagShape)).isRequired,
+    canUpdate: React.PropTypes.bool.isRequired,
   },
 
   relatedPuzzlesTagInterestingness(tag, metaForTagIfKnown) {
@@ -951,6 +959,7 @@ const RelatedPuzzleGroups = React.createClass({
               allTags={this.props.allTags}
               includeCount
               layout="inline"
+              canUpdate={this.props.canUpdate}
             />
           );
         }) : <span>No tags for this puzzle yet.</span>

--- a/imports/client/components/PuzzlePage.jsx
+++ b/imports/client/components/PuzzlePage.jsx
@@ -34,6 +34,7 @@ const RelatedPuzzleSection = React.createClass({
         Schemas.Tags.asReactPropTypes()
       ).isRequired
     ).isRequired,
+    canUpdate: React.PropTypes.bool.isRequired,
   },
   mixins: [PureRenderMixin],
   styles: {
@@ -46,7 +47,12 @@ const RelatedPuzzleSection = React.createClass({
     return (
       <div className="related-puzzles-section" style={this.styles}>
         <div>Related puzzles:</div>
-        <RelatedPuzzleGroups activePuzzle={this.props.activePuzzle} allPuzzles={this.props.allPuzzles} allTags={this.props.allTags} />
+        <RelatedPuzzleGroups
+          activePuzzle={this.props.activePuzzle}
+          allPuzzles={this.props.allPuzzles}
+          allTags={this.props.allTags}
+          canUpdate={this.props.canUpdate}
+        />
       </div>
     );
   },
@@ -311,6 +317,7 @@ const PuzzlePageSidebar = React.createClass({
       ).isRequired
     ).isRequired,
     displayNames: React.PropTypes.objectOf(React.PropTypes.string.isRequired).isRequired,
+    canUpdate: React.PropTypes.bool.isRequired,
   },
   mixins: [PureRenderMixin],
   styles: {
@@ -329,6 +336,7 @@ const PuzzlePageSidebar = React.createClass({
           activePuzzle={this.props.activePuzzle}
           allPuzzles={this.props.allPuzzles}
           allTags={this.props.allTags}
+          canUpdate={this.props.canUpdate}
         />
         <ChatSection
           chatReady={this.props.chatReady}
@@ -770,6 +778,7 @@ const PuzzlePage = React.createClass({
       displayNames,
       allGuesses,
       allDocuments,
+      canUpdate: Roles.userHasPermission(Meteor.userId(), 'mongo.puzzles.update'),
     };
   },
 
@@ -789,6 +798,7 @@ const PuzzlePage = React.createClass({
             chatReady={this.data.chatReady}
             chatMessages={this.data.chatMessages}
             displayNames={this.data.displayNames}
+            canUpdate={this.data.canUpdate}
           />
           <PuzzlePageContent
             puzzle={activePuzzle}


### PR DESCRIPTION
* Don't build the DOM for puzzle-editing modals until the button is clicked.  Saves 300msec off puzzle list render time for operators.
* Push subscriber counts down into their own `ReactMeteorData`-using component.
* Avoid recomputing `allTags` for every `Puzzle`.
* Pass `canUpdate` down through the component hierarchy.