### PR TITLE
Eliminate the private docker registry

### DIFF
--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -16,8 +16,6 @@
 #
 # - The application instances run several docker services:
 #
-#   - A registry to proxy access to private images
-#
 #   - An nginx instance for port 80, redirecting to HTTPS and serving
 #   - healthchecks for ALB
 #
@@ -40,13 +38,6 @@
 # need to do the following (and probably more I've forgotten):
 #
 # - Setup credstash (following the directions in the repo)
-#
-# - Generate the config.yml file for the registry. Starting with
-#   http://git.io/vERX3, add a section labeled proxy. Include the keys
-#   username and password with values for an account that has access
-#   to the ebroder/jolly-roger image, and set remoteurl:
-#   https://registry-1.docker.io. Store this using `credstash put
-#   registry/config.yml @path`
 #
 # - Store the MongoDB URL using `credstash put mongo @<path>`. The
 #   free account from mongolab (for instance) should be sufficient.
@@ -506,20 +497,14 @@ Resources:
                 ${PapertrailDockerConfig}
                 ${DatadogDockerConfig}
 
-                # Run a local registry proxy so we don't have to teach everything to auth for our private images
-                - mkdir -p /etc/docker/registry
-                - credstash get registry/config.yml > /etc/docker/registry/config.yml
-                - docker run --name registry -d --restart=unless-stopped -p 5000:5000 -v /etc/docker/registry:/etc/docker/registry registry:2
-                - sleep 5
-
                 # Pre-fetch images
-                - docker pull localhost:5000/ebroder/jolly-roger
+                - docker pull deathandmayhem/jolly-roger
                 - docker pull jwilder/nginx-proxy
                 - docker pull centurylink/watchtower
 
                 - docker run --name nginx-http -d --restart=unless-stopped -p 80:80 -v /etc/nginx-http/conf.d:/etc/nginx/conf.d nginx
 
-                - docker run --name jolly-roger -d --restart=unless-stopped -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION -e VIRTUAL_HOST=${AppUrl} -e ROOT_URL=https://${AppUrl} localhost:5000/ebroder/jolly-roger
+                - docker run --name jolly-roger -d --restart=unless-stopped -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION -e VIRTUAL_HOST=${AppUrl} -e ROOT_URL=https://${AppUrl} deathandmayhem/jolly-roger
 
                 - docker run --name nginx-https -d --restart=unless-stopped -p 8443:80 -e DEFAULT_HOST=${AppUrl} -v /var/run/docker.sock:/tmp/docker.sock:ro -v /etc/nginx-https/cache.conf:/etc/nginx/conf.d/cache.conf -v /etc/nginx-https/vhost.d:/etc/nginx/vhost.d jwilder/nginx-proxy
                 - docker run --name watchtower -d --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.sock centurylink/watchtower --interval 30 --cleanup

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ebroder/jolly-roger"
+    "url": "https://github.com/deathandmayhem/jolly-roger"
   },
   "scripts": {
     "lint": "eslint --ext js,jsx ."


### PR DESCRIPTION
Now that the Docker repo is public, it's no longer needed.