### PR TITLE
Assorted fixes

### DIFF
--- a/imports/client/components/AccountForm.jsx
+++ b/imports/client/components/AccountForm.jsx
@@ -106,6 +106,7 @@ class AccountForm extends React.Component {
       displayName: this.state.displayName,
       phoneNumber: this.state.phoneNumber,
       slackHandle: '',
+      muteApplause: false,
     };
 
     this.setState({

--- a/imports/client/components/Celebration.jsx
+++ b/imports/client/components/Celebration.jsx
@@ -36,8 +36,8 @@ class Celebration extends React.Component {
     return (
       <div className="celebration-overlay" onClick={this.maybeClose}>
         <div className="celebration">
-          <button type="button" className="close" onClick={this.onClose} ariaLabel="Close">
-            <span ariaHidden="true">×</span>
+          <button type="button" className="close" onClick={this.onClose} aria-label="Close">
+            <span aria-hidden="true">×</span>
           </button>
           {this.props.playAudio ? <audio src="/audio/applause.mp3" autoPlay /> : null}
           <h1>

--- a/imports/client/components/NotificationCenter.jsx
+++ b/imports/client/components/NotificationCenter.jsx
@@ -15,6 +15,7 @@ import subsCache from '../subsCache.js';
 import AnnouncementsSchema from '../../lib/schemas/announcements.js';
 import GuessesSchema from '../../lib/schemas/guess.js';
 import PuzzlesSchema from '../../lib/schemas/puzzles.js';
+import PendingAnnouncementsSchema from '../../lib/schemas/pending_announcements.js';
 import Announcements from '../../lib/models/announcements.js';
 import Guesses from '../../lib/models/guess.js';
 import PendingAnnouncements from '../../lib/models/pending_announcements.js';
@@ -249,7 +250,11 @@ class AnnouncementMessage extends React.PureComponent {
 class NotificationCenter extends React.Component {
   static propTypes = {
     ready: PropTypes.bool.isRequired,
-    announcements: PropTypes.arrayOf(PropTypes.shape(AnnouncementsSchema.asReactPropTypes())),
+    announcements: PropTypes.arrayOf(PropTypes.shape({
+      pa: PropTypes.shape(PendingAnnouncementsSchema.asReactPropTypes()).isRequired,
+      announcement: PropTypes.shape(AnnouncementsSchema.asReactPropTypes()).isRequired,
+      createdByDisplayName: PropTypes.string.isRequired,
+    })),
     guesses: PropTypes.arrayOf(PropTypes.shape({
       guess: PropTypes.shape(GuessesSchema.asReactPropTypes()),
       puzzle: PropTypes.shape(PuzzlesSchema.asReactPropTypes()),

--- a/imports/client/components/ProfilePage.jsx
+++ b/imports/client/components/ProfilePage.jsx
@@ -309,7 +309,7 @@ class OwnProfilePage extends React.Component {
           </HelpBlock>
         </FormGroup>
         {this.state.submitState === 'submitting' ? <Alert bsStyle="info">Saving...</Alert> : null}
-        {this.state.submitState === 'success' ? <Alert bsStyle="success" dismissAfter={5000} onDismiss={this.dismissAlert}>Saved changes.</Alert> : null}
+        {this.state.submitState === 'success' ? <Alert bsStyle="success" onDismiss={this.dismissAlert}>Saved changes.</Alert> : null}
         {this.state.submitState === 'error' ? (
           <Alert bsStyle="danger" onDismiss={this.dismissAlert}>
             Saving failed:

--- a/imports/client/components/PuzzlePage.jsx
+++ b/imports/client/components/PuzzlePage.jsx
@@ -871,7 +871,7 @@ class PuzzleGuessModal extends React.Component {
             <FormControl
               type="text"
               id="jr-puzzle-guess"
-              autoFocus="true"
+              autoFocus
               autoComplete="off"
               onChange={this.onGuessInputChange}
               value={this.state.guessInput}


### PR DESCRIPTION
I went through a bunch of our workflows with the browser console and server console open and looked for anything that seemed out of place.  I found several things:

* `saveProfile` takes one more argument than we were passing to it from the call in the setup flow, which was making new signups lack a profile
* `dismissAfter` is not a thing and we should remove it
* `NotificationCenter`'s propTypes were missing one layer of objects
* the `autoFocus` prop takes a boolean value, not a string value
* Unlike everything else, the React [props for `aria-*` should be kebab-case, not camelCase](https://reactjs.org/docs/accessibility.html)

r? @ebroder 