### PR TITLE
Try adding `<meta>` tags to `<head>` dynamically

### DIFF
--- a/imports/client/head.html
+++ b/imports/client/head.html
@@ -1,6 +1,0 @@
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Jolly Roger</title>
-</head>

--- a/imports/client/main.jsx
+++ b/imports/client/main.jsx
@@ -4,6 +4,23 @@ import ReactDOM from 'react-dom';
 import Routes from './components/Routes.jsx';
 
 Meteor.startup(() => {
+  // Set up some meta elements previously from head.html
+  // <meta charset="utf-8">
+  const metaCharset = document.createElement('meta');
+  metaCharset.setAttribute('charset', 'utf-8');
+  // <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  const metaIEEdge = document.createElement('meta');
+  metaIEEdge.setAttribute('http-equiv', 'X-UA-Compatible');
+  metaIEEdge.setAttribute('content', 'IE=edge');
+  // <meta name="viewport" content="width=device-width, initial-scale=1">
+  const metaViewport = document.createElement('meta');
+  metaViewport.setAttribute('name', 'viewport');
+  metaViewport.setAttribute('content', 'width=device-width, initial-scale=1');
+  document.head.appendChild(metaCharset);
+  document.head.appendChild(metaIEEdge);
+  document.head.appendChild(metaViewport);
+
+  // Add a div under <body> and mount all the React stuff upon it.
   const container = document.createElement('div');
   document.body.appendChild(container);
   ReactDOM.render(<Routes />, container);


### PR DESCRIPTION
We appear to have lost the mobile behavior that restricts width to the actual
device width.  I suspect this is because we lost the meta tags that were once
from `head.html`.

Try adding them dynamically with JS and see what browsers do.  It's not obvious
to me if under Blaze this would have been compiled into the initial HTML
fetched or if it would have dynamically added it like I'm doing here.

Confession: I haven't actually tested this on mobile or IE11, but it seems like it should either work, or there's nothing short of figuring out how to modify the initial HTML that will help me.

Fixes: #127
(probably)

r? @ebroder 