### PR TITLE
Excise Kadira; they've been dead for some time

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -36,5 +36,4 @@ standard-minifier-js@1.2.1
 react-meteor-data
 fourseven:scss
 shell-server
-meteorhacks:kadira
 meteorhacks:meteorx

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -53,7 +53,6 @@ meteor@1.6.0
 meteor-base@1.0.4
 meteorhacks:cluster@1.6.9
 meteorhacks:inject-initial@1.0.4
-meteorhacks:kadira@2.30.3
 meteorhacks:meteorx@1.4.1
 meteorhacks:zones@1.6.0
 minifier-css@1.2.15
@@ -65,7 +64,6 @@ modules@0.7.7
 modules-runtime@0.7.7
 mongo@1.1.14
 mongo-id@1.0.6
-mongo-livedata@1.0.12
 natestrauser:select2@4.0.3
 nicolaslopezj:roles@2.6.2
 npm-bcrypt@0.9.2

--- a/scripts/run_jolly_roger.sh
+++ b/scripts/run_jolly_roger.sh
@@ -19,11 +19,6 @@ if [ -z "${MAIL_URL+set}" ]; then
     export MAIL_URL="$(credstash get mailgun)"
 fi
 
-export KADIRA_APP_ID=q7S8XNdYngs3Qnb66
-if [ -z "${KADIRA_APP_SECRET+set}" ]; then
-    export KADIRA_APP_SECRET="$(credstash get kadira)"
-fi
-
 if [ -z "${HONEYCOMB_WRITE_KEY+set}" ]; then
     export HONEYCOMB_WRITE_KEY="$(credstash get honeycomb)"
 fi


### PR DESCRIPTION
`mongo-livedata` was autoremoved when I removed this; presumably the
still-present `livedata` package covers it.

Fixes #102.

r? @ebroder 