### PR TITLE
Fix handling empty tags

### DIFF
--- a/imports/client/components/PuzzleComponents.jsx
+++ b/imports/client/components/PuzzleComponents.jsx
@@ -129,7 +129,7 @@ const PuzzleModalForm = React.createClass({
 
   onTagsChange(event) {
     this.setState({
-      tags: jQuery(event.target).val(),
+      tags: jQuery(event.target).val() || [],
     });
   },
 


### PR DESCRIPTION
For whatever reason, select2 seems to be returning a value of `null`
when there are no tags set, instead of `[]` like we'd expect. Work
around it.