### PR TITLE
Switch from SubsManager to SubsCache

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -26,7 +26,7 @@ percolate:migrations
 service-configuration@1.0.11
 oauth@1.1.12
 google@1.1.15
-meteorhacks:subs-manager
+ccorcos:subs-cache
 http@1.2.10
 jquery@1.11.10
 meteorhacks:cluster
@@ -38,3 +38,4 @@ fourseven:scss
 shell-server
 meteorhacks:kadira
 meteorhacks:meteorx
+kadira:debug

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -18,7 +18,9 @@ boilerplate-generator@1.0.11
 caching-compiler@1.1.9
 caching-html-compiler@1.0.7
 callback-hook@1.0.10
+ccorcos:subs-cache@0.2.1
 check@1.2.4
+coffeescript@1.0.17
 dburles:collection-helpers@1.0.4
 ddp@1.2.5
 ddp-client@1.2.9
@@ -42,6 +44,8 @@ htmljs@1.0.11
 http@1.2.10
 id-map@1.0.9
 jquery@1.11.10
+kadira:debug@3.2.2
+kadira:runtime-dev@0.0.1
 launch-screen@1.0.12
 livedata@1.0.18
 localstorage@1.0.12
@@ -53,7 +57,6 @@ meteorhacks:cluster@1.6.9
 meteorhacks:inject-initial@1.0.4
 meteorhacks:kadira@2.30.3
 meteorhacks:meteorx@1.4.1
-meteorhacks:subs-manager@1.6.4
 meteorhacks:zones@1.6.0
 minifier-css@1.2.15
 minifier-js@1.2.15

--- a/imports/client/JRPropTypes.js
+++ b/imports/client/JRPropTypes.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { SubsManager } from 'meteor/meteorhacks:subs-manager';
+import { SubsCache } from 'meteor/ccorcos:subs-cache';
 
 const JRPropTypes = {
-  subs: React.PropTypes.instanceOf(SubsManager).isRequired,
+  subs: React.PropTypes.instanceOf(SubsCache).isRequired,
 };
 
 export { JRPropTypes };

--- a/imports/client/components/Routes.jsx
+++ b/imports/client/components/Routes.jsx
@@ -6,7 +6,7 @@ import {
   browserHistory,
 } from 'react-router';
 import DocumentTitle from 'react-document-title';
-import { SubsManager } from 'meteor/meteorhacks:subs-manager';
+import { SubsCache } from 'meteor/ccorcos:subs-cache';
 import { JRPropTypes } from '/imports/client/JRPropTypes.js';
 import { App } from '/imports/client/components/App.jsx';
 import { AnnouncementsPage } from '/imports/client/components/AnnouncementsPage.jsx';
@@ -31,7 +31,7 @@ const Routes = React.createClass({
 
   getChildContext() {
     if (!this.subs) {
-      this.subs = new SubsManager({ cacheLimit: 20, expireIn: 1 });
+      this.subs = new SubsCache({ cacheLimit: -1, expireAfter: 1 });
     }
 
     return { subs: this.subs };


### PR DESCRIPTION
The big win here is that SubsCache returns a handle whose `ready()`
method only takes into account the status of that specific sub, as
opposed to SubsManager, where `ready()` is always about the global
state of subscriptions.