### PR TITLE
Make subsCache instance an exported global

### DIFF
--- a/imports/client/JRPropTypes.js
+++ b/imports/client/JRPropTypes.js
@@ -1,8 +1,0 @@
-import PropTypes from 'prop-types';
-import { SubsCache } from 'meteor/ccorcos:subs-cache';
-
-const JRPropTypes = {
-  subs: PropTypes.instanceOf(SubsCache).isRequired,
-};
-
-export default JRPropTypes;

--- a/imports/client/components/AllProfileListPage.jsx
+++ b/imports/client/components/AllProfileListPage.jsx
@@ -1,19 +1,18 @@
 import React from 'react';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import JRPropTypes from '../JRPropTypes.js';
+import subsCache from '../subsCache.js';
 import navAggregatorType from './navAggregatorType.jsx';
 import ProfileList from './ProfileList.jsx';
 
 const AllProfileListPage = React.createClass({
   contextTypes: {
-    subs: JRPropTypes.subs,
     navAggregator: navAggregatorType,
   },
 
   mixins: [ReactMeteorData],
 
   getMeteorData() {
-    const profilesHandle = this.context.subs.subscribe('mongo.profiles');
+    const profilesHandle = subsCache.subscribe('mongo.profiles');
     const ready = profilesHandle.ready();
     const profiles = ready ? Models.Profiles.find({}, { sort: { displayName: 1 } }).fetch() : [];
     return {

--- a/imports/client/components/AnnouncementsPage.jsx
+++ b/imports/client/components/AnnouncementsPage.jsx
@@ -6,8 +6,8 @@ import Alert from 'react-bootstrap/lib/Alert';
 import Button from 'react-bootstrap/lib/Button';
 import marked from 'marked';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import JRPropTypes from '../JRPropTypes.js';
 import navAggregatorType from './navAggregatorType.jsx';
+import subsCache from '../subsCache.js';
 
 /* eslint-disable max-len */
 
@@ -107,7 +107,6 @@ const AnnouncementsPage = React.createClass({
   },
 
   contextTypes: {
-    subs: JRPropTypes.subs,
     navAggregator: navAggregatorType,
   },
 
@@ -117,8 +116,8 @@ const AnnouncementsPage = React.createClass({
     // We already have subscribed to mongo.announcements on the main page, since we want to be able
     // to show them on any page.  So we don't *need* to make the subscription here...
     // ...except that we might want to wait to render until we've received all of them?  IDK.
-    const announcementsHandle = this.context.subs.subscribe('mongo.announcements', { hunt: this.props.params.huntId });
-    const displayNamesHandle = Models.Profiles.subscribeDisplayNames(this.context.subs);
+    const announcementsHandle = subsCache.subscribe('mongo.announcements', { hunt: this.props.params.huntId });
+    const displayNamesHandle = Models.Profiles.subscribeDisplayNames(subsCache);
     const ready = announcementsHandle.ready() && displayNamesHandle.ready();
 
     let announcements;

--- a/imports/client/components/App.jsx
+++ b/imports/client/components/App.jsx
@@ -8,14 +8,13 @@ import Navbar from 'react-bootstrap/lib/Navbar';
 import { Link } from 'react-router';
 import RRBS from 'react-router-bootstrap';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import JRPropTypes from '../JRPropTypes.js';
+import subsCache from '../subsCache.js';
 import ConnectionStatus from './ConnectionStatus.jsx';
 import NotificationCenter from './NotificationCenter.jsx';
 import navAggregatorType from './navAggregatorType.jsx';
 
 const SharedNavbar = React.createClass({
   contextTypes: {
-    subs: JRPropTypes.subs,
     navAggregator: navAggregatorType,
   },
 
@@ -23,7 +22,7 @@ const SharedNavbar = React.createClass({
 
   getMeteorData() {
     const userId = Meteor.userId();
-    const profileSub = this.context.subs.subscribe('mongo.profiles', { _id: userId });
+    const profileSub = subsCache.subscribe('mongo.profiles', { _id: userId });
     const profile = Models.Profiles.findOne(userId);
     const displayName = profileSub.ready() ?
       ((profile && profile.displayName) || '<no name given>') : 'loading...';

--- a/imports/client/components/CelebrationCenter.jsx
+++ b/imports/client/components/CelebrationCenter.jsx
@@ -3,16 +3,12 @@ import React from 'react';
 import { Meteor } from 'meteor/meteor';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
 import Flags from '../../flags.js';
-import JRPropTypes from '../JRPropTypes.js';
+import subsCache from '../subsCache.js';
 import Celebration from './Celebration.jsx';
 
 const CelebrationCenter = React.createClass({
   propTypes: {
     huntId: PropTypes.string.isRequired,
-  },
-
-  contextTypes: {
-    subs: JRPropTypes.subs,
   },
 
   mixins: [ReactMeteorData],
@@ -53,7 +49,7 @@ const CelebrationCenter = React.createClass({
 
   getMeteorData() {
     // This should be effectively a noop, since we're already fetching it for every hunt
-    const puzzlesHandle = this.context.subs.subscribe('mongo.puzzles', { hunt: this.props.huntId });
+    const puzzlesHandle = subsCache.subscribe('mongo.puzzles', { hunt: this.props.huntId });
     if (puzzlesHandle.ready()) {
       if (this.watchHandle) {
         this.watchHandle.stop();

--- a/imports/client/components/GuessQueuePage.jsx
+++ b/imports/client/components/GuessQueuePage.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import classnames from 'classnames';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import JRPropTypes from '../JRPropTypes.js';
+import subsCache from '../subsCache.js';
 import navAggregatorType from './navAggregatorType.jsx';
 
 /* eslint-disable max-len */
@@ -115,20 +115,19 @@ const GuessQueuePage = React.createClass({
   },
 
   contextTypes: {
-    subs: JRPropTypes.subs,
     navAggregator: navAggregatorType,
   },
 
   mixins: [ReactMeteorData],
 
   getMeteorData() {
-    const guessesHandle = this.context.subs.subscribe('mongo.guesses', {
+    const guessesHandle = subsCache.subscribe('mongo.guesses', {
       hunt: this.props.params.huntId,
     });
-    const puzzlesHandle = this.context.subs.subscribe('mongo.puzzles', {
+    const puzzlesHandle = subsCache.subscribe('mongo.puzzles', {
       hunt: this.props.params.huntId,
     });
-    const displayNamesHandle = Models.Profiles.subscribeDisplayNames(this.context.subs);
+    const displayNamesHandle = Models.Profiles.subscribeDisplayNames(subsCache);
     const ready = guessesHandle.ready() && puzzlesHandle.ready() && displayNamesHandle.ready();
     const guesses = ready ? Models.Guesses.find({ hunt: this.props.params.huntId }, { sort: { createdAt: -1 } }).fetch() : [];
     const puzzles = ready ? _.indexBy(Models.Puzzles.find({ hunt: this.props.params.huntId }).fetch(), '_id') : {};

--- a/imports/client/components/HuntApp.jsx
+++ b/imports/client/components/HuntApp.jsx
@@ -8,7 +8,7 @@ import ButtonToolbar from 'react-bootstrap/lib/ButtonToolbar';
 import DocumentTitle from 'react-document-title';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
 import marked from 'marked';
-import JRPropTypes from '../JRPropTypes.js';
+import subsCache from '../subsCache.js';
 import navAggregatorType from './navAggregatorType.jsx';
 import CelebrationCenter from './CelebrationCenter.jsx';
 
@@ -70,7 +70,6 @@ const HuntMemberError = React.createClass({
 
   contextTypes: {
     router: PropTypes.object.isRequired,
-    subs: JRPropTypes.subs,
   },
 
   mixins: [ReactMeteorData],
@@ -129,15 +128,14 @@ const HuntApp = React.createClass({
   },
 
   contextTypes: {
-    subs: JRPropTypes.subs,
     navAggregator: navAggregatorType,
   },
 
   mixins: [ReactMeteorData],
 
   getMeteorData() {
-    const userHandle = this.context.subs.subscribe('selfHuntMembership');
-    const huntHandle = this.context.subs.subscribe('mongo.hunts.allowingDeleted', {
+    const userHandle = subsCache.subscribe('selfHuntMembership');
+    const huntHandle = subsCache.subscribe('mongo.hunts.allowingDeleted', {
       _id: this.props.params.huntId,
     });
     const member = Meteor.user() && _.contains(Meteor.user().hunts, this.props.params.huntId);

--- a/imports/client/components/HuntListPage.jsx
+++ b/imports/client/components/HuntListPage.jsx
@@ -14,7 +14,7 @@ import HelpBlock from 'react-bootstrap/lib/HelpBlock';
 import { Link } from 'react-router';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
 import Ansible from '../../ansible.js';
-import JRPropTypes from '../JRPropTypes.js';
+import subsCache from '../subsCache.js';
 import navAggregatorType from './navAggregatorType.jsx';
 import ModalForm from './ModalForm.jsx';
 
@@ -356,7 +356,6 @@ const MockHunt = React.createClass({
 
 const HuntListPage = React.createClass({
   contextTypes: {
-    subs: JRPropTypes.subs,
     navAggregator: navAggregatorType,
   },
 
@@ -368,8 +367,8 @@ const HuntListPage = React.createClass({
   },
 
   getMeteorData() {
-    const huntListHandle = this.context.subs.subscribe('mongo.hunts');
-    const myHuntsHandle = this.context.subs.subscribe('selfHuntMembership');
+    const huntListHandle = subsCache.subscribe('mongo.hunts');
+    const myHuntsHandle = subsCache.subscribe('selfHuntMembership');
     const ready = huntListHandle.ready() && myHuntsHandle.ready();
 
     const myHunts = {};

--- a/imports/client/components/HuntProfileListPage.jsx
+++ b/imports/client/components/HuntProfileListPage.jsx
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import JRPropTypes from '../JRPropTypes.js';
+import subsCache from '../subsCache.js';
 import navAggregatorType from './navAggregatorType.jsx';
 import ProfileList from './ProfileList.jsx';
 
@@ -14,15 +14,14 @@ const HuntProfileListPage = React.createClass({
   },
 
   contextTypes: {
-    subs: JRPropTypes.subs,
     navAggregator: navAggregatorType,
   },
 
   mixins: [ReactMeteorData],
 
   getMeteorData() {
-    const usersHandle = this.context.subs.subscribe('huntMembers', this.props.params.huntId);
-    const profilesHandle = this.context.subs.subscribe('mongo.profiles');
+    const usersHandle = subsCache.subscribe('huntMembers', this.props.params.huntId);
+    const profilesHandle = subsCache.subscribe('mongo.profiles');
 
     const ready = usersHandle.ready() && profilesHandle.ready();
     if (!ready) {

--- a/imports/client/components/NotificationCenter.jsx
+++ b/imports/client/components/NotificationCenter.jsx
@@ -12,7 +12,7 @@ import marked from 'marked';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
 import classnames from 'classnames';
 import CopyToClipboard from 'react-copy-to-clipboard';
-import JRPropTypes from '../JRPropTypes.js';
+import subsCache from '../subsCache.js';
 
 /* eslint-disable max-len */
 
@@ -253,10 +253,6 @@ const AnnouncementMessage = React.createClass({
 });
 
 const NotificationCenter = React.createClass({
-  contextTypes: {
-    subs: JRPropTypes.subs,
-  },
-
   mixins: [ReactMeteorData],
 
   getInitialState() {
@@ -273,23 +269,23 @@ const NotificationCenter = React.createClass({
     let guessesHandle = { ready: () => true };
     let puzzlesHandle = { ready: () => true };
     if (canUpdateGuesses) {
-      guessesHandle = this.context.subs.subscribe('mongo.guesses', { state: 'pending' });
-      puzzlesHandle = this.context.subs.subscribe('mongo.puzzles');
+      guessesHandle = subsCache.subscribe('mongo.guesses', { state: 'pending' });
+      puzzlesHandle = subsCache.subscribe('mongo.puzzles');
     }
 
     // This is overly broad, but we likely already have the data cached locally
-    const selfHandle = this.context.subs.subscribe('mongo.profiles', { _id: Meteor.userId() });
-    const displayNamesHandle = this.context.subs.subscribe(
+    const selfHandle = subsCache.subscribe('mongo.profiles', { _id: Meteor.userId() });
+    const displayNamesHandle = subsCache.subscribe(
       'mongo.profiles',
       {},
       { fields: { displayName: 1 } }
     );
-    const announcementsHandle = this.context.subs.subscribe('mongo.announcements');
+    const announcementsHandle = subsCache.subscribe('mongo.announcements');
 
     const query = {
       user: Meteor.userId(),
     };
-    const paHandle = this.context.subs.subscribe('mongo.pending_announcements', query);
+    const paHandle = subsCache.subscribe('mongo.pending_announcements', query);
 
     // Don't even try to put things together until we have the announcements loaded
     if (!selfHandle.ready() || !displayNamesHandle.ready() || !announcementsHandle.ready()) {

--- a/imports/client/components/ProfilePage.jsx
+++ b/imports/client/components/ProfilePage.jsx
@@ -10,7 +10,7 @@ import FormGroup from 'react-bootstrap/lib/FormGroup';
 import HelpBlock from 'react-bootstrap/lib/HelpBlock';
 import Label from 'react-bootstrap/lib/Label';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import JRPropTypes from '../JRPropTypes.js';
+import subsCache from '../subsCache.js';
 import navAggregatorType from './navAggregatorType.jsx';
 
 /* eslint-disable max-len */
@@ -411,7 +411,6 @@ const ProfilePage = React.createClass({
   },
 
   contextTypes: {
-    subs: JRPropTypes.subs,
     navAggregator: navAggregatorType,
   },
 
@@ -420,8 +419,8 @@ const ProfilePage = React.createClass({
   getMeteorData() {
     const uid = this.props.params.userId === 'me' ? Meteor.userId() : this.props.params.userId;
 
-    const profileHandle = this.context.subs.subscribe('mongo.profiles', { _id: uid });
-    const userRolesHandle = this.context.subs.subscribe('userRoles', uid);
+    const profileHandle = subsCache.subscribe('mongo.profiles', { _id: uid });
+    const userRolesHandle = subsCache.subscribe('userRoles', uid);
     const user = Meteor.user();
     const defaultEmail = user && user.emails && user.emails.length > 0 && user.emails[0] && user.emails[0].address;
     const data = {

--- a/imports/client/components/PuzzleListPage.jsx
+++ b/imports/client/components/PuzzleListPage.jsx
@@ -12,7 +12,7 @@ import Nav from 'react-bootstrap/lib/Nav';
 import NavItem from 'react-bootstrap/lib/NavItem';
 import { Link, browserHistory } from 'react-router';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
-import JRPropTypes from '../JRPropTypes.js';
+import subsCache from '../subsCache.js';
 import PuzzleList from './PuzzleList.jsx';
 import RelatedPuzzleGroup from './RelatedPuzzleGroup.jsx';
 import PuzzleModalForm from './PuzzleModalForm.jsx';
@@ -377,19 +377,15 @@ const PuzzleListPage = React.createClass({
     location: PropTypes.object,
   },
 
-  contextTypes: {
-    subs: JRPropTypes.subs,
-  },
-
   mixins: [ReactMeteorData],
 
   getMeteorData() {
-    const puzzlesHandle = this.context.subs.subscribe('mongo.puzzles', { hunt: this.props.params.huntId });
-    const tagsHandle = this.context.subs.subscribe('mongo.tags', { hunt: this.props.params.huntId });
+    const puzzlesHandle = subsCache.subscribe('mongo.puzzles', { hunt: this.props.params.huntId });
+    const tagsHandle = subsCache.subscribe('mongo.tags', { hunt: this.props.params.huntId });
 
     if (!Flags.active('disable.subcounters')) {
       // Don't bother including this in ready - it's ok if it trickles in
-      this.context.subs.subscribe('subscribers.counts', { hunt: this.props.params.huntId });
+      subsCache.subscribe('subscribers.counts', { hunt: this.props.params.huntId });
     }
 
     const ready = puzzlesHandle.ready() && tagsHandle.ready();

--- a/imports/client/components/PuzzlePage.jsx
+++ b/imports/client/components/PuzzlePage.jsx
@@ -23,7 +23,7 @@ import moment from 'moment';
 import TextareaAutosize from 'react-textarea-autosize';
 import { ReactMeteorData } from 'meteor/react-meteor-data';
 import Ansible from '../../ansible.js';
-import JRPropTypes from '../JRPropTypes.js';
+import subsCache from '../subsCache.js';
 import navAggregatorType from './navAggregatorType.jsx';
 import ModalForm from './ModalForm.jsx';
 import PuzzleModalForm from './PuzzleModalForm.jsx';
@@ -54,16 +54,12 @@ const ViewersList = React.createClass({
     name: PropTypes.string.isRequired,
   },
 
-  contextTypes: {
-    subs: JRPropTypes.subs,
-  },
-
   mixins: [ReactMeteorData],
 
   getMeteorData() {
     // Don't want this subscription persisting longer than necessary
     const subscribersHandle = Meteor.subscribe('subscribers.fetch', this.props.name);
-    const profilesHandle = this.context.subs.subscribe('mongo.profiles');
+    const profilesHandle = subsCache.subscribe('mongo.profiles');
 
     const ready = subscribersHandle.ready() && profilesHandle.ready();
     if (!ready) {
@@ -966,7 +962,6 @@ const PuzzlePage = React.createClass({
   },
 
   contextTypes: {
-    subs: JRPropTypes.subs,
     navAggregator: navAggregatorType,
   },
 
@@ -1045,19 +1040,19 @@ const PuzzlePage = React.createClass({
       });
     }
 
-    const displayNamesHandle = Models.Profiles.subscribeDisplayNames(this.context.subs);
+    const displayNamesHandle = Models.Profiles.subscribeDisplayNames(subsCache);
     let displayNames = {};
     if (displayNamesHandle.ready()) {
       displayNames = Models.Profiles.displayNames();
     }
 
-    const puzzlesHandle = this.context.subs.subscribe('mongo.puzzles', { hunt: this.props.params.huntId });
-    const tagsHandle = this.context.subs.subscribe('mongo.tags', { hunt: this.props.params.huntId });
-    const guessesHandle = this.context.subs.subscribe('mongo.guesses', { puzzle: this.props.params.puzzleId });
-    const documentsHandle = this.context.subs.subscribe('mongo.documents', { puzzle: this.props.params.puzzleId });
+    const puzzlesHandle = subsCache.subscribe('mongo.puzzles', { hunt: this.props.params.huntId });
+    const tagsHandle = subsCache.subscribe('mongo.tags', { hunt: this.props.params.huntId });
+    const guessesHandle = subsCache.subscribe('mongo.guesses', { puzzle: this.props.params.puzzleId });
+    const documentsHandle = subsCache.subscribe('mongo.documents', { puzzle: this.props.params.puzzleId });
 
     if (!Flags.active('disable.subcounters')) {
-      this.context.subs.subscribe('subscribers.counts', { hunt: this.props.params.huntId });
+      subsCache.subscribe('subscribers.counts', { hunt: this.props.params.huntId });
     }
 
     const puzzlesReady = puzzlesHandle.ready() && tagsHandle.ready() && guessesHandle.ready() && documentsHandle.ready() && displayNamesHandle.ready();
@@ -1084,7 +1079,7 @@ const PuzzlePage = React.createClass({
 
     const chatFields = {};
     FilteredChatFields.forEach((f) => { chatFields[f] = 1; });
-    const chatHandle = this.context.subs.subscribe(
+    const chatHandle = subsCache.subscribe(
       'mongo.chatmessages',
       { puzzle: this.props.params.puzzleId },
       { fields: chatFields }

--- a/imports/client/components/Routes.jsx
+++ b/imports/client/components/Routes.jsx
@@ -6,8 +6,6 @@ import {
   browserHistory,
 } from 'react-router';
 import DocumentTitle from 'react-document-title';
-import { SubsCache } from 'meteor/ccorcos:subs-cache';
-import JRPropTypes from '../JRPropTypes.js';
 import AllProfileListPage from './AllProfileListPage.jsx';
 import App from './App.jsx';
 import AnnouncementsPage from './AnnouncementsPage.jsx';
@@ -30,21 +28,15 @@ import UserInvitePage from './UserInvitePage.jsx';
 
 const Routes = React.createClass({
   childContextTypes: {
-    subs: JRPropTypes.subs,
     navAggregator: navAggregatorType,
   },
 
   getChildContext() {
-    if (!this.subs) {
-      this.subs = new SubsCache({ cacheLimit: -1, expireAfter: 1 });
-    }
-
     if (!this.navAggregator) {
       this.navAggregator = new NavAggregator();
     }
 
     return {
-      subs: this.subs,
       navAggregator: this.navAggregator,
     };
   },

--- a/imports/client/subsCache.js
+++ b/imports/client/subsCache.js
@@ -1,0 +1,3 @@
+import { SubsCache } from 'meteor/ccorcos:subs-cache';
+
+export default new SubsCache({ cacheLimit: -1, expireAfter: 1 });


### PR DESCRIPTION
The previous implementation used React's deprecated legacy context interfaces, and was _basically_ global already (it's not like we ever de-instantiated the Routes class, and even if we did we wouldn't cleanup the subs cache instance). Let's just make it official.

(I think we want to keep the subs cache around, because there are a lot of cases where we take pretty eager subscriptions - e.g. all of `mongo.profiles` on the view count modal - but don't want to necessarily load them up for the entire site)