### PR TITLE
Switch from ReactMeteorData to using withTracker

### DIFF
--- a/imports/client/components/AllProfileListPage.jsx
+++ b/imports/client/components/AllProfileListPage.jsx
@@ -1,32 +1,26 @@
 import React from 'react';
-import { ReactMeteorData } from 'meteor/react-meteor-data';
+import PropTypes from 'prop-types';
+import { withTracker } from 'meteor/react-meteor-data';
 import subsCache from '../subsCache.js';
 import navAggregatorType from './navAggregatorType.jsx';
 import ProfileList from './ProfileList.jsx';
 
 const AllProfileListPage = React.createClass({
+  propTypes: {
+    ready: PropTypes.bool.isRequired,
+    profiles: PropTypes.arrayOf(PropTypes.shape(Schemas.Profiles.asReactPropTypes())).isRequired,
+  },
+
   contextTypes: {
     navAggregator: navAggregatorType,
   },
 
-  mixins: [ReactMeteorData],
-
-  getMeteorData() {
-    const profilesHandle = subsCache.subscribe('mongo.profiles');
-    const ready = profilesHandle.ready();
-    const profiles = ready ? Models.Profiles.find({}, { sort: { displayName: 1 } }).fetch() : [];
-    return {
-      ready,
-      profiles,
-    };
-  },
-
   render() {
     let body;
-    if (!this.data.ready) {
+    if (!this.props.ready) {
       body = <div>loading...</div>;
     } else {
-      body = <ProfileList profiles={this.data.profiles} />;
+      body = <ProfileList profiles={this.props.profiles} />;
     }
 
     return (
@@ -41,4 +35,12 @@ const AllProfileListPage = React.createClass({
   },
 });
 
-export default AllProfileListPage;
+export default withTracker(() => {
+  const profilesHandle = subsCache.subscribe('mongo.profiles');
+  const ready = profilesHandle.ready();
+  const profiles = ready ? Models.Profiles.find({}, { sort: { displayName: 1 } }).fetch() : [];
+  return {
+    ready,
+    profiles,
+  };
+})(AllProfileListPage);

--- a/imports/client/components/Authenticator.jsx
+++ b/imports/client/components/Authenticator.jsx
@@ -3,16 +3,16 @@ import { _ } from 'meteor/underscore';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { browserHistory } from 'react-router';
-import { ReactMeteorData } from 'meteor/react-meteor-data';
+import { withTracker } from 'meteor/react-meteor-data';
 
 const Authenticator = React.createClass({
   propTypes: {
     route: PropTypes.object,
     children: PropTypes.node,
     location: PropTypes.object,
+    loggingIn: PropTypes.bool,
+    userId: PropTypes.string,
   },
-
-  mixins: [ReactMeteorData],
 
   getInitialState() {
     return { loading: true };
@@ -26,29 +26,22 @@ const Authenticator = React.createClass({
     this.checkAuth();
   },
 
-  getMeteorData() {
-    return {
-      loggingIn: Meteor.loggingIn(),
-      user: Meteor.user(),
-    };
-  },
-
   checkAuth() {
     if (this.state.loading) {
-      if (this.data.loggingIn) {
+      if (this.props.loggingIn) {
         return;
       } else {
         this.setState({ loading: false });
       }
     }
 
-    if (!this.data.user && this.props.route.authenticated) {
+    if (!this.props.userId && this.props.route.authenticated) {
       const stateToSave = _.pick(this.props.location, 'pathname', 'query');
       browserHistory.replace({
         pathname: '/login',
         state: stateToSave,
       });
-    } else if (this.data.user && !this.props.route.authenticated) {
+    } else if (this.props.userId && !this.props.route.authenticated) {
       const state = _.extend({ path: '/', query: undefined }, this.props.location.state);
       browserHistory.replace({
         pathname: state.pathname,
@@ -66,4 +59,9 @@ const Authenticator = React.createClass({
   },
 });
 
-export default Authenticator;
+export default withTracker(() => {
+  return {
+    loggingIn: Meteor.loggingIn(),
+    userId: Meteor.userId(),
+  };
+})(Authenticator);

--- a/imports/client/components/ConnectionStatus.jsx
+++ b/imports/client/components/ConnectionStatus.jsx
@@ -1,24 +1,22 @@
 import { Meteor } from 'meteor/meteor';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Alert from 'react-bootstrap/lib/Alert';
 import Button from 'react-bootstrap/lib/Button';
-import { ReactMeteorData } from 'meteor/react-meteor-data';
+import { withTracker } from 'meteor/react-meteor-data';
 import Ansible from '../../ansible.js';
 
 const ConnectionStatus = React.createClass({
-  mixins: [ReactMeteorData],
+  propTypes: {
+    meteorStatus: PropTypes.object,
+  },
 
   componentWillMount() {
     this.forceUpdateBound = this.forceUpdate.bind(this);
   },
 
-  getMeteorData() {
-    const data = { meteorStatus: Meteor.status() };
-    return data;
-  },
-
   render() {
-    switch (this.data.meteorStatus.status) {
+    switch (this.props.meteorStatus.status) {
       case 'connecting':
         return (
           <Alert bsStyle="warning">
@@ -31,12 +29,12 @@ const ConnectionStatus = React.createClass({
             <strong>Oh no!</strong>
             {' '}
             Unable to connect to Jolly Roger:
-            {this.data.meteorStatus.reason}
+            {this.props.meteorStatus.reason}
           </Alert>
         );
       case 'waiting': {
         const now = Date.now();
-        const timeToRetry = Math.ceil((this.data.meteorStatus.retryTime - now) / 1000);
+        const timeToRetry = Math.ceil((this.props.meteorStatus.retryTime - now) / 1000);
 
         // Trigger a refresh in a second.  TODO: debounce this?
         window.setTimeout(this.forceUpdateBound, 1000);
@@ -64,10 +62,12 @@ const ConnectionStatus = React.createClass({
       case 'connected':
         return null;
       default:
-        Ansible.warn('Unknown connection status', { state: this.data.meteorStatus.status });
+        Ansible.warn('Unknown connection status', { state: this.props.meteorStatus.status });
         return null;
     }
   },
 });
 
-export default ConnectionStatus;
+export default withTracker(() => {
+  return { meteorStatus: Meteor.status() };
+})(ConnectionStatus);

--- a/imports/client/components/GuessQueuePage.jsx
+++ b/imports/client/components/GuessQueuePage.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
 import classnames from 'classnames';
-import { ReactMeteorData } from 'meteor/react-meteor-data';
+import { withTracker } from 'meteor/react-meteor-data';
 import subsCache from '../subsCache.js';
 import navAggregatorType from './navAggregatorType.jsx';
 
@@ -112,56 +112,33 @@ const GuessQueuePage = React.createClass({
     params: PropTypes.shape({
       huntId: PropTypes.string.isRequired,
     }).isRequired,
+    ready: PropTypes.bool.isRequired,
+    guesses: PropTypes.arrayOf(PropTypes.shape(Schemas.Guesses.asReactPropTypes())).isRequired,
+    puzzles: PropTypes.objectOf(PropTypes.shape(Schemas.Puzzles.asReactPropTypes())).isRequired,
+    displayNames: PropTypes.objectOf(PropTypes.string).isRequired,
+    canEdit: PropTypes.bool.isRequired,
   },
 
   contextTypes: {
     navAggregator: navAggregatorType,
   },
 
-  mixins: [ReactMeteorData],
-
-  getMeteorData() {
-    const guessesHandle = subsCache.subscribe('mongo.guesses', {
-      hunt: this.props.params.huntId,
-    });
-    const puzzlesHandle = subsCache.subscribe('mongo.puzzles', {
-      hunt: this.props.params.huntId,
-    });
-    const displayNamesHandle = Models.Profiles.subscribeDisplayNames(subsCache);
-    const ready = guessesHandle.ready() && puzzlesHandle.ready() && displayNamesHandle.ready();
-    const guesses = ready ? Models.Guesses.find({ hunt: this.props.params.huntId }, { sort: { createdAt: -1 } }).fetch() : [];
-    const puzzles = ready ? _.indexBy(Models.Puzzles.find({ hunt: this.props.params.huntId }).fetch(), '_id') : {};
-    let displayNames = {};
-    if (ready) {
-      displayNames = Models.Profiles.displayNames();
-    }
-
-    const canEdit = Roles.userHasPermission(Meteor.userId(), 'mongo.guesses.update');
-    return {
-      ready,
-      guesses,
-      puzzles,
-      displayNames,
-      canEdit,
-    };
-  },
-
   renderPage() {
-    if (!this.data.ready) {
+    if (!this.props.ready) {
       return <div>loading...</div>;
     }
 
     return (
       <div>
         <h1>Guess queue</h1>
-        {this.data.guesses.map((guess) => {
+        {this.props.guesses.map((guess) => {
           return (
             <GuessBlock
               key={guess._id}
               guess={guess}
-              createdByDisplayName={this.data.displayNames[guess.createdBy]}
-              puzzle={this.data.puzzles[guess.puzzle]}
-              canEdit={this.data.canEdit}
+              createdByDisplayName={this.props.displayNames[guess.createdBy]}
+              puzzle={this.props.puzzles[guess.puzzle]}
+              canEdit={this.props.canEdit}
             />
           );
         })}
@@ -182,4 +159,36 @@ const GuessQueuePage = React.createClass({
   },
 });
 
-export default GuessQueuePage;
+const GuessQueuePageContainer = withTracker(({ params }) => {
+  const guessesHandle = subsCache.subscribe('mongo.guesses', {
+    hunt: params.huntId,
+  });
+  const puzzlesHandle = subsCache.subscribe('mongo.puzzles', {
+    hunt: params.huntId,
+  });
+  const displayNamesHandle = Models.Profiles.subscribeDisplayNames(subsCache);
+  const ready = guessesHandle.ready() && puzzlesHandle.ready() && displayNamesHandle.ready();
+  const guesses = ready ? Models.Guesses.find({ hunt: params.huntId }, { sort: { createdAt: -1 } }).fetch() : [];
+  const puzzles = ready ? _.indexBy(Models.Puzzles.find({ hunt: params.huntId }).fetch(), '_id') : {};
+  let displayNames = {};
+  if (ready) {
+    displayNames = Models.Profiles.displayNames();
+  }
+
+  const canEdit = Roles.userHasPermission(Meteor.userId(), 'mongo.guesses.update');
+  return {
+    ready,
+    guesses,
+    puzzles,
+    displayNames,
+    canEdit,
+  };
+})(GuessQueuePage);
+
+GuessQueuePageContainer.propTypes = {
+  params: PropTypes.shape({
+    huntId: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default GuessQueuePageContainer;

--- a/imports/client/components/SetupPage.jsx
+++ b/imports/client/components/SetupPage.jsx
@@ -1,6 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import React from 'react';
-import { ReactMeteorData } from 'meteor/react-meteor-data';
+import PropTypes from 'prop-types';
+import { withTracker } from 'meteor/react-meteor-data';
 import Alert from 'react-bootstrap/lib/Alert';
 import Button from 'react-bootstrap/lib/Button';
 import navAggregatorType from './navAggregatorType.jsx';
@@ -8,22 +9,19 @@ import navAggregatorType from './navAggregatorType.jsx';
 /* eslint-disable max-len */
 
 const SetupPage = React.createClass({
+  propTypes: {
+    config: PropTypes.object,
+    canSetupGDrive: PropTypes.bool.isRequired,
+  },
+
   contextTypes: {
     navAggregator: navAggregatorType,
   },
-
-  mixins: [ReactMeteorData],
 
   getInitialState() {
     return {
       state: 'idle',
     };
-  },
-
-  getMeteorData() {
-    const config = ServiceConfiguration.configurations.findOne({ service: 'google' });
-    const canSetupGDrive = Roles.userHasPermission(Meteor.userId(), 'gdrive.credential');
-    return { config, canSetupGDrive };
   },
 
   dismissAlert() {
@@ -51,11 +49,11 @@ const SetupPage = React.createClass({
   },
 
   renderBody() {
-    if (!this.data.canSetupGDrive) {
+    if (!this.props.canSetupGDrive) {
       return <div>This page is for administering the Jolly Roger web app</div>;
     }
 
-    if (!this.data.config) {
+    if (!this.props.config) {
       return (
         <div>
           Can&apos;t finish setup until Google configuration is in place. Go to the Meteor shell, and call
@@ -104,4 +102,8 @@ const SetupPage = React.createClass({
   },
 });
 
-export default SetupPage;
+export default withTracker(() => {
+  const config = ServiceConfiguration.configurations.findOne({ service: 'google' });
+  const canSetupGDrive = Roles.userHasPermission(Meteor.userId(), 'gdrive.credential');
+  return { config, canSetupGDrive };
+})(SetupPage);

--- a/imports/client/components/SubscriberCount.jsx
+++ b/imports/client/components/SubscriberCount.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ReactMeteorData } from 'meteor/react-meteor-data';
+import { withTracker } from 'meteor/react-meteor-data';
 import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 
@@ -11,21 +11,12 @@ const SubscriberCount = React.createClass({
   displayName: 'SubscriberCount',
   propTypes: {
     puzzleId: PropTypes.string.isRequired,
-  },
-
-  mixins: [ReactMeteorData],
-
-  getMeteorData() {
-    const disabled = Flags.active('disable.subcounters');
-    const count = SubscriberCounters.findOne(`puzzle:${this.props.puzzleId}`);
-    return {
-      disabled,
-      viewCount: count ? count.value : 0,
-    };
+    disabled: PropTypes.bool.isRequired,
+    viewCount: PropTypes.number.isRequired,
   },
 
   render() {
-    if (this.data.disabled) {
+    if (this.props.disabled) {
       return <div />;
     }
 
@@ -38,7 +29,7 @@ const SubscriberCount = React.createClass({
       <OverlayTrigger placement="top" overlay={countTooltip}>
         <span>
           (
-          {this.data.viewCount}
+          {this.props.viewCount}
           )
         </span>
       </OverlayTrigger>
@@ -46,4 +37,17 @@ const SubscriberCount = React.createClass({
   },
 });
 
-export default SubscriberCount;
+const SubscriberCountContainer = withTracker(({ puzzleId }) => {
+  const disabled = Flags.active('disable.subcounters');
+  const count = SubscriberCounters.findOne(`puzzle:${puzzleId}`);
+  return {
+    disabled,
+    viewCount: count ? count.value : 0,
+  };
+})(SubscriberCount);
+
+SubscriberCountContainer.propTypes = {
+  puzzleId: PropTypes.string,
+};
+
+export default SubscriberCountContainer;

--- a/imports/client/components/TagEditor.jsx
+++ b/imports/client/components/TagEditor.jsx
@@ -2,7 +2,7 @@ import { _ } from 'meteor/underscore';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { jQuery } from 'meteor/jquery';
-import { ReactMeteorData } from 'meteor/react-meteor-data';
+import { withTracker } from 'meteor/react-meteor-data';
 import ReactSelect2 from './ReactSelect2.jsx';
 
 const TagEditor = React.createClass({
@@ -12,9 +12,8 @@ const TagEditor = React.createClass({
     puzzleId: PropTypes.string.isRequired,
     onSubmit: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
+    allTags: PropTypes.arrayOf(PropTypes.shape(Schemas.Tags.asReactPropTypes())).isRequired,
   },
-
-  mixins: [ReactMeteorData],
 
   componentDidMount() {
     // Focus the input when mounted - the user just clicked on the button-link.
@@ -32,18 +31,13 @@ const TagEditor = React.createClass({
     this.props.onCancel();
   },
 
-  getMeteorData() {
-    const puzzle = Models.Puzzles.findOne(this.props.puzzleId);
-    return { allTags: Models.Tags.find({ hunt: puzzle.hunt }).fetch() };
-  },
-
   render() {
     return (
       <span>
         <ReactSelect2
           selectRef={(node) => { this.selectNode = node; }}
           style={{ minWidth: '100px' }}
-          data={[''].concat(_.pluck(this.data.allTags, 'name'))}
+          data={[''].concat(_.pluck(this.props.allTags, 'name'))}
           options={{ tags: true }}
         />
       </span>
@@ -51,4 +45,13 @@ const TagEditor = React.createClass({
   },
 });
 
-export default TagEditor;
+const TagEditorContainer = withTracker(({ puzzleId }) => {
+  const puzzle = Models.Puzzles.findOne(puzzleId);
+  return { allTags: Models.Tags.find({ hunt: puzzle.hunt }).fetch() };
+})(TagEditor);
+
+TagEditorContainer.propTypes = {
+  puzzleId: PropTypes.string,
+};
+
+export default TagEditorContainer;


### PR DESCRIPTION
This converts everything except `CelebrationCenter` to use `withTracker` instead of the `ReactMeteorData` mixin.

Converting the `CelebrationCenter` is a little challenging because it uses an `observe` callback on a cursor, and there's not an obvious way to thread that callback through to the actual React component.

Before merging, I also want to do a pretty careful readthrough - I'm especially concerned about whether I got all of the new propTypes annotations correct (including whether I've appropriately tagged things as required or not)