### PR TITLE
Show breadcrumbs immediately in more places while loading data

### DIFF
--- a/imports/client/components/AnnouncementsPage.jsx
+++ b/imports/client/components/AnnouncementsPage.jsx
@@ -138,18 +138,13 @@ const AnnouncementsPage = React.createClass({
     };
   },
 
-  render() {
+  renderPage() {
     if (!this.data.ready) {
       return <div>loading...</div>;
     }
 
     return (
       <div>
-        <this.context.navAggregator.NavItem
-          itemKey="announcements"
-          to={`/hunts/${this.props.params.huntId}/announcements`}
-          label="Announcements"
-        />
         <h1>Announcements</h1>
         {this.data.canCreateAnnouncements && <AnnouncementForm huntId={this.props.params.huntId} />}
         {/* ostensibly these should be ul and li, but then I have to deal with overriding
@@ -166,6 +161,18 @@ const AnnouncementsPage = React.createClass({
           })}
         </div>
       </div>
+    );
+  },
+
+  render() {
+    return (
+      <this.context.navAggregator.NavItem
+        itemKey="announcements"
+        to={`/hunts/${this.props.params.huntId}/announcements`}
+        label="Announcements"
+      >
+        {this.renderPage()}
+      </this.context.navAggregator.NavItem>
     );
   },
 });

--- a/imports/client/components/GuessQueuePage.jsx
+++ b/imports/client/components/GuessQueuePage.jsx
@@ -130,7 +130,7 @@ const GuessQueuePage = React.createClass({
     };
   },
 
-  render() {
+  renderPage() {
     if (!this.data.ready) {
       return <div>loading...</div>;
     }
@@ -138,11 +138,6 @@ const GuessQueuePage = React.createClass({
     return (
       <div>
         <h1>Guess queue</h1>
-        <this.context.navAggregator.NavItem
-          itemKey="guessqueue"
-          to={`/hunts/${this.props.params.huntId}/announcements`}
-          label="Guess queue"
-        />
         {this.data.guesses.map((guess) => {
           return (
             <GuessBlock
@@ -155,6 +150,18 @@ const GuessQueuePage = React.createClass({
           );
         })}
       </div>
+    );
+  },
+
+  render() {
+    return (
+      <this.context.navAggregator.NavItem
+        itemKey="guessqueue"
+        to={`/hunts/${this.props.params.huntId}/announcements`}
+        label="Guess queue"
+      >
+        {this.renderPage()}
+      </this.context.navAggregator.NavItem>
     );
   },
 });

--- a/imports/client/components/HuntApp.jsx
+++ b/imports/client/components/HuntApp.jsx
@@ -142,7 +142,7 @@ const HuntApp = React.createClass({
     };
   },
 
-  render() {
+  renderBody() {
     if (!this.data.ready) {
       return <span>loading...</span>;
     }
@@ -155,6 +155,10 @@ const HuntApp = React.createClass({
       return <HuntMemberError huntId={this.props.params.huntId} />;
     }
 
+    return React.Children.only(this.props.children);
+  },
+
+  render() {
     const title = this.data.hunt ? `${this.data.hunt.name} :: Jolly Roger` : '';
 
     return (
@@ -167,9 +171,9 @@ const HuntApp = React.createClass({
           <this.context.navAggregator.NavItem
             itemKey="huntid"
             to={`/hunts/${this.props.params.huntId}`}
-            label={this.data.hunt.name}
+            label={this.data.ready ? this.data.hunt.name : 'loading...'}
           >
-            {React.Children.only(this.props.children)}
+            {this.renderBody()}
           </this.context.navAggregator.NavItem>
         </this.context.navAggregator.NavItem>
       </DocumentTitle>


### PR DESCRIPTION
A few places we were rendering the "loading..." stub while waiting for data, but we could show an additional breadcrumb to indicate that the click was successful, and to make it possible to navigate back using the breadcrumbs without having to wait for the rest of the data to finish loading.