### PR TITLE
Bump base image to bionic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 

--- a/build.sh
+++ b/build.sh
@@ -3,19 +3,19 @@
 set -eux
 set -o pipefail
 
-# Install apt https support for node
+# Install apt https support for node.  Install gnupg so that apt-key add works.
 apt-get update
-apt-get install --no-install-recommends -y apt-transport-https ca-certificates
+apt-get install --no-install-recommends -y apt-transport-https ca-certificates gnupg
 
 # Add debathena and node apt repos
 apt-key adv --keyserver keyserver.ubuntu.com --recv-key D1CD49BDD30B677273A75C66E4EE62700D8A9E8F
-echo "deb http://debathena.mit.edu/apt trusty debathena debathena-config debathena-system" > /etc/apt/sources.list.d/debathena.list
+echo "deb http://debathena.mit.edu/apt bionic debathena debathena-config debathena-system" > /etc/apt/sources.list.d/debathena.list
 apt-key adv --keyserver keyserver.ubuntu.com --recv-key 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280
-echo "deb https://deb.nodesource.com/node_8.x trusty main" > /etc/apt/sources.list.d/node.list
+echo "deb https://deb.nodesource.com/node_8.x bionic main" > /etc/apt/sources.list.d/node.list
 
 # Install build deps
 apt-get update
-apt-get install --no-install-recommends -y python python-pip python-dev build-essential debathena-moira-clients kstart curl nodejs git
+apt-get install --no-install-recommends -y python python-pip python-dev python-setuptools python-wheel build-essential debathena-moira-clients kstart curl nodejs git
 
 pip install 'credstash==1.12.0'
 


### PR DESCRIPTION
Some notes:

* the bionic docker base image does not have any version of gnupg installed by
  default, somehow, so we have to install it for apt-key add to work
* python-setuptools is only a `Recommends:` on python-pip, so it doesn't get
  pulled in by default.  That said, credstash requires setuptools be installed
  for us to `pip install credstash`, so we add that.
* even once we have setuptools, the `bdist_wheel` subcommand doesn't exist if
  we don't also grab the `python-wheel` package, so throw that in too.

Tested by running the docker build locally until I no longer saw error messages in the build log.

r? @ebroder 