### PR TITLE
Switch from absolute to relative imports

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -53,6 +53,9 @@
     // While this rule is generally useful, it currently gets confused by Meteor's import rewriting
     // for import { thing } from "meteor/meteorpackagename", so we need it to chill out.
     "import/no-extraneous-dependencies": ["off"],
+
+    // Absolute imports work with Meteor, but aren't well-understood by IDEs, like VS Code
+    "import/no-absolute-path": ["error"],
   },
   "globals": {
     // Long-term, reduce this list to nothing by making full use of import/export

--- a/client/main.js
+++ b/client/main.js
@@ -4,27 +4,27 @@
 
 // explicitly import all the stuff from lib/ since mainModule skips autoloading
 // things
-import '/imports/lib/config/accounts.js';
-import '/imports/lib/models/00index.js';
-import '/imports/lib/models/announcements.js';
-import '/imports/lib/models/chats.js';
-import '/imports/lib/models/document_permissions.js';
-import '/imports/lib/models/documents.js';
-import '/imports/lib/models/feature_flags.js';
-import '/imports/lib/models/guess.js';
-import '/imports/lib/models/hunts.js';
-import '/imports/lib/models/pending_announcements.js';
-import '/imports/lib/models/profiles.js';
-import '/imports/lib/models/proptypes.js';
-import '/imports/lib/models/puzzles.js';
-import '/imports/lib/models/tags.js';
-import '/imports/lib/models/users.js';
-import '/imports/lib/roles.js';
+import '../imports/lib/config/accounts.js';
+import '../imports/lib/models/00index.js';
+import '../imports/lib/models/announcements.js';
+import '../imports/lib/models/chats.js';
+import '../imports/lib/models/document_permissions.js';
+import '../imports/lib/models/documents.js';
+import '../imports/lib/models/feature_flags.js';
+import '../imports/lib/models/guess.js';
+import '../imports/lib/models/hunts.js';
+import '../imports/lib/models/pending_announcements.js';
+import '../imports/lib/models/profiles.js';
+import '../imports/lib/models/proptypes.js';
+import '../imports/lib/models/puzzles.js';
+import '../imports/lib/models/tags.js';
+import '../imports/lib/models/users.js';
+import '../imports/lib/roles.js';
 
 // Configure marked and moment
-import '/imports/client/marked.js';
-import '/imports/client/moment.js';
+import '../imports/client/marked.js';
+import '../imports/client/moment.js';
 
 // explicitly import all the stuff from client/
-import '/imports/client/main.jsx';
-import '/imports/client/close.js';
+import '../imports/client/main.jsx';
+import '../imports/client/close.js';

--- a/imports/client/components/AllProfileListPage.jsx
+++ b/imports/client/components/AllProfileListPage.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import JRPropTypes from '/imports/client/JRPropTypes.js';
-import { navAggregatorType } from '/imports/client/components/NavAggregator.jsx';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import ProfileList from '/imports/client/components/ProfileList.jsx';
+import JRPropTypes from '../JRPropTypes.js';
+import { navAggregatorType } from './NavAggregator.jsx';
+import ProfileList from './ProfileList.jsx';
 
 const AllProfileListPage = React.createClass({
   contextTypes: {

--- a/imports/client/components/AnnouncementsPage.jsx
+++ b/imports/client/components/AnnouncementsPage.jsx
@@ -3,9 +3,9 @@ import moment from 'moment';
 import React from 'react';
 import BS from 'react-bootstrap';
 import marked from 'marked';
-import JRPropTypes from '/imports/client/JRPropTypes.js';
-import { navAggregatorType } from '/imports/client/components/NavAggregator.jsx';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
+import JRPropTypes from '../JRPropTypes.js';
+import { navAggregatorType } from './NavAggregator.jsx';
 
 /* eslint-disable max-len */
 

--- a/imports/client/components/App.jsx
+++ b/imports/client/components/App.jsx
@@ -4,10 +4,10 @@ import BS from 'react-bootstrap';
 import { Link } from 'react-router';
 import RRBS from 'react-router-bootstrap';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import JRPropTypes from '/imports/client/JRPropTypes.js';
-import ConnectionStatus from '/imports/client/components/ConnectionStatus.jsx';
-import NotificationCenter from '/imports/client/components/NotificationCenter.jsx';
-import { navAggregatorType } from '/imports/client/components/NavAggregator.jsx';
+import JRPropTypes from '../JRPropTypes.js';
+import ConnectionStatus from './ConnectionStatus.jsx';
+import NotificationCenter from './NotificationCenter.jsx';
+import { navAggregatorType } from './NavAggregator.jsx';
 
 const SharedNavbar = React.createClass({
   contextTypes: {

--- a/imports/client/components/CelebrationCenter.jsx
+++ b/imports/client/components/CelebrationCenter.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Meteor } from 'meteor/meteor';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import Flags from '/imports/flags.js';
-import JRPropTypes from '/imports/client/JRPropTypes.js';
-import Celebration from '/imports/client/components/Celebration.jsx';
+import Flags from '../../flags.js';
+import JRPropTypes from '../JRPropTypes.js';
+import Celebration from './Celebration.jsx';
 
 const CelebrationCenter = React.createClass({
   propTypes: {

--- a/imports/client/components/ConnectionStatus.jsx
+++ b/imports/client/components/ConnectionStatus.jsx
@@ -1,8 +1,8 @@
 import { Meteor } from 'meteor/meteor';
 import React from 'react';
 import BS from 'react-bootstrap';
-import Ansible from '/imports/ansible.js';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
+import Ansible from '../../ansible.js';
 
 const ConnectionStatus = React.createClass({
   mixins: [ReactMeteorData],

--- a/imports/client/components/Documents.jsx
+++ b/imports/client/components/Documents.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import BS from 'react-bootstrap';
-import DeepLink from '/imports/client/components/DeepLink.jsx';
+import DeepLink from './DeepLink.jsx';
 
 const GoogleDocumentDisplay = React.createClass({
   propTypes: {

--- a/imports/client/components/EnrollForm.jsx
+++ b/imports/client/components/EnrollForm.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AccountForm from '/imports/client/components/AccountForm.jsx';
+import AccountForm from './AccountForm.jsx';
 
 const EnrollForm = React.createClass({
   propTypes: {

--- a/imports/client/components/GuessQueuePage.jsx
+++ b/imports/client/components/GuessQueuePage.jsx
@@ -3,9 +3,9 @@ import { _ } from 'meteor/underscore';
 import React from 'react';
 import { Link } from 'react-router';
 import classnames from 'classnames';
-import JRPropTypes from '/imports/client/JRPropTypes.js';
-import { navAggregatorType } from '/imports/client/components/NavAggregator.jsx';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
+import JRPropTypes from '../JRPropTypes.js';
+import { navAggregatorType } from './NavAggregator.jsx';
 
 /* eslint-disable max-len */
 

--- a/imports/client/components/HuntApp.jsx
+++ b/imports/client/components/HuntApp.jsx
@@ -3,11 +3,11 @@ import { _ } from 'meteor/underscore';
 import React from 'react';
 import BS from 'react-bootstrap';
 import DocumentTitle from 'react-document-title';
-import JRPropTypes from '/imports/client/JRPropTypes.js';
-import { navAggregatorType } from '/imports/client/components/NavAggregator.jsx';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import CelebrationCenter from '/imports/client/components/CelebrationCenter.jsx';
 import marked from 'marked';
+import JRPropTypes from '../JRPropTypes.js';
+import { navAggregatorType } from './NavAggregator.jsx';
+import CelebrationCenter from './CelebrationCenter.jsx';
 
 const HuntDeletedError = React.createClass({
   propTypes: {

--- a/imports/client/components/HuntListPage.jsx
+++ b/imports/client/components/HuntListPage.jsx
@@ -3,11 +3,11 @@ import { _ } from 'meteor/underscore';
 import React from 'react';
 import { Link } from 'react-router';
 import BS from 'react-bootstrap';
-import Ansible from '/imports/ansible.js';
-import JRPropTypes from '/imports/client/JRPropTypes.js';
-import { navAggregatorType } from '/imports/client/components/NavAggregator.jsx';
-import ModalForm from '/imports/client/components/ModalForm.jsx';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
+import Ansible from '../../ansible.js';
+import JRPropTypes from '../JRPropTypes.js';
+import { navAggregatorType } from './NavAggregator.jsx';
+import ModalForm from './ModalForm.jsx';
 
 /* eslint-disable max-len */
 

--- a/imports/client/components/HuntProfileListPage.jsx
+++ b/imports/client/components/HuntProfileListPage.jsx
@@ -1,9 +1,9 @@
 import { Meteor } from 'meteor/meteor';
 import React from 'react';
-import JRPropTypes from '/imports/client/JRPropTypes.js';
-import { navAggregatorType } from '/imports/client/components/NavAggregator.jsx';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import ProfileList from '/imports/client/components/ProfileList.jsx';
+import JRPropTypes from '../JRPropTypes.js';
+import { navAggregatorType } from './NavAggregator.jsx';
+import ProfileList from './ProfileList.jsx';
 
 const HuntProfileListPage = React.createClass({
   propTypes: {

--- a/imports/client/components/LoginForm.jsx
+++ b/imports/client/components/LoginForm.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AccountForm from '/imports/client/components/AccountForm.jsx';
+import AccountForm from './AccountForm.jsx';
 
 const LoginForm = React.createClass({
   getInitialState() {

--- a/imports/client/components/NotificationCenter.jsx
+++ b/imports/client/components/NotificationCenter.jsx
@@ -6,10 +6,10 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
 import { Link } from 'react-router';
 import moment from 'moment';
 import marked from 'marked';
-import JRPropTypes from '/imports/client/JRPropTypes.js';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
 import classnames from 'classnames';
 import CopyToClipboard from 'react-copy-to-clipboard';
+import JRPropTypes from '../JRPropTypes.js';
 
 /* eslint-disable max-len */
 

--- a/imports/client/components/PasswordResetForm.jsx
+++ b/imports/client/components/PasswordResetForm.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import AccountForm from '/imports/client/components/AccountForm.jsx';
+import AccountForm from './AccountForm.jsx';
 
 const PasswordResetForm = React.createClass({
   propTypes: {

--- a/imports/client/components/ProfilePage.jsx
+++ b/imports/client/components/ProfilePage.jsx
@@ -1,9 +1,9 @@
 import { Meteor } from 'meteor/meteor';
 import React from 'react';
 import BS from 'react-bootstrap';
-import JRPropTypes from '/imports/client/JRPropTypes.js';
-import { navAggregatorType } from '/imports/client/components/NavAggregator.jsx';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
+import JRPropTypes from '../JRPropTypes.js';
+import { navAggregatorType } from './NavAggregator.jsx';
 
 /* eslint-disable max-len */
 

--- a/imports/client/components/PuzzleComponents.jsx
+++ b/imports/client/components/PuzzleComponents.jsx
@@ -5,14 +5,14 @@ import React from 'react';
 import { Link } from 'react-router';
 import BS from 'react-bootstrap';
 import classnames from 'classnames';
-import Ansible from '/imports/ansible.js';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
-import ModalForm from '/imports/client/components/ModalForm.jsx';
-import ReactSelect2 from '/imports/client/components/ReactSelect2.jsx';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import { SubscriberCounters } from '/imports/client/subscribers.js';
-import Flags from '/imports/flags.js';
-import LabelledRadioGroup from '/imports/client/components/LabelledRadioGroup.jsx';
+import Ansible from '../../ansible.js';
+import ModalForm from './ModalForm.jsx';
+import ReactSelect2 from './ReactSelect2.jsx';
+import { SubscriberCounters } from '../subscribers.js';
+import Flags from '../../flags.js';
+import LabelledRadioGroup from './LabelledRadioGroup.jsx';
 
 /* eslint-disable max-len */
 

--- a/imports/client/components/PuzzleListPage.jsx
+++ b/imports/client/components/PuzzleListPage.jsx
@@ -3,14 +3,14 @@ import { _ } from 'meteor/underscore';
 import React from 'react';
 import BS from 'react-bootstrap';
 import { Link, browserHistory } from 'react-router';
-import JRPropTypes from '/imports/client/JRPropTypes.js';
+import { ReactMeteorData } from 'meteor/react-meteor-data';
+import JRPropTypes from '../JRPropTypes.js';
 import {
   PuzzleList,
   RelatedPuzzleGroup,
   PuzzleModalForm,
-} from '/imports/client/components/PuzzleComponents.jsx';
-import { ReactMeteorData } from 'meteor/react-meteor-data';
-import Flags from '/imports/flags.js';
+} from './PuzzleComponents.jsx';
+import Flags from '../../flags.js';
 
 /* eslint-disable max-len */
 

--- a/imports/client/components/PuzzlePage.jsx
+++ b/imports/client/components/PuzzlePage.jsx
@@ -3,25 +3,25 @@ import { _ } from 'meteor/underscore';
 import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import BS from 'react-bootstrap';
-import Ansible from '/imports/ansible.js';
 import DocumentTitle from 'react-document-title';
 import classnames from 'classnames';
 import marked from 'marked';
 import moment from 'moment';
-import JRPropTypes from '/imports/client/JRPropTypes.js';
-import { navAggregatorType } from '/imports/client/components/NavAggregator.jsx';
-import ModalForm from '/imports/client/components/ModalForm.jsx';
 import TextareaAutosize from 'react-textarea-autosize';
+import { ReactMeteorData } from 'meteor/react-meteor-data';
+import Ansible from '../../ansible.js';
+import JRPropTypes from '../JRPropTypes.js';
+import { navAggregatorType } from './NavAggregator.jsx';
+import ModalForm from './ModalForm.jsx';
 import {
   TagList,
   RelatedPuzzleGroups,
   PuzzleModalForm,
-} from '/imports/client/components/PuzzleComponents.jsx';
-import { ReactMeteorData } from 'meteor/react-meteor-data';
-import { Subscribers, SubscriberCounters } from '/imports/client/subscribers.js';
-import Flags from '/imports/flags.js';
-import SplitPanePlus from '/imports/client/components/SplitPanePlus.jsx';
-import DocumentDisplay from '/imports/client/components/Documents.jsx';
+} from './PuzzleComponents.jsx';
+import { Subscribers, SubscriberCounters } from '../subscribers.js';
+import Flags from '../../flags.js';
+import SplitPanePlus from './SplitPanePlus.jsx';
+import DocumentDisplay from './Documents.jsx';
 
 /* eslint-disable max-len, no-console */
 

--- a/imports/client/components/Routes.jsx
+++ b/imports/client/components/Routes.jsx
@@ -7,25 +7,25 @@ import {
 } from 'react-router';
 import DocumentTitle from 'react-document-title';
 import { SubsCache } from 'meteor/ccorcos:subs-cache';
-import JRPropTypes from '/imports/client/JRPropTypes.js';
-import AllProfileListPage from '/imports/client/components/AllProfileListPage.jsx';
-import App from '/imports/client/components/App.jsx';
-import AnnouncementsPage from '/imports/client/components/AnnouncementsPage.jsx';
-import Authenticator from '/imports/client/components/Authenticator.jsx';
-import EnrollForm from '/imports/client/components/EnrollForm.jsx';
-import GuessQueuePage from '/imports/client/components/GuessQueuePage.jsx';
-import HuntApp from '/imports/client/components/HuntApp.jsx';
-import HuntListPage from '/imports/client/components/HuntListPage.jsx';
-import HuntProfileListPage from '/imports/client/components/HuntProfileListPage.jsx';
-import LoginForm from '/imports/client/components/LoginForm.jsx';
-import { NavAggregator, navAggregatorType } from '/imports/client/components/NavAggregator.jsx';
-import PasswordResetForm from '/imports/client/components/PasswordResetForm.jsx';
-import ProfilePage from '/imports/client/components/ProfilePage.jsx';
-import PuzzleListPage from '/imports/client/components/PuzzleListPage.jsx';
-import PuzzlePage from '/imports/client/components/PuzzlePage.jsx';
-import SetupPage from '/imports/client/components/SetupPage.jsx';
-import SplashPage from '/imports/client/components/SplashPage.jsx';
-import UserInvitePage from '/imports/client/components/UserInvitePage.jsx';
+import JRPropTypes from '../JRPropTypes.js';
+import AllProfileListPage from './AllProfileListPage.jsx';
+import App from './App.jsx';
+import AnnouncementsPage from './AnnouncementsPage.jsx';
+import Authenticator from './Authenticator.jsx';
+import EnrollForm from './EnrollForm.jsx';
+import GuessQueuePage from './GuessQueuePage.jsx';
+import HuntApp from './HuntApp.jsx';
+import HuntListPage from './HuntListPage.jsx';
+import HuntProfileListPage from './HuntProfileListPage.jsx';
+import LoginForm from './LoginForm.jsx';
+import { NavAggregator, navAggregatorType } from './NavAggregator.jsx';
+import PasswordResetForm from './PasswordResetForm.jsx';
+import ProfilePage from './ProfilePage.jsx';
+import PuzzleListPage from './PuzzleListPage.jsx';
+import PuzzlePage from './PuzzlePage.jsx';
+import SetupPage from './SetupPage.jsx';
+import SplashPage from './SplashPage.jsx';
+import UserInvitePage from './UserInvitePage.jsx';
 
 const Routes = React.createClass({
   childContextTypes: {

--- a/imports/client/components/SetupPage.jsx
+++ b/imports/client/components/SetupPage.jsx
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import React from 'react';
 import BS from 'react-bootstrap';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import { navAggregatorType } from '/imports/client/components/NavAggregator.jsx';
+import { navAggregatorType } from './NavAggregator.jsx';
 
 /* eslint-disable max-len */
 

--- a/imports/client/main.jsx
+++ b/imports/client/main.jsx
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Routes from '/imports/client/components/Routes.jsx';
+import Routes from './components/Routes.jsx';
 
 Meteor.startup(() => {
   const container = document.createElement('div');

--- a/imports/lib/models/announcements.js
+++ b/imports/lib/models/announcements.js
@@ -1,5 +1,5 @@
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
-import { huntsMatchingCurrentUser } from '/imports/model-helpers.js';
+import { huntsMatchingCurrentUser } from '../../model-helpers.js';
 
 // A broadcast message from a hunt operator to be displayed
 // to all participants in the specified hunt.

--- a/imports/lib/models/chats.js
+++ b/imports/lib/models/chats.js
@@ -1,5 +1,5 @@
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
-import { huntsMatchingCurrentUser } from '/imports/model-helpers.js';
+import { huntsMatchingCurrentUser } from '../../model-helpers.js';
 
 // A single chat message
 Schemas.ChatMessages = new SimpleSchema([

--- a/imports/lib/models/documents.js
+++ b/imports/lib/models/documents.js
@@ -1,5 +1,5 @@
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
-import { huntsMatchingCurrentUser } from '/imports/model-helpers.js';
+import { huntsMatchingCurrentUser } from '../../model-helpers.js';
 
 Schemas.Documents = new SimpleSchema([
   Schemas.Base,

--- a/imports/lib/models/guess.js
+++ b/imports/lib/models/guess.js
@@ -1,5 +1,5 @@
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
-import { answerify, huntsMatchingCurrentUser } from '/imports/model-helpers.js';
+import { answerify, huntsMatchingCurrentUser } from '../../model-helpers.js';
 
 Schemas.Guesses = new SimpleSchema([
   Schemas.Base,

--- a/imports/lib/models/puzzles.js
+++ b/imports/lib/models/puzzles.js
@@ -1,5 +1,5 @@
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
-import { answerify, huntsMatchingCurrentUser } from '/imports/model-helpers.js';
+import { answerify, huntsMatchingCurrentUser } from '../../model-helpers.js';
 
 Schemas.Puzzles = new SimpleSchema([
   Schemas.Base,

--- a/imports/lib/models/tags.js
+++ b/imports/lib/models/tags.js
@@ -1,5 +1,5 @@
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
-import { huntsMatchingCurrentUser } from '/imports/model-helpers.js';
+import { huntsMatchingCurrentUser } from '../../model-helpers.js';
 
 Schemas.Tags = new SimpleSchema([
   Schemas.Base,

--- a/imports/server/accounts.js
+++ b/imports/server/accounts.js
@@ -1,8 +1,8 @@
 import { Meteor } from 'meteor/meteor';
 import { Accounts } from 'meteor/accounts-base';
 import { _ } from 'meteor/underscore';
-import Ansible from '/imports/ansible.js';
 import logfmt from 'logfmt';
+import Ansible from '../ansible.js';
 
 const summaryFromLoginInfo = function (info) {
   switch (info.methodName) {

--- a/imports/server/announcements.js
+++ b/imports/server/announcements.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
-import Ansible from '/imports/ansible.js';
+import Ansible from '../ansible.js';
 
 Meteor.methods({
   postAnnouncement(huntId, message) {

--- a/imports/server/api-init.js
+++ b/imports/server/api-init.js
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor';
 import { WebApp } from 'meteor/webapp';
-import app from '/imports/server/api.js';
+import app from './api.js';
 
 WebApp.connectHandlers.use('/api', Meteor.bindEnvironment(app));

--- a/imports/server/api.js
+++ b/imports/server/api.js
@@ -1,6 +1,6 @@
 import express from 'express';
-import authenticator from '/imports/server/api/authenticator.js';
-import users from '/imports/server/api/resources/users.js';
+import authenticator from './api/authenticator.js';
+import users from './api/resources/users.js';
 
 const app = express();
 app.use(authenticator);

--- a/imports/server/api_keys.js
+++ b/imports/server/api_keys.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { check, Match } from 'meteor/check';
 import { Random } from 'meteor/random';
-import Ansible from '/imports/ansible.js';
+import Ansible from '../ansible.js';
 
 const userForKeyOperation = function userForKeyOperation(currentUser, forUser) {
   const canOverrideUser = Roles.userHasRole(currentUser, 'admin');

--- a/imports/server/blanche.js
+++ b/imports/server/blanche.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { _ } from 'meteor/underscore';
 import child from 'child_process';
-import Ansible from '/imports/ansible.js';
+import Ansible from '../ansible.js';
 
 const execFile = Meteor.wrapAsync(child.execFile);
 

--- a/imports/server/chat.js
+++ b/imports/server/chat.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
-import { postSlackMessage } from '/imports/server/slack.js';
+import { postSlackMessage } from './slack.js';
 
 Meteor.methods({
   sendChatMessage(puzzleId, message) {

--- a/imports/server/fixture.js
+++ b/imports/server/fixture.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
-import huntFixtures from '/imports/fixtures.js';
+import huntFixtures from '../fixtures.js';
 
 Meteor.methods({
   createFixtureHunt() {

--- a/imports/server/gdrive-init.js
+++ b/imports/server/gdrive-init.js
@@ -3,8 +3,8 @@
 
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
-import Ansible from '/imports/ansible.js';
 import googleapis from 'googleapis';
+import Ansible from '../ansible.js';
 
 let oauthClient = null;
 gdrive = null;

--- a/imports/server/gdrive.js
+++ b/imports/server/gdrive.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
-import Ansible from '/imports/ansible.js';
 import { _ } from 'meteor/underscore';
+import Ansible from '../ansible.js';
 
 const MimeTypes = {
   spreadsheet: 'application/vnd.google-apps.spreadsheet',

--- a/imports/server/global-hooks.js
+++ b/imports/server/global-hooks.js
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor';
-import { Hooks, SlackHooks } from '/imports/server/hooks.js';
+import { Hooks, SlackHooks } from './hooks.js';
 /* global globalHooks: true */
 
 Meteor.startup(() => {

--- a/imports/server/guesses.js
+++ b/imports/server/guesses.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
-import Ansible from '/imports/ansible.js';
+import Ansible from '../ansible.js';
 
 function addChatMessage(guess, newState) {
   const message = `Guess ${guess.guess} was marked ${newState}`;

--- a/imports/server/hooks.js
+++ b/imports/server/hooks.js
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor';
-import { postSlackMessage } from '/imports/server/slack.js';
+import { postSlackMessage } from './slack.js';
 
 class Hooks {
   constructor() {

--- a/imports/server/hunts.js
+++ b/imports/server/hunts.js
@@ -1,10 +1,10 @@
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
 import { _ } from 'meteor/underscore';
-import Ansible from '/imports/ansible.js';
-import List from '/imports/server/blanche.js';
 import { Accounts } from 'meteor/accounts-base';
 import { Email } from 'meteor/email';
+import Ansible from '../ansible.js';
+import List from './blanche.js';
 
 const existingJoinEmail = (user, hunt, joinerName) => {
   const email = user && user.emails && user.emails[0] && user.emails[0].address;

--- a/imports/server/migrations/14-fix-display-names-index.js
+++ b/imports/server/migrations/14-fix-display-names-index.js
@@ -1,5 +1,5 @@
 import { Migrations } from 'meteor/percolate:migrations';
-import { dropIndex } from '/imports/server/migrations.js';
+import { dropIndex } from '../migrations.js';
 
 Migrations.add({
   version: 14,

--- a/imports/server/migrations/15-backfill-chat-base-props.js
+++ b/imports/server/migrations/15-backfill-chat-base-props.js
@@ -1,5 +1,5 @@
 import { Migrations } from 'meteor/percolate:migrations';
-import { dropIndex } from '/imports/server/migrations.js';
+import { dropIndex } from '../migrations.js';
 
 Migrations.add({
   version: 15,

--- a/imports/server/migrations/7-more-indexes.js
+++ b/imports/server/migrations/7-more-indexes.js
@@ -1,6 +1,6 @@
 import { Migrations } from 'meteor/percolate:migrations';
 import { Meteor } from 'meteor/meteor';
-import { dropIndex } from '/imports/server/migrations.js';
+import { dropIndex } from '../migrations.js';
 
 Migrations.add({
   version: 7,

--- a/imports/server/models/lock.js
+++ b/imports/server/models/lock.js
@@ -1,7 +1,7 @@
 // Locks are a server-only class
 import { Meteor } from 'meteor/meteor';
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
-import Ansible from '/imports/ansible.js';
+import Ansible from '../ansible.js';
 
 const Future = Npm.require('fibers/future');
 

--- a/imports/server/models/subscribers.js
+++ b/imports/server/models/subscribers.js
@@ -12,7 +12,7 @@ import { Random } from 'meteor/random';
 import { _ } from 'meteor/underscore';
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 import moment from 'moment';
-import Flags from '/imports/flags.js';
+import Flags from '../../flags.js';
 
 const serverId = Random.id();
 

--- a/imports/server/observability.js
+++ b/imports/server/observability.js
@@ -1,6 +1,6 @@
 import { MeteorX } from 'meteor/meteorhacks:meteorx';
 import { _ } from 'meteor/underscore';
-import { honeyBuilder } from '/imports/server/honey.js';
+import { honeyBuilder } from './honey.js';
 
 /* eslint-disable no-underscore-dangle */
 

--- a/imports/server/profile.js
+++ b/imports/server/profile.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
-import Ansible from '/imports/ansible.js';
+import Ansible from '../ansible.js';
 
 Meteor.methods({
   saveProfile(newProfile) {

--- a/imports/server/puzzle.js
+++ b/imports/server/puzzle.js
@@ -2,9 +2,9 @@ import { Meteor } from 'meteor/meteor';
 import { Match, check } from 'meteor/check';
 import { Random } from 'meteor/random';
 import { _ } from 'meteor/underscore';
-import Ansible from '/imports/ansible.js';
-import { ensureDocument, renameDocument, grantPermission } from '/imports/server/gdrive.js';
-import Flags from '/imports/flags.js';
+import Ansible from '../ansible.js';
+import { ensureDocument, renameDocument, grantPermission } from './gdrive.js';
+import Flags from '../flags.js';
 // TODO: gdrive, globalHooks
 
 function getOrCreateTagByName(huntId, name) {

--- a/imports/server/setup.js
+++ b/imports/server/setup.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
-import Ansible from '/imports/ansible.js';
+import Ansible from '../ansible.js';
 
 Meteor.methods({
   setupGdriveCreds(key, secret) {

--- a/imports/server/slack-methods.js
+++ b/imports/server/slack-methods.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { Match, check } from 'meteor/check';
 import { HTTP } from 'meteor/http';
-import Ansible from '/imports/ansible.js';
+import Ansible from '../ansible.js';
 
 Meteor.methods({
   slackInvite(userId) {

--- a/imports/server/slack.js
+++ b/imports/server/slack.js
@@ -1,5 +1,5 @@
 import { HTTP } from 'meteor/http';
-import Ansible from '/imports/ansible.js';
+import Ansible from '../ansible.js';
 
 function postSlackMessage(message, channel, username) {
   const config = ServiceConfiguration.configurations.findOne({ service: 'slack' });

--- a/imports/server/users.js
+++ b/imports/server/users.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { check } from 'meteor/check';
-import Ansible from '/imports/ansible.js';
+import Ansible from '../ansible.js';
 
 Meteor.methods({
   // Temporarily de-op yourself

--- a/server/main.js
+++ b/server/main.js
@@ -1,67 +1,67 @@
 // explicitly import all the stuff from lib/ since mainModule skips autoloading
 // things
-import '/imports/lib/config/accounts.js';
-import '/imports/lib/models/00index.js';
-import '/imports/lib/models/announcements.js';
-import '/imports/lib/models/chats.js';
-import '/imports/lib/models/document_permissions.js';
-import '/imports/lib/models/documents.js';
-import '/imports/lib/models/feature_flags.js';
-import '/imports/lib/models/guess.js';
-import '/imports/lib/models/hunts.js';
-import '/imports/lib/models/pending_announcements.js';
-import '/imports/lib/models/profiles.js';
-import '/imports/lib/models/proptypes.js';
-import '/imports/lib/models/puzzles.js';
-import '/imports/lib/models/tags.js';
-import '/imports/lib/models/users.js';
-import '/imports/lib/roles.js';
+import '../imports/lib/config/accounts.js';
+import '../imports/lib/models/00index.js';
+import '../imports/lib/models/announcements.js';
+import '../imports/lib/models/chats.js';
+import '../imports/lib/models/document_permissions.js';
+import '../imports/lib/models/documents.js';
+import '../imports/lib/models/feature_flags.js';
+import '../imports/lib/models/guess.js';
+import '../imports/lib/models/hunts.js';
+import '../imports/lib/models/pending_announcements.js';
+import '../imports/lib/models/profiles.js';
+import '../imports/lib/models/proptypes.js';
+import '../imports/lib/models/puzzles.js';
+import '../imports/lib/models/tags.js';
+import '../imports/lib/models/users.js';
+import '../imports/lib/roles.js';
 
 // explicitly import server-only models
-import '/imports/server/models/api_keys.js';
-import '/imports/server/models/lock.js';
-import '/imports/server/models/settings.js';
-import '/imports/server/models/subscribers.js';
+import '../imports/server/models/api_keys.js';
+import '../imports/server/models/lock.js';
+import '../imports/server/models/settings.js';
+import '../imports/server/models/subscribers.js';
 
 // register migrations
-import '/imports/server/migrations/1-basic-indexes.js';
-import '/imports/server/migrations/2-lock-unique.js';
-import '/imports/server/migrations/3-subscribers-indexes.js';
-import '/imports/server/migrations/4-fix-subscribers-indexes.js';
-import '/imports/server/migrations/5-pending-announcement-indexes.js';
-import '/imports/server/migrations/6-open-signups.js';
-import '/imports/server/migrations/7-more-indexes.js';
-import '/imports/server/migrations/8-subscriber-servers-index.js';
-import '/imports/server/migrations/9-remove-old-profile-fields.js';
-import '/imports/server/migrations/10-rename-hunt-slack-field.js';
-import '/imports/server/migrations/11-api-keys-indexes.js';
-import '/imports/server/migrations/12-doc-perms-indexes.js';
-import '/imports/server/migrations/13-display-names-index.js';
-import '/imports/server/migrations/14-fix-display-names-index.js';
-import '/imports/server/migrations/15-backfill-chat-base-props.js';
-import '/imports/server/migrations/16-feature-flag-indexes.js';
-import '/imports/server/migrations/17-update-documents-provider.js';
-import '/imports/server/migrations/18-rename-gdrive-template.js';
-import '/imports/server/migrations/19-subscribers-name-index.js';
+import '../imports/server/migrations/1-basic-indexes.js';
+import '../imports/server/migrations/2-lock-unique.js';
+import '../imports/server/migrations/3-subscribers-indexes.js';
+import '../imports/server/migrations/4-fix-subscribers-indexes.js';
+import '../imports/server/migrations/5-pending-announcement-indexes.js';
+import '../imports/server/migrations/6-open-signups.js';
+import '../imports/server/migrations/7-more-indexes.js';
+import '../imports/server/migrations/8-subscriber-servers-index.js';
+import '../imports/server/migrations/9-remove-old-profile-fields.js';
+import '../imports/server/migrations/10-rename-hunt-slack-field.js';
+import '../imports/server/migrations/11-api-keys-indexes.js';
+import '../imports/server/migrations/12-doc-perms-indexes.js';
+import '../imports/server/migrations/13-display-names-index.js';
+import '../imports/server/migrations/14-fix-display-names-index.js';
+import '../imports/server/migrations/15-backfill-chat-base-props.js';
+import '../imports/server/migrations/16-feature-flag-indexes.js';
+import '../imports/server/migrations/17-update-documents-provider.js';
+import '../imports/server/migrations/18-rename-gdrive-template.js';
+import '../imports/server/migrations/19-subscribers-name-index.js';
 
 // Other stuff in the server folder
-import '/imports/server/accounts.js';
-import '/imports/server/announcements.js';
-import '/imports/server/ansible.js';
-import '/imports/server/api-init.js';
-import '/imports/server/api_keys.js';
-import '/imports/server/chat.js';
-import '/imports/server/feature_flags.js';
-import '/imports/server/fixture.js';
-import '/imports/server/gdrive-init.js';
-import '/imports/server/git_revision.js';
-import '/imports/server/guesses.js';
-import '/imports/server/hunts.js';
-import '/imports/server/global-hooks.js'; // previously index.js
-import '/imports/server/migrations-run.js'; // runs migrations
-import '/imports/server/observability.js';
-import '/imports/server/profile.js';
-import '/imports/server/puzzle.js';
-import '/imports/server/setup.js';
-import '/imports/server/slack-methods.js';
-import '/imports/server/users.js';
+import '../imports/server/accounts.js';
+import '../imports/server/announcements.js';
+import '../imports/server/ansible.js';
+import '../imports/server/api-init.js';
+import '../imports/server/api_keys.js';
+import '../imports/server/chat.js';
+import '../imports/server/feature_flags.js';
+import '../imports/server/fixture.js';
+import '../imports/server/gdrive-init.js';
+import '../imports/server/git_revision.js';
+import '../imports/server/guesses.js';
+import '../imports/server/hunts.js';
+import '../imports/server/global-hooks.js'; // previously index.js
+import '../imports/server/migrations-run.js'; // runs migrations
+import '../imports/server/observability.js';
+import '../imports/server/profile.js';
+import '../imports/server/puzzle.js';
+import '../imports/server/setup.js';
+import '../imports/server/slack-methods.js';
+import '../imports/server/users.js';


### PR DESCRIPTION
VS Code seems unable to resolve Meteor's style of absolute imports (I
think it assumes that they're absolute to the filesystem), and there's
some implication that Typescript doesn't support them either.

Switch to relative imports, and add eslint enforcement that we don't
introduce new ones.