### PR TITLE
Don't require `is:meta` tags; only require `meta-for` for behavior

### DIFF
--- a/imports/client/components/PuzzleListPage.jsx
+++ b/imports/client/components/PuzzleListPage.jsx
@@ -214,7 +214,7 @@ const PuzzleListView = React.createClass({
           } else {
             return -2;
           }
-        } else if (tag.name === 'is:meta' && !puzzle.answer) {
+        } else if ((tag.name === 'is:meta' || tag.name.lastIndexOf('meta-for:', 0) === 0) && !puzzle.answer) {
           hasUnsolvedMeta = true;
         }
       }


### PR DESCRIPTION
I'm leaving the rest of the behavior in because we have past hunts
where we made use of these tags, but we shouldn't need is:meta or
is:metameta going forward.