### PR TITLE
Fix clickable tags on puzzle list page

### DIFF
--- a/imports/client/components/Tag.jsx
+++ b/imports/client/components/Tag.jsx
@@ -44,8 +44,10 @@ const Tag = React.createClass({
     if (this.props.linkToSearch) {
       title = (
         <Link
-          to={`/hunts/${this.props.tag.hunt}/puzzles`}
-          query={{ q: this.props.tag.name }}
+          to={{
+            pathname: `/hunts/${this.props.tag.hunt}/puzzles`,
+            query: { q: this.props.tag.name },
+          }}
           className="tag-link"
         >
           {name}


### PR DESCRIPTION
We appear to be misusing the API for `<Link>`.  It'll change again in
react-router 4, but in the meantime, let's eliminate the noisy console warning
and make the feature work again.

https://github.com/ReactTraining/react-router/blob/v3/docs/API.md#link

r? @ebroder 