### PR TITLE
Fix description of "open signups"

### DIFF
--- a/imports/client/components/HuntListPage.jsx
+++ b/imports/client/components/HuntListPage.jsx
@@ -176,7 +176,7 @@ const HuntModalForm = React.createClass({
 
         <BS.FormGroup>
           <BS.ControlLabel htmlFor={`${idPrefix}open-signups`} className="col-xs-3">
-            Open signups
+            Open invites
           </BS.ControlLabel>
           <div className="col-xs-9">
             <BS.Checkbox
@@ -186,7 +186,7 @@ const HuntModalForm = React.createClass({
               disabled={disableForm}
             />
             <BS.HelpBlock>
-              If open signups are enabled, then any current member of the hunt can add a new member to the hunt. Otherwise, only operators can add new members.
+              If open invites are enabled, then any current member of the hunt can add a new member to the hunt. Otherwise, only operators can add new members.
             </BS.HelpBlock>
           </div>
         </BS.FormGroup>


### PR DESCRIPTION
It's too much work to change the field name, but we can make the
description more descriptive.