### PR TITLE
Re-license Jolly Roger under the MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Evan Broder, Drew Fisher, Grant Elliott
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "jolly-roger",
   "version": "0.0.1",
   "description": "A website for organizing puzzle hunters",
-  "author": "",
+  "author": "Evan Broder, Drew Fisher, Grant Elliott",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ebroder/jolly-roger"


### PR DESCRIPTION
We'd like to open-source Jolly Roger. In order to do that, we all need to agree to re-license our contributions under an open-source friendly license. Drew and I prefer the MIT license, so that's what I've gone with.

@zarvox and @grantaelliott, I need explicit approvals from both of you on this PR in order to merge it. By approving this pull request, you agree to re-license all past contributions under the MIT license.