### PR TITLE
Switch to using a custom resource for AMI lookups

### DIFF
--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -104,12 +104,6 @@ Parameters:
     Default: ''
     NoEcho: true
 
-Mappings:
-  UbuntuAmis:
-    us-east-1:
-      trusty: ami-5ac2cd4d
-      xenial: ami-9dcfdb8a
-
 Conditions:
   HavePapertrail: !Not [!Equals [!Ref PapertrailHost, '']]
   HaveDatadog: !Not [!Equals [!Ref DatadogApiKey, '']]
@@ -122,6 +116,107 @@ Resources:
         Rules:
           - ExpirationInDays: 30
             Status: Enabled
+
+  AMILookupRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [lambda.amazonaws.com]
+            Action: ["sts:AssumeRole"]
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: "arn:aws:logs:*:*:*"
+  AMILookupFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Look up the latest Ubuntu AMI given specific parameters
+      Runtime: nodejs8.10
+      Handler: "index.main"
+      Timeout: 10
+      Role: !GetAtt AMILookupRole.Arn
+      Code:
+        ZipFile: |
+          const https = require('https');
+          const response = require('cfn-response');
+          const assert = require('assert');
+
+          const getContent = function(url) {
+            return new Promise((resolve, reject) => {
+              const request = https.get(url, (response) => {
+                if (response.statusCode < 200 || response.statusCode > 299) {
+                  reject(new Error('Error loading: ' + response.statusCode));
+                }
+                const body = [];
+                response.on('data', (chunk) => body.push(chunk));
+                response.on('end', () => resolve(body.join('')));
+              });
+              request.on('error', (err) => reject(err));
+            });
+          };
+
+          // By promise-ifying this we can block the main function from resolving until this finishes
+          const sendResponse = function(event, context, status, data) {
+            return new Promise((resolve) => {
+              const fakeContext = Object.assign({}, context, { done: resolve });
+              response.send(event, fakeContext, status, data);
+            });
+          }
+
+          exports.main = async (event, context) => {
+            try {
+              const suite = event.ResourceProperties.Suite;
+              const instanceType = event.ResourceProperties.InstanceType;
+              const arch = event.ResourceProperties.Architecture;
+              const region = event.ResourceProperties.Region;
+              const virtType = event.ResourceProperties.VirtualizationType;
+              assert(suite && instanceType && arch && region && virtType);
+
+              const raw = await getContent(`https://cloud-images.ubuntu.com/query/${suite}/server/released.current.txt`);
+              const data = raw.split('\n').map(l => l.split('\t')).
+                map(l => ({
+                  suite: l[0],
+                  stream: l[1],
+                  tag: l[2],
+                  serial: l[3],
+                  itype: l[4],
+                  arch: l[5],
+                  region: l[6],
+                  ami: l[7],
+                  aki: l[8],
+                  virttype: l[10],
+                }));
+              const match = data.find(l =>
+                l.suite === suite &&
+                l.itype === instanceType &&
+                l.arch === arch &&
+                l.region === region &&
+                l.virttype === virtType);
+              await sendResponse(event, context, response.SUCCESS, {AMI: match.ami});
+            } catch (e) {
+              await sendResponse(event, context, response.FAILED, {Error: e.message});
+            }
+          };
+  AMILookup:
+    Type: Custom::AMILookup
+    Properties:
+      ServiceToken: !GetAtt AMILookupFunction.Arn
+      Suite: xenial
+      Region: !Ref "AWS::Region"
+      InstanceType: ebs-ssd
+      Architecture: amd64
+      VirtualizationType: hvm
 
   VPC:
     Type: AWS::EC2::VPC
@@ -330,7 +425,7 @@ Resources:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
       IamInstanceProfile: !Ref AppInstanceProfile
-      ImageId: !FindInMap [UbuntuAmis, !Ref "AWS::Region", xenial]
+      ImageId: !GetAtt AMILookup.AMI
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:


### PR DESCRIPTION
The CloudFormation template previously had a hard-coded set of AMIs to
use, but that gets stale quickly. Instead, use a custom resource backed
by a Lambda function to lookup the latest AMIs whenever the
CloudFormation template gets updated.

(This won't, e.g., upgrade instances if they're replaced between
CloudFormation runs, but it's still better than a fixed AMI.)

I haven't been able to test this in prod yet, because the stack is currently stuck due to a bug in an earlier version. I think it'll eventually reset after enough time.