### PR TITLE
Add `assert` as a devDependency for bundle-visualizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -144,6 +144,15 @@
         "safer-buffer": "~2.1.0"
       }
     },
+    "assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "dev": true,
+      "requires": {
+        "util": "0.10.3"
+      }
+    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -3584,6 +3593,23 @@
       "dev": true,
       "requires": {
         "os-homedir": "^1.0.0"
+      }
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-textarea-autosize": "^4.0.4"
   },
   "devDependencies": {
+    "assert": "^1.4.1",
     "babel-eslint": "6.1.2",
     "eslint": "3.11.1",
     "eslint-config-airbnb": "10.0.1",


### PR DESCRIPTION
Without this when I run

```
meteor run --production --extra-packages bundle-visualizer
```

I get errors in the Chrome console and no visualizer.  This change
appears to make the bundle visualizer work:

![image](https://user-images.githubusercontent.com/307325/46920786-1cd55b00-cfa8-11e8-910a-92044e52de77.png)

r? @ebroder