### PR TITLE
Fix Google Sheet in Safari

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -246,7 +246,12 @@
   background-color: #ddddff;
 }
 
-.google-spreadsheet {
-  width: 100%;
-  height: 100%;
+.puzzle-document>.google-spreadsheet {
+  width:100%;
+  height:100%;
+  position:absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
 }

--- a/imports/client/components/PuzzlePage.jsx
+++ b/imports/client/components/PuzzlePage.jsx
@@ -559,7 +559,7 @@ const PuzzlePageMultiplayerDocument = React.createClass({
         const url = `https://docs.google.com/spreadsheets/d/${this.props.document.value.id}/edit?ui=2&rm=embedded#gid=0`;
         return (
           <div className="puzzle-document">
-            <iframe className="google-spreadsheet" style={{ position: 'absolute', top: 0, bottom: 0, left: 0, right: 0 }} src={url} />
+            <iframe className="google-spreadsheet" src={url} />
           </div>
         );
       }


### PR DESCRIPTION
Fixes a bug introduced in 1a0aabb that causes the google sheet to render at minimal height in Safari.  There might be a better way to do this, but this gets it working again for now.