### PR TITLE
Fix undefined deref error when profiles haven't loaded yet

### DIFF
--- a/imports/client/components/CelebrationCenter.jsx
+++ b/imports/client/components/CelebrationCenter.jsx
@@ -65,7 +65,8 @@ const CelebrationCenter = React.createClass({
       });
     }
 
-    const muted = Models.Profiles.findOne({ _id: Meteor.userId() }).muteApplause;
+    const profile = Models.Profiles.findOne({ _id: Meteor.userId() });
+    const muted = profile && profile.muteApplause;
 
     return {
       disabled: Flags.active('disable.applause'),


### PR DESCRIPTION
Refreshing while looking at a puzzle page crashes on the client, which is no good.