### PR TITLE
Special-case a new "administrivia" tag

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -109,6 +109,9 @@
   border-radius: 2px;
   background-color: #ddd;
   color: #000;
+  &.tag-administrivia {
+    background-color: #ffff77;
+  }
   &.tag-meta {
     background-color: #ffd57f;
   }

--- a/imports/client/components/PuzzleComponents.jsx
+++ b/imports/client/components/PuzzleComponents.jsx
@@ -468,12 +468,14 @@ const Tag = React.createClass({
 
   render() {
     const name = this.props.tag.name;
+    const isAdministrivia = name === 'administrivia';
     const isMeta = name === 'is:meta' || name === 'is:metameta';
     const isGroup = name.lastIndexOf('group:', 0) === 0;
     const isMetaFor = name.lastIndexOf('meta-for:', 0) === 0;
     const isNeeds = name.lastIndexOf('needs:', 0) === 0;
     const isPriority = name.lastIndexOf('priority:', 0) === 0;
     const classNames = classnames('tag',
+      isAdministrivia ? 'tag-administrivia' : null,
       isMeta ? 'tag-meta' : null,
       isGroup ? 'tag-group' : null,
       isMetaFor ? 'tag-meta-for' : null,

--- a/imports/client/components/PuzzleListPage.jsx
+++ b/imports/client/components/PuzzleListPage.jsx
@@ -124,8 +124,10 @@ const PuzzleListView = React.createClass({
     // First, filter puzzles by search keys and unsolved (if selected).
     const filteredPuzzles = this.filteredPuzzles(this.props.puzzles);
 
-    // Extract remaining puzzles into groups.  Collect puzzles that appear in no groups into a final
-    // group, "ungrouped".  Each group (except ungrouped) has shape:
+    // Extract remaining puzzles into groups (including the
+    // "administrivia" group).  Collect puzzles that appear in no
+    // groups into a final group, "ungrouped".  Each group (except
+    // ungrouped) has shape:
     // {
     //   sharedTag: (tag shape),
     //   puzzles: [(puzzle shape)],
@@ -139,7 +141,8 @@ const PuzzleListView = React.createClass({
       let grouped = false;
       for (let j = 0; j < puzzle.tags.length; j++) {
         const tag = tagsByIndex[puzzle.tags[j]];
-        if (tag.name.lastIndexOf('group:', 0) === 0) {
+        if (tag.name === 'administrivia' ||
+            tag.name.lastIndexOf('group:', 0) === 0) {
           grouped = true;
           if (!groupsMap[tag._id]) {
             groupsMap[tag._id] = [];
@@ -184,6 +187,7 @@ const PuzzleListView = React.createClass({
 
   interestingnessOfGroup(group, indexedTags) {
     // Rough idea: sort, from top to bottom:
+    // -3 administrivia always floats to the top
     // -2 Group with unsolved puzzle with matching meta-for:<this group>
     // -1 Group with some other unsolved is:meta puzzle
     //  0 Groups with no metas yet
@@ -195,6 +199,10 @@ const PuzzleListView = React.createClass({
     // ungrouped puzzles go after groups, esp. after groups with a known unsolved meta.
     // Guarantees that if ia === ib, then sharedTag exists.
     if (!sharedTag) return 1;
+
+    if (sharedTag.name === 'administrivia') {
+      return -3;
+    }
 
     // Look for a puzzle with meta-for:(this group's shared tag)
     let metaForTag;


### PR DESCRIPTION
Puzzles tagged with 'administrivia' bubble up to the top of the page,
and can be used for things like tools, "who's bringing what", or
capturing hunt structure.