### PR TITLE
Add method to expose git revision to client

### DIFF
--- a/server/git_revision.js
+++ b/server/git_revision.js
@@ -1,0 +1,14 @@
+import { Meteor } from 'meteor/meteor';
+
+Meteor.methods({
+  // A dumb method to expose the git revision of the server's running build to
+  // the client for easier observability.  Print from the JS console with:
+  // Meteor.call("gitRevision", (err, val) => console.log(val));
+  gitRevision() {
+    if (process.env.GIT_REVISION) {
+      return process.env.GIT_REVISION;
+    } else {
+      return 'development';
+    }
+  },
+});


### PR DESCRIPTION
Making this a method means we can use it from the console but don't load it by
default.

r? @ebroder 