### PR TITLE
Compile Bootstrap from LESS ourselves

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -38,3 +38,4 @@ server-render
 # Versions after 0.9.6 have a bug where they over-aggressively deref a sub if
 # you sub more than once
 ccorcos:subs-cache@0.9.6
+less

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -42,6 +42,7 @@ http@1.4.1
 id-map@1.1.0
 inter-process-messaging@0.1.0
 launch-screen@1.1.1
+less@2.8.0
 livedata@1.0.18
 localstorage@1.2.0
 logging@1.1.20

--- a/client/main.js
+++ b/client/main.js
@@ -1,4 +1,4 @@
-import 'bootstrap/dist/css/bootstrap.min.css';
+import '../imports/client/stylesheets/bootstrap.less';
 
 // explicitly import all the stuff from lib/ since mainModule skips autoloading
 // things

--- a/imports/client/stylesheets/bootstrap.less
+++ b/imports/client/stylesheets/bootstrap.less
@@ -1,0 +1,3 @@
+@import "../../../node_modules/bootstrap/less/bootstrap.less";
+
+@icon-font-path: "/fonts/";


### PR DESCRIPTION
This lets us override the font path, which matters because we're
injecting Bootstrap via a style element (so relative paths get resolved
differently depending on the URL).

Fixes #156.