### PR TITLE
Remove unnecessary reference to fixtures

### DIFF
--- a/server/hunts.js
+++ b/server/hunts.js
@@ -3,7 +3,6 @@ import { check } from 'meteor/check';
 import { _ } from 'meteor/underscore';
 import Ansible from '/imports/ansible.js';
 import { List } from '/imports/server/blanche.js';
-import { huntFixtures } from '/imports/fixtures.js';
 import { Accounts } from 'meteor/accounts-base';
 import { Email } from 'meteor/email';
 
@@ -38,7 +37,7 @@ Meteor.methods({
     check(huntId, String);
     check(email, String);
 
-    const hunt = huntFixtures[huntId] || Models.Hunts.findOne(huntId);
+    const hunt = Models.Hunts.findOne(huntId);
     if (!hunt) {
       throw new Meteor.Error(404, 'Unknown hunt');
     }


### PR DESCRIPTION
The way we use fixtures now is to provide a Meteor method "createFixtureHunt" that you can call from the JS console, which allows us to keep the data out of the bundle.

If the fixture is then only used to populate the database, we needn't special-case other lookup paths.

r? @ebroder 