### PR TITLE
Make "operating mode" more universal

### DIFF
--- a/imports/client/components/HuntListPage.jsx
+++ b/imports/client/components/HuntListPage.jsx
@@ -254,7 +254,6 @@ const Hunt = React.createClass({
 
   getMeteorData() {
     return {
-      isOperator: Roles.userHasRole(Meteor.userId(), 'admin'),
       canUpdate: Roles.userHasPermission(Meteor.userId(), 'mongo.hunts.update'),
 
       // Because we delete by setting the deleted flag, you only need
@@ -320,7 +319,7 @@ const Hunt = React.createClass({
           {this.deleteButton()}
         </BS.ButtonGroup>
         {' '}
-        <Link to={this.data.isOperator ? `/hunts/${hunt._id}` : `/hunts/${hunt._id}/puzzles`}>
+        <Link to={`/hunts/${hunt._id}`}>
           {hunt.name}
         </Link>
       </li>

--- a/imports/client/components/NotificationCenter.jsx
+++ b/imports/client/components/NotificationCenter.jsx
@@ -249,18 +249,12 @@ const NotificationCenter = React.createClass({
   },
 
   getMeteorData() {
-    const operator = Roles.userHasRole(Meteor.userId(), 'admin');
-
-    const user = Meteor.user();
-    let operating = user && user.profile && user.profile.operating;
-    if (operating === undefined) {
-      operating = true;
-    }
+    const canUpdateGuesses = Roles.userHasPermission(Meteor.userId(), 'mongo.guesses.update');
 
     // Yes this is hideous, but it just makes the logic easier
     let guessesHandle = { ready: () => true };
     let puzzlesHandle = { ready: () => true };
-    if (Roles.userHasRole(Meteor.userId(), 'admin') && operating) {
+    if (canUpdateGuesses) {
       guessesHandle = this.context.subs.subscribe('mongo.guesses', { state: 'pending' });
       puzzlesHandle = this.context.subs.subscribe('mongo.puzzles');
     }
@@ -293,7 +287,7 @@ const NotificationCenter = React.createClass({
       slackConfigured: profile && profile.slackHandle,
     };
 
-    if (operator && operating) {
+    if (canUpdateGuesses) {
       Models.Guesses.find({ state: 'pending' }, { sort: { createdAt: 1 } }).forEach((guess) => {
         data.guesses.push({
           guess,

--- a/imports/client/components/SetupPage.jsx
+++ b/imports/client/components/SetupPage.jsx
@@ -21,8 +21,8 @@ const SetupPage = React.createClass({
 
   getMeteorData() {
     const config = ServiceConfiguration.configurations.findOne({ service: 'google' });
-    const admin = Roles.userHasRole(Meteor.userId(), 'admin');
-    return { config, admin };
+    const canSetupGDrive = Roles.userHasPermission(Meteor.userId(), 'gdrive.credential');
+    return { config, canSetupGDrive };
   },
 
   dismissAlert() {
@@ -50,7 +50,7 @@ const SetupPage = React.createClass({
   },
 
   renderBody() {
-    if (!this.data.admin) {
+    if (!this.data.canSetupGDrive) {
       return <div>This page is for administering the Jolly Roger web app</div>;
     }
 

--- a/imports/server/api/resources/users.js
+++ b/imports/server/api/resources/users.js
@@ -35,7 +35,7 @@ const renderUser = function renderUser(user, profile) {
     primaryEmail: user.emails[0].address,
     googleAccount: profile.googleAccount,
     active,
-    operator: Roles.userHasRole(user._id, 'admin'),
+    operator: Roles.userHasPermission(user._id, 'users.makeOperator'),
   };
 };
 

--- a/lib/models/hunts.js
+++ b/lib/models/hunts.js
@@ -58,7 +58,6 @@ Models.Hunts.publish();
 
 // operators are always allowed to join someone to a hunt; non-admins
 // can if they are a member and if the hunt allows open signups.
-Roles.registerAction('hunt.join', true);
 Roles.loggedInRole.allow('hunt.join', (huntId) => {
   if (!_.include(Meteor.user().hunts, huntId)) {
     return false;

--- a/lib/roles.js
+++ b/lib/roles.js
@@ -1,0 +1,6 @@
+Roles.registerAction('gdrive.credential', true);
+Roles.registerAction('hunt.join', true);
+Roles.registerAction('users.makeOperator', true);
+
+const InactiveOperatorRole = new Roles.Role('inactiveOperator');
+InactiveOperatorRole.allow('users.makeOperator', () => true);

--- a/server/setup.js
+++ b/server/setup.js
@@ -2,8 +2,6 @@ import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 import Ansible from '/imports/ansible.js';
 
-Roles.registerAction('gdrive.credential', true);
-
 Meteor.methods({
   setupGdriveCreds(key, secret) {
     check(this.userId, String);

--- a/server/users.js
+++ b/server/users.js
@@ -3,19 +3,25 @@ import { check } from 'meteor/check';
 import Ansible from '/imports/ansible.js';
 
 Meteor.methods({
+  // Temporarily de-op yourself
+  stopOperating() {
+    Roles.checkPermission(this.userId, 'users.makeOperator');
+
+    Roles.addUserToRoles(this.userId, 'inactiveOperator');
+    Roles.removeUserFromRoles(this.userId, 'admin');
+  },
+
   makeOperator(targetUserId) {
     check(targetUserId, String);
-    if (!Roles.userHasRole(this.userId, 'admin')) {
-      throw new Meteor.Error(403, 'Non-operators may not grant operator permissions.');
+
+    Roles.checkPermission(this.userId, 'users.makeOperator');
+
+    if (this.userId !== targetUserId) {
+      Ansible.log('Promoting user to operator', { user: targetUserId, promoter: this.userId });
     }
 
-    Ansible.log('Promoting user to operator', { user: targetUserId, promoter: this.userId });
-    Meteor.users.update({
-      _id: targetUserId,
-    }, {
-      $addToSet: {
-        roles: 'admin',
-      },
-    });
+    Roles.addUserToRoles(targetUserId, 'admin');
+    // This may be a noop
+    Roles.removeUserFromRoles(targetUserId, 'inactiveOperator');
   },
 });


### PR DESCRIPTION
Move everything to a permission check instead of a role check, and
then disable "operating mode" by actually de-opping the user to a role
whose only permission is to re-op people.