### PR TITLE
Workaround Meteor enrollment token bug

### DIFF
--- a/lib/config/accounts.js
+++ b/lib/config/accounts.js
@@ -3,4 +3,10 @@ import { Accounts } from 'meteor/accounts-base';
 Accounts.config({
   forbidClientAccountCreation: true,
   sendVerificationEmail: true,
+  // Meteor's accounts-password has a bug wherein all tokens will be removed from the database
+  // according to the expiry rules of password reset tokens.  To avoid enrollment tokens from
+  // being cleared super quickly, we increase the lifetime of password reset tokens.
+  // See https://github.com/meteor/meteor/issues/7794#issuecomment-270253106
+  // If Meteor fixes the problem described in that comment, we can remove this.
+  passwordResetTokenExpirationInDays: 30,
 });


### PR DESCRIPTION
A bunch of people have looked too late at their email and their jolly-roger
signup token is no longer valid.

Meteor 1.4.2 is supposed to have password reset tokens last 3 days, and
enrollment tokens last 30 days, but due to the issue described in [1],
enrollment tokens are deleted on the same schedule as password reset tokens.

The workaround is allowing long-lived password reset tokens, which are a
reasonable usability/security tradeoff for us.  Hopefully Meteor will fix the
issue soon.

[1] - https://github.com/meteor/meteor/issues/7794#issuecomment-270253106

Until then, I don't think jolly-roger accounts are at particularly high-risk
and this is a reasonable usability/security tradeoff.