### PR TITLE
Switch to pulling bootstrap from NPM

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -7,7 +7,6 @@
 ecmascript@0.12.0
 ecmascript-collections
 accounts-password@1.5.1
-twbs:bootstrap
 audit-argument-checks@1.0.7
 aldeed:collection2
 aldeed:simple-schema

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -41,7 +41,6 @@ hot-code-push@1.0.4
 http@1.4.1
 id-map@1.1.0
 inter-process-messaging@0.1.0
-jquery@1.11.11
 launch-screen@1.1.1
 livedata@1.0.18
 localstorage@1.2.0
@@ -89,7 +88,6 @@ standard-minifier-css@1.5.1
 standard-minifier-js@2.4.0
 tmeasday:check-npm-versions@0.3.2
 tracker@1.2.0
-twbs:bootstrap@3.3.6
 underscore@1.0.10
 url@1.2.0
 webapp@1.7.0

--- a/client/main.js
+++ b/client/main.js
@@ -1,3 +1,5 @@
+import 'bootstrap/dist/css/bootstrap.min.css';
+
 // explicitly import all the stuff from lib/ since mainModule skips autoloading
 // things
 import '../imports/lib/config/accounts.js';

--- a/client/stylesheets/breadcrumbs.scss
+++ b/client/stylesheets/breadcrumbs.scss
@@ -1,4 +1,4 @@
-.nav-breadcrumbs {
+.jolly-roger .nav-breadcrumbs {
   height: 50px; // navbar height
   vertical-align: top; // Fill content from top
   background-color: transparent;
@@ -17,7 +17,7 @@
 }
 
 @media (max-width: 767px) {
-  .nav-breadcrumbs {
+  .jolly-roger .nav-breadcrumbs {
     // Don't cause the logo or hamburger button to wrap onto a new line.
     // Size allowed is 100% of navbar width, minus 50px for the jolly-roger logo, and
     // 1+10+22+10+1 + 8px = 52px for the toggle button.
@@ -26,7 +26,7 @@
 }
 
 @media (min-width: 768px) {
-  .nav-breadcrumbs {
+  .jolly-roger .nav-breadcrumbs {
     max-width: calc(100vw - 280px); // Hopefully most people's names fit in 250px
   }
 }
@@ -38,6 +38,6 @@
   text-overflow: ellipsis;
 }
 
-button.navbar-toggle {
+.jolly-roger button.navbar-toggle {
   margin-right: 8px; // Pack tighter to make more space in navbar.
 }

--- a/client/stylesheets/index.css
+++ b/client/stylesheets/index.css
@@ -1,9 +1,9 @@
-.navbar-brand {
+.jolly-roger .navbar-brand {
     padding: 0;
     float: none;
 }
 
-.navbar-brand > img {
+.jolly-roger .navbar-brand > img {
     display: inline-block;
 }
 

--- a/imports/client/main.jsx
+++ b/imports/client/main.jsx
@@ -5,6 +5,7 @@ import Routes from './components/Routes.jsx';
 
 Meteor.startup(() => {
   const container = document.createElement('div');
+  container.className = 'jolly-roger';
   document.body.appendChild(container);
   ReactDOM.render(<Routes />, container);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -573,6 +573,11 @@
         "type-is": "~1.6.16"
       }
     },
+    "bootstrap": {
+      "version": "3.3.7",
+      "resolved": "http://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
+      "integrity": "sha1-WjiTlFSfIzMIdaOxUGVldPip63E="
+    },
     "bowser": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@babel/runtime": "^7.1.2",
     "bcrypt": "^1.0.1",
+    "bootstrap": "^3.3.6",
     "classnames": "^2.2.5",
     "element-resize-detector": "^1.1.14",
     "express": "^4.14.0",

--- a/public/bootstrap.min.css.map
+++ b/public/bootstrap.min.css.map
@@ -1,0 +1,1 @@
+../node_modules/bootstrap/dist/css/bootstrap.min.css.map

--- a/public/fonts/glyphicons-halflings-regular.eot
+++ b/public/fonts/glyphicons-halflings-regular.eot
@@ -1,0 +1,1 @@
+../../node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.eot

--- a/public/fonts/glyphicons-halflings-regular.svg
+++ b/public/fonts/glyphicons-halflings-regular.svg
@@ -1,0 +1,1 @@
+../../node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.svg

--- a/public/fonts/glyphicons-halflings-regular.ttf
+++ b/public/fonts/glyphicons-halflings-regular.ttf
@@ -1,0 +1,1 @@
+../../node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.ttf

--- a/public/fonts/glyphicons-halflings-regular.woff
+++ b/public/fonts/glyphicons-halflings-regular.woff
@@ -1,0 +1,1 @@
+../../node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.woff

--- a/public/fonts/glyphicons-halflings-regular.woff2
+++ b/public/fonts/glyphicons-halflings-regular.woff2
@@ -1,0 +1,1 @@
+../../node_modules/bootstrap/dist/fonts/glyphicons-halflings-regular.woff2


### PR DESCRIPTION
This didn't really have a ton of impact on the bundle size, as far as I can tell - maybe 10's of kilobytes? - but I definitely prefer this as a way to ship bootstrap.

Couple notes:
- Including the CSS by importing it like this results in it being injected into the DOM in a style tag, rather than being compiled into the merged stylesheet, which means that it comes after our CSS in precedence, so I needed to make a few of our declarations more specific.
- Symlinking from `node_modules` into the `public/` directory is the [documentation recommended way](https://guide.meteor.com/using-npm-packages.html#npm-assets) to include extra assets. Seems a bit gross, but I guess it's fine

Neither of these seem like dealbreakers