### PR TITLE
Deep link into native Google apps on mobile

### DIFF
--- a/imports/client/components/DeepLink.jsx
+++ b/imports/client/components/DeepLink.jsx
@@ -1,0 +1,54 @@
+import { Meteor } from 'meteor/meteor';
+import { _ } from 'meteor/underscore';
+import React from 'react';
+
+const DeepLink = React.createClass({
+  propTypes: {
+    children: React.PropTypes.node.isRequired,
+    nativeUrl: React.PropTypes.string.isRequired,
+    browserUrl: React.PropTypes.string.isRequired,
+  },
+
+  getInitialState() {
+    return { state: 'idle' };
+  },
+
+  onAttemptingNativeTimeout() {
+    this.setState({ state: 'idle' });
+    if (new Date() - this.state.startNativeLoad < 10000) {
+      this.browserOpen();
+    }
+  },
+
+  onClick() {
+    // window.orientation is a good proxy for mobile device
+    if (window.orientation) {
+      this.setState({ state: 'attemptingNative', startNativeLoad: new Date() });
+      Meteor.setTimeout(this.onAttemptingNativeTimeout, 25);
+    } else {
+      this.browserOpen();
+    }
+  },
+
+  browserOpen() {
+    window.open(this.props.browserUrl, '_blank');
+  },
+
+  nativeIframe() {
+    return (
+      <iframe width="1px" height="1px" src={this.props.nativeUrl} />
+    );
+  },
+
+  render() {
+    const rest = _.omit(this.props, 'children', 'nativeUrl', 'browserUrl');
+    return (
+      <div onClick={this.onClick} {...rest}>
+        {this.state.state === 'attemptingNative' && this.nativeIframe()}
+        {this.props.children}
+      </div>
+    );
+  },
+});
+
+export { DeepLink };

--- a/imports/client/components/Documents.jsx
+++ b/imports/client/components/Documents.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import BS from 'react-bootstrap';
+import { DeepLink } from '/imports/client/components/DeepLink.jsx';
 
 const GoogleDocumentDisplay = React.createClass({
   propTypes: {
@@ -8,10 +10,12 @@ const GoogleDocumentDisplay = React.createClass({
 
   render() {
     let url;
+    let deepUrl;
     let title;
     switch (this.props.document.value.type) {
       case 'spreadsheet':
         url = `https://docs.google.com/spreadsheets/d/${this.props.document.value.id}/edit?ui=2&rm=embedded#gid=0`;
+        deepUrl = `googlesheets://${url}`;
         title = 'worksheet';
         break;
       case 'document':
@@ -29,9 +33,9 @@ const GoogleDocumentDisplay = React.createClass({
     switch (this.props.displayMode) {
       case 'link':
         return (
-          <a className="gdrive-button" href={url} target="_blank" rel="noreferrer noopener">
-            Open {title}
-          </a>
+          <DeepLink className="gdrive-button" nativeUrl={deepUrl} browserUrl={url}>
+            <BS.Button>Open {title}</BS.Button>
+          </DeepLink>
         );
       case 'embed':
         return (


### PR DESCRIPTION
We can use the presence of `window.orientation` as a proxy for whether
or not a link to a native app is likely to work, and fallback to
opening a new window with the browser version.

I tested (or had someone test) this on:
- Chrome on Linux
- Firefox on Linux
- IE
- Edge
- iOS (10.2) without the Google Sheets app installed
- iOS with the Google Sheets app installed
- Android (7.1.1) + Chrome (55) without the Google Sheets app installed
- Android + Chrome with the Google Sheets app installed

I think that should be pretty representative, so hopefully this should be ready to go.