### PR TITLE
Import specific classes from react-bootstrap

### DIFF
--- a/imports/client/components/NavAggregator.jsx
+++ b/imports/client/components/NavAggregator.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Breadcrumb, BreadcrumbItem } from 'react-bootstrap';
+import Breadcrumb from 'react-bootstrap/lib/Breadcrumb';
+import BreadcrumbItem from 'react-bootstrap/lib/BreadcrumbItem';
 import RRBS from 'react-router-bootstrap';
 import { _ } from 'meteor/underscore';
 


### PR DESCRIPTION
I appear to have missed this in one of my patches, and it's bloating the JS bundle a bit.

Before:
1.34 MB production bundle
163 kB of that from react-bootstrap

After:
1.27 MB production bundle
92 kB of that from react-bootstrap