### PR TITLE
Make a bunch more things configurable in SetupPage

### DIFF
--- a/client/stylesheets/setup.scss
+++ b/client/stylesheets/setup.scss
@@ -1,0 +1,63 @@
+.setup-page {
+  section {
+    margin-bottom: 24px;
+  }
+}
+
+.gdrive-subsection {
+  &:not(:last-child) {
+    border-bottom: 1px solid #ccc;
+    padding-bottom: 16px;
+    margin-bottom: 16px;
+  }
+}
+.gdrive-subsection-header {
+  font-size: 16px;
+  font-weight: bold;
+  //background-color: #f0f0f0
+}
+
+.setup-section-header {
+  background-color: #f0f0f0;
+  font-size: 18px;
+  border-bottom: 1px solid black;
+  margin-bottom: 16px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 48px;
+}
+.setup-section-header-label {
+  flex: 1 1 auto;
+}
+.setup-section-header-buttons {
+  flex: 0 0 auto;
+  button {
+    margin-left: 8px;
+    margin-bottom: 8px;
+  }
+}
+
+
+.circuit-breaker {
+  margin-bottom: 16px;
+}
+.circuit-breaker-row {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  background: #eee;
+}
+.circuit-breaker-label {
+  font-size: 16px;
+  flex: 1 1 auto;
+}
+.circuit-breaker-buttons {
+  flex: 0 0 auto;
+  button {
+    margin-left: 8px;
+  }
+}

--- a/imports/client/components/AccountForm.jsx
+++ b/imports/client/components/AccountForm.jsx
@@ -106,6 +106,7 @@ class AccountForm extends React.Component {
       displayName: this.state.displayName,
       phoneNumber: this.state.phoneNumber,
       slackHandle: '',
+      muteApplause: false,
     };
 
     this.setState({

--- a/imports/client/components/Celebration.jsx
+++ b/imports/client/components/Celebration.jsx
@@ -36,8 +36,8 @@ class Celebration extends React.Component {
     return (
       <div className="celebration-overlay" onClick={this.maybeClose}>
         <div className="celebration">
-          <button type="button" className="close" onClick={this.onClose} ariaLabel="Close">
-            <span ariaHidden="true">×</span>
+          <button type="button" className="close" onClick={this.onClose} aria-label="Close">
+            <span aria-hidden="true">×</span>
           </button>
           {this.props.playAudio ? <audio src="/audio/applause.mp3" autoPlay /> : null}
           <h1>

--- a/imports/client/components/HuntListPage.jsx
+++ b/imports/client/components/HuntListPage.jsx
@@ -49,12 +49,12 @@ class HuntModalForm extends React.Component {
     };
     if (this.props.hunt) {
       return _.extend(state, {
-        name: this.props.hunt.name,
-        mailingLists: this.props.hunt.mailingLists.join(', '),
-        signupMessage: this.props.hunt.signupMessage,
-        openSignups: this.props.hunt.openSignups,
-        firehoseSlackChannel: this.props.hunt.firehoseSlackChannel,
-        puzzleHooksSlackChannel: this.props.hunt.puzzleHooksSlackChannel,
+        name: this.props.hunt.name || '',
+        mailingLists: this.props.hunt.mailingLists.join(', ') || '',
+        signupMessage: this.props.hunt.signupMessage || '',
+        openSignups: this.props.hunt.openSignups || false,
+        firehoseSlackChannel: this.props.hunt.firehoseSlackChannel || '',
+        puzzleHooksSlackChannel: this.props.hunt.puzzleHooksSlackChannel || '',
       });
     } else {
       return _.extend(state, {

--- a/imports/client/components/HuntListPage.jsx
+++ b/imports/client/components/HuntListPage.jsx
@@ -118,7 +118,7 @@ class HuntModalForm extends React.Component {
           errorMessage: error.message,
         });
       } else {
-        this.setState(this.initialState()());
+        this.setState(this.initialState());
         callback();
       }
     });

--- a/imports/client/components/NotificationCenter.jsx
+++ b/imports/client/components/NotificationCenter.jsx
@@ -15,6 +15,7 @@ import subsCache from '../subsCache.js';
 import AnnouncementsSchema from '../../lib/schemas/announcements.js';
 import GuessesSchema from '../../lib/schemas/guess.js';
 import PuzzlesSchema from '../../lib/schemas/puzzles.js';
+import PendingAnnouncementsSchema from '../../lib/schemas/pending_announcements.js';
 import Announcements from '../../lib/models/announcements.js';
 import Guesses from '../../lib/models/guess.js';
 import PendingAnnouncements from '../../lib/models/pending_announcements.js';
@@ -249,7 +250,11 @@ class AnnouncementMessage extends React.PureComponent {
 class NotificationCenter extends React.Component {
   static propTypes = {
     ready: PropTypes.bool.isRequired,
-    announcements: PropTypes.arrayOf(PropTypes.shape(AnnouncementsSchema.asReactPropTypes())),
+    announcements: PropTypes.arrayOf(PropTypes.shape({
+      pa: PropTypes.shape(PendingAnnouncementsSchema.asReactPropTypes()).isRequired,
+      announcement: PropTypes.shape(AnnouncementsSchema.asReactPropTypes()).isRequired,
+      createdByDisplayName: PropTypes.string.isRequired,
+    })),
     guesses: PropTypes.arrayOf(PropTypes.shape({
       guess: PropTypes.shape(GuessesSchema.asReactPropTypes()),
       puzzle: PropTypes.shape(PuzzlesSchema.asReactPropTypes()),

--- a/imports/client/components/ProfilePage.jsx
+++ b/imports/client/components/ProfilePage.jsx
@@ -14,6 +14,7 @@ import subsCache from '../subsCache.js';
 import navAggregatorType from './navAggregatorType.jsx';
 import ProfilesSchema from '../../lib/schemas/profiles.js';
 import Profiles from '../../lib/models/profiles.js';
+import Flags from '../../flags.js';
 
 /* eslint-disable max-len */
 
@@ -65,6 +66,7 @@ class OthersProfilePage extends React.Component {
 class GoogleLinkBlock extends React.Component {
   static propTypes = {
     profile: PropTypes.shape(ProfilesSchema.asReactPropTypes()),
+    googleDisabled: PropTypes.bool.isRequired,
     config: PropTypes.object,
   };
 
@@ -115,6 +117,10 @@ class GoogleLinkBlock extends React.Component {
   linkButton = () => {
     if (this.state.state === 'linking') {
       return <Button bsStyle="primary" disabled>Linking...</Button>;
+    }
+
+    if (this.props.googleDisabled) {
+      return <Button bsStyle="primary" disabled>Google integration currently disabled</Button>;
     }
 
     const text = (this.props.profile.googleAccount) ?
@@ -193,7 +199,8 @@ class GoogleLinkBlock extends React.Component {
 
 const GoogleLinkBlockContainer = withTracker(() => {
   const config = ServiceConfiguration.configurations.findOne({ service: 'google' });
-  return { config };
+  const googleDisabled = Flags.active('disable.google');
+  return { config, googleDisabled };
 })(GoogleLinkBlock);
 
 class OwnProfilePage extends React.Component {

--- a/imports/client/components/ProfilePage.jsx
+++ b/imports/client/components/ProfilePage.jsx
@@ -309,7 +309,7 @@ class OwnProfilePage extends React.Component {
           </HelpBlock>
         </FormGroup>
         {this.state.submitState === 'submitting' ? <Alert bsStyle="info">Saving...</Alert> : null}
-        {this.state.submitState === 'success' ? <Alert bsStyle="success" dismissAfter={5000} onDismiss={this.dismissAlert}>Saved changes.</Alert> : null}
+        {this.state.submitState === 'success' ? <Alert bsStyle="success" onDismiss={this.dismissAlert}>Saved changes.</Alert> : null}
         {this.state.submitState === 'error' ? (
           <Alert bsStyle="danger" onDismiss={this.dismissAlert}>
             Saving failed:

--- a/imports/client/components/ProfilePage.jsx
+++ b/imports/client/components/ProfilePage.jsx
@@ -21,7 +21,7 @@ class OthersProfilePage extends React.Component {
   static propTypes = {
     profile: PropTypes.shape(ProfilesSchema.asReactPropTypes()),
     viewerCanMakeOperator: PropTypes.bool.isRequired,
-    targetIsAdmin: PropTypes.bool.isRequired,
+    targetIsOperator: PropTypes.bool.isRequired,
   };
 
   makeOperator = () => {
@@ -31,8 +31,8 @@ class OthersProfilePage extends React.Component {
   render() {
     // TODO: figure out something for profile pictures - gravatar?
     const profile = this.props.profile;
-    const showOperatorBadge = this.props.targetIsAdmin;
-    const showMakeOperatorButton = this.props.viewerCanMakeOperator && !this.props.targetIsAdmin;
+    const showOperatorBadge = this.props.targetIsOperator;
+    const showMakeOperatorButton = this.props.viewerCanMakeOperator && !this.props.targetIsOperator;
     return (
       <div>
         <h1>{profile.displayName}</h1>
@@ -404,8 +404,8 @@ class ProfilePage extends React.Component {
     isSelf: PropTypes.bool.isRequired,
     profile: PropTypes.shape(ProfilesSchema.asReactPropTypes()).isRequired,
     viewerCanMakeOperator: PropTypes.bool.isRequired,
-    viewerIsAdmin: PropTypes.bool.isRequired,
-    targetIsAdmin: PropTypes.bool.isRequired,
+    viewerIsOperator: PropTypes.bool.isRequired,
+    targetIsOperator: PropTypes.bool.isRequired,
   };
 
   static contextTypes = {
@@ -421,7 +421,7 @@ class ProfilePage extends React.Component {
         <OwnProfilePage
           initialProfile={this.props.profile}
           canMakeOperator={this.props.viewerCanMakeOperator}
-          operating={this.props.viewerIsAdmin}
+          operating={this.props.viewerIsOperator}
         />
       );
     } else {
@@ -429,7 +429,7 @@ class ProfilePage extends React.Component {
         <OthersProfilePage
           profile={this.props.profile}
           viewerCanMakeOperator={this.props.viewerCanMakeOperator}
-          targetIsAdmin={this.props.targetIsAdmin}
+          targetIsOperator={this.props.targetIsOperator}
         />
       );
     }
@@ -475,8 +475,8 @@ const ProfilePageContainer = withTracker(({ params }) => {
       createdBy: Meteor.userId(),
     },
     viewerCanMakeOperator: Roles.userHasPermission(Meteor.userId(), 'users.makeOperator'),
-    viewerIsAdmin: Roles.userHasRole(Meteor.userId(), 'admin'),
-    targetIsAdmin: Roles.userHasPermission(uid, 'users.makeOperator'),
+    viewerIsOperator: Roles.userHasRole(Meteor.userId(), 'operator'),
+    targetIsOperator: Roles.userHasPermission(uid, 'users.makeOperator'),
   };
   return data;
 })(ProfilePage);

--- a/imports/client/components/PuzzlePage.jsx
+++ b/imports/client/components/PuzzlePage.jsx
@@ -871,7 +871,7 @@ class PuzzleGuessModal extends React.Component {
             <FormControl
               type="text"
               id="jr-puzzle-guess"
-              autoFocus="true"
+              autoFocus
               autoComplete="off"
               onChange={this.onGuessInputChange}
               value={this.state.guessInput}

--- a/imports/client/components/SetupPage.jsx
+++ b/imports/client/components/SetupPage.jsx
@@ -3,37 +3,151 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withTracker } from 'meteor/react-meteor-data';
 import Alert from 'react-bootstrap/lib/Alert';
+import Badge from 'react-bootstrap/lib/Badge';
 import Button from 'react-bootstrap/lib/Button';
+import ControlLabel from 'react-bootstrap/lib/ControlLabel';
+import FormControl from 'react-bootstrap/lib/FormControl';
+import FormGroup from 'react-bootstrap/lib/FormGroup';
 import navAggregatorType from './navAggregatorType.jsx';
+import Flags from '../../flags.js';
+import Settings from '../../lib/models/settings.js';
 
-/* eslint-disable max-len */
+/* eslint-disable max-len, react/jsx-one-expression-per-line */
 
-class SetupPage extends React.Component {
+const googleCompletenessStrings = [
+  'Unconfigured',
+  '1/3 complete',
+  '2/3 complete',
+  'Configured',
+];
+
+class GoogleOAuthForm extends React.Component {
   static propTypes = {
-    config: PropTypes.object,
-    canSetupGDrive: PropTypes.bool.isRequired,
+    isConfigured: PropTypes.bool.isRequired,
+    initialClientId: PropTypes.string,
   };
 
-  static contextTypes = {
-    navAggregator: navAggregatorType,
+  constructor(props) {
+    super(props);
+    const clientId = props.initialClientId || '';
+    this.state = {
+      submitState: 'idle',
+      clientId,
+      clientSecret: '',
+    };
+  }
+
+  dismissAlert = () => {
+    this.setState({ submitState: 'idle' });
   };
 
+  onSubmitOauthConfiguration = (e) => {
+    e.preventDefault();
+
+    const clientId = this.state.clientId.trim();
+    const clientSecret = this.state.clientSecret.trim();
+
+    if (clientId.length > 0 && clientSecret.length === 0) {
+      this.setState({
+        submitState: 'error',
+        submitError: 'You appear to be clearing the secret but not the client ID.  Please provide a secret.',
+      });
+    } else {
+      this.setState({
+        submitState: 'submitting',
+      });
+      Meteor.call('setupGoogleOAuthClient', clientId, clientSecret, (err) => {
+        if (err) {
+          this.setState({
+            submitState: 'error',
+            submitError: err.message,
+          });
+        } else {
+          this.setState({
+            submitState: 'success',
+          });
+        }
+      });
+    }
+  };
+
+  onClientIdChange = (e) => {
+    this.setState({
+      clientId: e.target.value,
+    });
+  };
+
+  onClientSecretChange = (e) => {
+    this.setState({
+      clientSecret: e.target.value,
+    });
+  };
+
+  render() {
+    const shouldDisableForm = this.state.submitState === 'submitting';
+    const secretPlaceholder = this.props.isConfigured ? '<configured secret not revealed>' : '';
+    return (
+      <form onSubmit={this.onSubmitOauthConfiguration}>
+        {this.state.submitState === 'submitting' ? <Alert bsStyle="info">Saving...</Alert> : null}
+        {this.state.submitState === 'success' ? <Alert bsStyle="success" onDismiss={this.dismissAlert}>Saved changes.</Alert> : null}
+        {this.state.submitState === 'error' ? (
+          <Alert bsStyle="danger" onDismiss={this.dismissAlert}>
+            Saving failed:
+            {' '}
+            {this.state.submitError}
+          </Alert>
+        ) : null}
+        <FormGroup>
+          <ControlLabel htmlFor="jr-setup-edit-google-client-id">
+            Client ID
+          </ControlLabel>
+          <FormControl
+            id="jr-setup-edit-google-client-id"
+            type="text"
+            value={this.state.clientId}
+            disabled={shouldDisableForm}
+            onChange={this.onClientIdChange}
+          />
+        </FormGroup>
+        <FormGroup>
+          <ControlLabel htmlFor="jr-setup-edit-google-client-secret">
+            Client secret
+          </ControlLabel>
+          <FormControl
+            id="jr-setup-edit-google-client-secret"
+            type="text"
+            value={this.state.clientSecret}
+            disabled={shouldDisableForm}
+            onChange={this.onClientSecretChange}
+            placeholder={secretPlaceholder}
+          />
+        </FormGroup>
+        <Button bsStyle="primary" type="submit" disabled={shouldDisableForm} onSubmit={this.onSubmitOauthConfiguration}>
+          Save
+        </Button>
+      </form>
+    );
+  }
+}
+
+class GoogleAuthorizeDriveClientForm extends React.Component {
   state = {
-    state: 'idle',
+    submitState: 'idle',
+    error: '',
   };
 
   dismissAlert = () => {
-    this.setState({ state: 'idle' });
+    this.setState({ submitState: 'idle' });
   };
 
   requestComplete = (token) => {
     const secret = OAuth._retrieveCredentialSecret(token);
-    this.setState({ state: 'submitting' });
+    this.setState({ submitState: 'submitting' });
     Meteor.call('setupGdriveCreds', token, secret, (error) => {
       if (error) {
-        this.setState({ state: 'error', error });
+        this.setState({ submitState: 'error', error });
       } else {
-        this.setState({ state: 'success' });
+        this.setState({ submitState: 'success' });
       }
     });
   };
@@ -46,35 +160,12 @@ class SetupPage extends React.Component {
     return false;
   };
 
-  renderBody = () => {
-    if (!this.props.canSetupGDrive) {
-      return <div>This page is for administering the Jolly Roger web app</div>;
-    }
-
-    if (!this.props.config) {
-      return (
-        <div>
-          Can&apos;t finish setup until Google configuration is in place. Go to the Meteor shell, and call
-
-          <pre>
-            {'ServiceConfiguration.configurations.upsert(\n' +
-             '  {service: \'google\'},\n' +
-             '  {\n' +
-             '    clientId: \'client id\',\n' +
-             '    secret: \'secret\',\n' +
-             '    loginStyle: \'popup\',\n' +
-             '  }\n' +
-             ')'}
-          </pre>
-        </div>
-      );
-    }
-
+  render() {
     return (
       <div>
-        {this.state.state === 'submitting' ? <Alert bsStyle="info">Saving...</Alert> : null}
-        {this.state.state === 'success' ? <Alert bsStyle="success" dismissAfter={5000} onDismiss={this.dismissAlert}>Saved changes.</Alert> : null}
-        {this.state.state === 'error' ? (
+        {this.state.submitState === 'submitting' ? <Alert bsStyle="info">Saving...</Alert> : null}
+        {this.state.submitState === 'success' ? <Alert bsStyle="success" onDismiss={this.dismissAlert}>Saved changes.</Alert> : null}
+        {this.state.submitState === 'error' ? (
           <Alert bsStyle="danger" onDismiss={this.dismissAlert}>
             Saving failed:
             {' '}
@@ -85,7 +176,613 @@ class SetupPage extends React.Component {
         for Google Drive management. (This will replace any previously configured account)
       </div>
     );
+  }
+}
+
+class GoogleDriveTemplateForm extends React.Component {
+  static propTypes = {
+    initialDocTemplate: PropTypes.string,
+    initialSpreadsheetTemplate: PropTypes.string,
   };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      submitState: 'idle',
+      docTemplate: props.initialDocTemplate || '',
+      spreadsheetTemplate: props.initialSpreadsheetTemplate || '',
+    };
+  }
+
+  dismissAlert = () => {
+    this.setState({ submitState: 'idle' });
+  };
+
+  onSpreadsheetTemplateChange = (e) => {
+    this.setState({
+      spreadsheetTemplate: e.target.value,
+    });
+  };
+
+  onDocTemplateChange = (e) => {
+    this.setState({
+      docTemplate: e.target.value,
+    });
+  };
+
+  saveTemplates = (e) => {
+    e.preventDefault();
+    const ssTemplate = this.state.spreadsheetTemplate.trim();
+    const ssId = ssTemplate.length > 0 ? ssTemplate : undefined;
+    const docTemplateString = this.state.docTemplate.trim();
+    const docId = docTemplateString.length > 0 ? docTemplateString : undefined;
+    this.setState({
+      submitState: 'submitting',
+    });
+    Meteor.call('setupGdriveTemplates', ssId, docId, (error) => {
+      if (error) {
+        this.setState({ submitState: 'error', error });
+      } else {
+        this.setState({ submitState: 'success' });
+      }
+    });
+  };
+
+  render() {
+    const shouldDisableForm = this.state.submitState === 'submitting';
+    return (
+      <div>
+        {this.state.submitState === 'submitting' ? <Alert bsStyle="info">Saving...</Alert> : null}
+        {this.state.submitState === 'success' ? <Alert bsStyle="success" onDismiss={this.dismissAlert}>Saved changes.</Alert> : null}
+        {this.state.submitState === 'error' ? (
+          <Alert bsStyle="danger" onDismiss={this.dismissAlert}>
+            Saving failed:
+            {' '}
+            {this.state.error.message}
+          </Alert>
+        ) : null}
+        <FormGroup>
+          <ControlLabel htmlFor="jr-setup-edit-gdrive-sheet-template">
+            Spreadsheet template doc id
+          </ControlLabel>
+          <FormControl
+            id="jr-setup-edit-gdrive-sheet-template"
+            type="text"
+            value={this.state.spreadsheetTemplate}
+            disabled={shouldDisableForm}
+            onChange={this.onSpreadsheetTemplateChange}
+          />
+        </FormGroup>
+        <FormGroup>
+          <ControlLabel htmlFor="jr-setup-edit-gdrive-doc-template">
+            Document template doc id
+          </ControlLabel>
+          <FormControl
+            id="jr-setup-edit-gdrive-doc-template"
+            type="text"
+            value={this.state.docTemplate}
+            disabled={shouldDisableForm}
+            onChange={this.onDocTemplateChange}
+          />
+        </FormGroup>
+        <Button bsStyle="primary" onClick={this.saveTemplates} disabled={shouldDisableForm}>Save</Button>
+      </div>
+    );
+  }
+}
+
+class GoogleIntegrationSection extends React.Component {
+  static propTypes = {
+    // oauth config
+    oauthSettings: PropTypes.object,
+
+    // gdrive credential
+    gdriveCredential: PropTypes.object,
+
+    // document template data
+    docTemplate: PropTypes.string,
+    spreadsheetTemplate: PropTypes.string,
+
+    enabled: PropTypes.bool.isRequired,
+  };
+
+  onToggleEnabled = () => {
+    const newValue = !this.props.enabled;
+    const ffValue = newValue ? 'off' : 'on';
+    Meteor.call('setFeatureFlag', 'disable.google', ffValue);
+  };
+
+  disconnectGdrive = () => {
+    Meteor.call('clearGdriveCreds');
+  };
+
+  render() {
+    const firstButtonLabel = this.props.enabled ? 'Enabled' : 'Enable';
+    const secondButtonLabel = this.props.enabled ? 'Disable' : 'Disabled';
+    const clientId = (this.props.oauthSettings && this.props.oauthSettings.clientId) || '';
+
+    let stepsDone = 0;
+    if (this.props.oauthSettings) {
+      stepsDone += 1;
+    }
+    if (this.props.gdriveCredential) {
+      stepsDone += 1;
+    }
+    if (this.props.spreadsheetTemplate) {
+      stepsDone += 1;
+    }
+
+    const comp = googleCompletenessStrings[stepsDone];
+    const oauthBadgeLabel = this.props.oauthSettings ? 'configured' : 'unconfigured';
+    const driveBadgeLabel = this.props.gdriveCredential ? 'configured' : 'unconfigured';
+    const maybeDriveUserEmail = this.props.gdriveCredential && this.props.gdriveCredential.value && this.props.gdriveCredential.value.email;
+    const templateBadgeLabel = this.props.spreadsheetTemplate ? 'configured' : 'unconfigured';
+
+    return (
+      <section>
+        <h1 className="setup-section-header">
+          <span className="setup-section-header-label">
+            Google integration
+          </span>
+          <Badge>
+            {comp}
+          </Badge>
+          <span className="setup-section-header-buttons">
+            <Button bsStyle="default" disabled={this.props.enabled} onClick={this.onToggleEnabled}>
+              {firstButtonLabel}
+            </Button>
+            <Button bsStyle="default" disabled={!this.props.enabled} onClick={this.onToggleEnabled}>
+              {secondButtonLabel}
+            </Button>
+          </span>
+        </h1>
+        <p>
+          There are three pieces to Jolly Roger&apos;s Google integration capabilities:
+        </p>
+        <ol>
+          <li>
+            The OAuth client, which allows Jolly Roger to have users link
+            their Google account to their Jolly Roger account.
+          </li>
+          <li>
+            Google Drive automation, which automatically creates and shares
+            spreadsheets and documents with users when they try to load that
+            puzzle page in Jolly Roger.
+          </li>
+          <li>
+            Template documents, which allow customizing the spreadsheet or
+            doc to be used as a template when new puzzles are created.  This is
+            particularly useful for making all cells use a monospace font by
+            default.
+          </li>
+        </ol>
+
+        <div className="gdrive-subsection">
+          <h2 className="gdrive-subsection-header">
+            <span>OAuth client</span>
+            {' '}
+            <Badge>{oauthBadgeLabel}</Badge>
+          </h2>
+          <p>
+            Integrating with Google requires registering an app ID which
+            identifies your Jolly Roger instance, and obtaining an app secret
+            which proves to Google that you are the operator of this app.
+          </p>
+          <ul>
+            <li>
+              Follow <a href="https://support.google.com/googleapi/answer/6158849" target="_blank" rel="noopener noreferrer">Google&apos;s instructions</a> on how to create an app and register an OAuth 2.0 client.
+              You can ignore the bit about &quot;Service accounts, web applications, and installed applications&quot;.
+            </li>
+            <li>Set <strong>Authorized JavaScript origins</strong> to <span>{Meteor.absoluteUrl('')}</span></li>
+            <li>Set <strong>Authorized redirect URI</strong> to <span>{Meteor.absoluteUrl('/_oauth/google')}</span></li>
+          </ul>
+          <p>
+            Then, copy the client ID and secret into the fields here and click the Save button.
+          </p>
+          <GoogleOAuthForm initialClientId={clientId} isConfigured={!!this.props.oauthSettings} />
+        </div>
+
+        <div className="gdrive-subsection">
+          <h2 className="gdrive-subsection-header">
+            <span>Drive user</span>
+            {' '}
+            <Badge>{driveBadgeLabel}</Badge>
+          </h2>
+          <p>
+            Jolly Roger automates the creation of Google spreadsheets and
+            documents for each puzzle, as well as sharing them with any viewer who
+            has linked their Google account to their profile.
+            To do so, Jolly Roger needs to be authenticated as some Google
+            Drive user which will create and own each spreadsheet and document.
+            In production, Death and Mayhem use a separate Google account not
+            associated with any particular hunter for this purpose, and we
+            recommend this setup.
+          </p>
+          {maybeDriveUserEmail && (
+            <p>
+              Currently connected as <strong>{maybeDriveUserEmail}</strong>. <Button onClick={this.disconnectGdrive}>Disconnect</Button>
+            </p>
+          )}
+          <GoogleAuthorizeDriveClientForm />
+        </div>
+
+        <div className="gdrive-subsection">
+          <h2 className="gdrive-subsection-header">
+            <span>Document templates</span>
+            {' '}
+            <Badge>{templateBadgeLabel}</Badge>
+          </h2>
+          <p>
+            Jolly Roger can create new documents for each puzzle it&apos; made aware of,
+            but teams often would prefer that it make a new copy of some template document
+            or spreadsheet.  For instance, you might use this to set the default typeface
+            to be a monospace font, or to embed your team&apos;s set of Sheets macros, or
+            whatever other script you may wish to integrate.
+          </p>
+          <ul>
+            <li>If you wish to use templates, enter the document id (the part of a docs/sheets link after &quot;https://docs.google.com/document/d/&quot; and before &quot;/edit&quot;) for the appropriate template below and press Save.</li>
+            <li>To disable templates, replace the template ID with an empty string and press Save.</li>
+            <li>Template documents must be accessible by the Drive user connected above.</li>
+          </ul>
+          <GoogleDriveTemplateForm
+            initialSpreadsheetTemplate={this.props.spreadsheetTemplate}
+            initialDocTemplate={this.props.docTemplate}
+          />
+        </div>
+      </section>
+    );
+  }
+}
+
+class SlackIntegrationSection extends React.Component {
+  static propTypes = {
+    configured: PropTypes.bool.isRequired,
+    enabled: PropTypes.bool.isRequired,
+  };
+
+  state = {
+    apiKeyValue: '',
+    submitState: 'idle',
+    submitError: '',
+  };
+
+  onToggleEnabled = () => {
+    const newValue = !this.props.enabled;
+    const ffValue = newValue ? 'off' : 'on';
+    Meteor.call('setFeatureFlag', 'disable.slack', ffValue);
+  };
+
+  onApiKeyChange = (e) => {
+    this.setState({
+      apiKeyValue: e.target.value,
+    });
+  };
+
+  onSaveApiKey = (e) => {
+    e.preventDefault();
+    this.setState({
+      submitState: 'submitting',
+    });
+
+    Meteor.call('configureSlack', this.state.apiKeyValue.trim(), (err) => {
+      if (err) {
+        this.setState({
+          submitState: 'error',
+          submitError: err.message,
+        });
+      } else {
+        this.setState({
+          submitState: 'success',
+        });
+      }
+    });
+  };
+
+  dismissAlert = () => {
+    this.setState({
+      submitState: 'idle',
+      submitError: '',
+    });
+  };
+
+  render() {
+    const firstButtonLabel = this.props.enabled ? 'Enabled' : 'Enable';
+    const secondButtonLabel = this.props.enabled ? 'Disable' : 'Disabled';
+
+    const shouldDisableForm = this.state.submitState === 'submitting';
+
+    return (
+      <section>
+        <h1 className="setup-section-header">
+          <span className="setup-section-header-label">
+            Slack integration
+          </span>
+          <Badge>
+            {this.props.configured ? 'Configured' : 'Unconfigured'}
+          </Badge>
+          {this.props.configured && (
+          <span className="setup-section-header-buttons">
+            <Button bsStyle="default" disabled={this.props.enabled} onClick={this.onToggleEnabled}>
+              {firstButtonLabel}
+            </Button>
+            <Button bsStyle="default" disabled={!this.props.enabled} onClick={this.onToggleEnabled}>
+              {secondButtonLabel}
+            </Button>
+          </span>
+          )}
+        </h1>
+        <p>
+          Jolly Roger supports mirroring internal chat to Slack.  Hunts may configure a &quot;general&quot;
+          channel where we&apos;ll send messages about puzzles being solved and new puzzles being added.
+          Each hunt may additionally configure a &quot;firehose&quot; channel, where we&apos;ll mirror every chat
+          message sent about any puzzle in that hunt, to make it easy for people to use Slack&apos;s dingwords
+          to take note.
+        </p>
+
+        {this.state.submitState === 'submitting' ? <Alert bsStyle="info">Saving...</Alert> : null}
+        {this.state.submitState === 'success' ? <Alert bsStyle="success" onDismiss={this.dismissAlert}>Saved changes.</Alert> : null}
+        {this.state.submitState === 'error' ? (
+          <Alert bsStyle="danger" onDismiss={this.dismissAlert}>
+            Saving failed:
+            {' '}
+            {this.state.submitError}
+          </Alert>
+        ) : null}
+
+        <FormGroup>
+          <ControlLabel htmlFor="jr-setup-edit-slack-api-key">
+            API key
+          </ControlLabel>
+          <FormControl
+            id="jr-setup-edit-slack-api-key"
+            type="text"
+            placeholder="xoxp-..."
+            value={this.state.apiKeyValue}
+            disabled={shouldDisableForm}
+            onChange={this.onApiKeyChange}
+          />
+        </FormGroup>
+        <Button bsStyle="primary" type="submit" onClick={this.onSaveApiKey}>Save</Button>
+      </section>
+    );
+  }
+}
+
+class CircuitBreakerControl extends React.Component {
+  static propTypes = {
+    // disabled should be false if the circuit breaker is not intentionally disabling the feature,
+    // and true if the feature is currently disabled.
+    // most features will have false here most of the time.
+    featureDisabled: PropTypes.bool.isRequired,
+
+    // What do you call this circuit breaker?
+    title: PropTypes.string.isRequired,
+
+    // some explanation of what this feature flag controls and why you might want to toggle it.
+    children: PropTypes.node,
+
+    // callback to call when the user requests changing this flag's state
+    onChange: PropTypes.func.isRequired,
+  };
+
+  onChange = () => {
+    const desiredState = !this.props.featureDisabled;
+    this.props.onChange(desiredState);
+  };
+
+  render() {
+    // Is the feature that this circuit breaker disables currently available?
+    const featureIsEnabled = !this.props.featureDisabled;
+    const firstButtonLabel = featureIsEnabled ? 'Enabled' : 'Enable';
+    const secondButtonLabel = featureIsEnabled ? 'Disable' : 'Disabled';
+
+    return (
+      <div className="circuit-breaker">
+        <div className="circuit-breaker-row">
+          <div className="circuit-breaker-label">
+            {this.props.title}
+          </div>
+          <div className="circuit-breaker-buttons">
+            <Button bsStyle="default" disabled={featureIsEnabled} onClick={this.onChange}>
+              {firstButtonLabel}
+            </Button>
+            <Button bsStyle="default" disabled={!featureIsEnabled} onClick={this.onChange}>
+              {secondButtonLabel}
+            </Button>
+          </div>
+        </div>
+        <div className="circuit-breaker-description">
+          {this.props.children}
+        </div>
+      </div>
+    );
+  }
+}
+
+class CircuitBreakerSection extends React.Component {
+  static propTypes = {
+    flagDisableGdrivePermissions: PropTypes.bool.isRequired,
+    flagDisableSubcounters: PropTypes.bool.isRequired,
+    flagDisableViewerLists: PropTypes.bool.isRequired,
+    flagDisableApplause: PropTypes.bool.isRequired,
+  };
+
+  setFlagValue(flag, value) {
+    const type = value ? 'on' : 'off';
+    Meteor.call('setFeatureFlag', flag, type);
+  }
+
+  render() {
+    return (
+      <section>
+        <h1 className="setup-section-header">
+          Circuit breakers
+        </h1>
+        <p>
+          Jolly Roger has several features which can be responsible for high
+          server load or increased latency.  We allow them to be disabled at
+          runtime to enable graceful degradation if your deployment is having
+          issues.
+        </p>
+        <CircuitBreakerControl
+          title="Drive permission sharing"
+          featureDisabled={this.props.flagDisableGdrivePermissions}
+          onChange={newValue => this.setFlagValue('disable.gdrive_permissions', newValue)}
+        >
+          <p>
+            When Jolly Roger creates a spreadsheet or document, we grant
+            anonymous access to the sheet or doc by link.  This has the unfortunate
+            effect of making all viewers appear unidentified, e.g. Anonymous
+            Aardvark, since otherwise Google Doc scripting tools could be used to
+            harvest information about anyone who opens a link viewers.
+          </p>
+          <p>
+            If, however, the document has already been explicitly shared with a particular google account,
+            then that user&apos;s identity will be revealed in the document, which means you can see who it is
+            editing or highlighting what cell in the spreadsheet and whatnot.
+          </p>
+          <p>
+            Since sharing documents with N people in a hunt is N API calls, to
+            avoid getting rate-limited by Google, we opt to do this sharing lazily
+            when hunters open the puzzle page.
+          </p>
+          <p>
+            Disabling this feature means that Jolly Roger will continue to
+            create documents, but will not attempt to share them to users that have
+            linked their Google identity.  As a result, new documents will show
+            entirely anonymous animal users, and users looking at documents for the
+            first time will also remain anonymous within the Google iframe.
+          </p>
+        </CircuitBreakerControl>
+        <CircuitBreakerControl
+          title="Viewer counts"
+          featureDisabled={this.props.flagDisableSubcounters}
+          onChange={newValue => this.setFlagValue('disable.subcounters', newValue)}
+        >
+          <p>
+            To allow people to get a sense of how many people are looking at any given puzzle at a time,
+            we track which users have which puzzle open, and send these aggregate counts to all viewers.
+            This is expensive, because it fans out at O(tabs open to the site) per user navigation, which
+            grows quickly.
+          </p>
+          <p>
+            If you&apos;re seeing Jolly Roger getting slow under load, consider
+            disabling this feature to reduce the total amount of work the server
+            has to do.
+          </p>
+          <p>
+            Disabling this feature means that Jolly Roger will no longer show
+            viewer counts for puzzles.
+          </p>
+        </CircuitBreakerControl>
+        <CircuitBreakerControl
+          title="Viewer details"
+          featureDisabled={this.props.flagDisableViewerLists}
+          onChange={newValue => this.setFlagValue('disable.subfetches', newValue)}
+        >
+          <p>
+            The Viewer counts feature also allows viewing which specific users are currently active
+            on a puzzle.  This can cause additional server load.
+          </p>
+          <p>
+            Disabling this feature means that Jolly Roger will no longer allow
+            clicking on the viewer count on a puzzle page to bring up a list of
+            which specific users are included in a particular view count.
+          </p>
+        </CircuitBreakerControl>
+        <CircuitBreakerControl
+          title="Celebrations"
+          featureDisabled={this.props.flagDisableApplause}
+          onChange={newValue => this.setFlagValue('disable.applause', newValue)}
+        >
+          <p>
+            Some teams like broadcasting when a puzzle is solved, to make
+            people aware of the shape of correct answers and to celebrate progress.
+            Others do not, prefering to avoid distracting people or creating
+            sound, especially since some puzzles involve audio cues.
+            While individual users can squelch applause in their
+            profile/settings, we also provide this global toggle if your team
+            prefers to forgo this celebratory opportunity.
+          </p>
+          <p>
+            Disabling this feature means that Jolly Roger will not show a modal
+            and play an applause sound to all open tabs of all members of a
+            particular hunt when a puzzle in that hunt is solved.
+          </p>
+        </CircuitBreakerControl>
+      </section>
+    );
+  }
+}
+
+class SetupPageRewrite extends React.Component {
+  static propTypes = {
+    ready: PropTypes.bool.isRequired,
+
+    canConfigure: PropTypes.bool.isRequired,
+
+    googleConfig: PropTypes.object,
+    gdriveCredential: PropTypes.object,
+    docTemplate: PropTypes.string,
+    spreadsheetTemplate: PropTypes.string,
+
+    slackConfig: PropTypes.object,
+    flagDisableSlack: PropTypes.bool.isRequired,
+
+    flagDisableGoogleIntegration: PropTypes.bool.isRequired,
+    flagDisableGdrivePermissions: PropTypes.bool.isRequired,
+    flagDisableSubcounters: PropTypes.bool.isRequired,
+    flagDisableViewerLists: PropTypes.bool.isRequired,
+    flagDisableApplause: PropTypes.bool.isRequired,
+  };
+
+  static contextTypes = {
+    navAggregator: navAggregatorType,
+  };
+
+  renderBody() {
+    if (!this.props.ready) {
+      return (
+        <div className="setup-page">
+          Loading...
+        </div>
+      );
+    }
+
+
+    if (!this.props.canConfigure) {
+      return (
+        <div className="setup-page">
+          <h1>Not authorized</h1>
+          <p>This page allows server admins to reconfigure the server, but you&apos;re not an admin.</p>
+        </div>
+      );
+    }
+
+    const slackConfigured = !!this.props.slackConfig;
+    const slackEnabled = !this.props.flagDisableSlack;
+    return (
+      <div className="setup-page">
+        <GoogleIntegrationSection
+          oauthSettings={this.props.googleConfig}
+          enabled={!this.props.flagDisableGoogleIntegration}
+          gdriveCredential={this.props.gdriveCredential}
+          docTemplate={this.props.docTemplate}
+          spreadsheetTemplate={this.props.spreadsheetTemplate}
+        />
+        <SlackIntegrationSection
+          configured={slackConfigured}
+          enabled={slackEnabled}
+        />
+        <CircuitBreakerSection
+          flagDisableGdrivePermissions={this.props.flagDisableGdrivePermissions}
+          flagDisableSubcounters={this.props.flagDisableSubcounters}
+          flagDisableViewerLists={this.props.flagDisableViewerLists}
+          flagDisableApplause={this.props.flagDisableApplause}
+        />
+      </div>
+    );
+  }
 
   render() {
     return (
@@ -101,7 +798,45 @@ class SetupPage extends React.Component {
 }
 
 export default withTracker(() => {
-  const config = ServiceConfiguration.configurations.findOne({ service: 'google' });
-  const canSetupGDrive = Roles.userHasPermission(Meteor.userId(), 'gdrive.credential');
-  return { config, canSetupGDrive };
-})(SetupPage);
+  const canConfigure = Roles.userHasRole(Meteor.userId(), 'admin');
+
+  // We need to fetch the contents of the Settings table
+  const settingsHandle = Meteor.subscribe('mongo.settings');
+
+  // Google
+  const googleConfig = ServiceConfiguration.configurations.findOne({ service: 'google' });
+  const gdriveCredential = Settings.findOne({ name: 'gdrive.credential' });
+  const docTemplate = Settings.findOne({ name: 'gdrive.template.document' });
+  const spreadsheetTemplate = Settings.findOne({ name: 'gdrive.template.spreadsheet' });
+
+  // Slack
+  const slackConfig = ServiceConfiguration.configurations.findOne({ service: 'slack' });
+  const flagDisableSlack = Flags.active('disable.slack');
+
+  // Circuit breakers
+  const flagDisableGoogleIntegration = Flags.active('disable.google');
+  const flagDisableGdrivePermissions = Flags.active('disable.gdrive_permissions');
+  const flagDisableSubcounters = Flags.active('disable.subcounters');
+  const flagDisableViewerLists = Flags.active('disable.subfetches');
+  const flagDisableApplause = Flags.active('disable.applause');
+
+  return {
+    ready: settingsHandle.ready(),
+
+    canConfigure,
+
+    googleConfig,
+    gdriveCredential,
+    docTemplate: docTemplate && docTemplate.value && docTemplate.value.id,
+    spreadsheetTemplate: spreadsheetTemplate && spreadsheetTemplate.value && spreadsheetTemplate.value.id,
+
+    slackConfig,
+    flagDisableSlack,
+
+    flagDisableGoogleIntegration,
+    flagDisableGdrivePermissions,
+    flagDisableSubcounters,
+    flagDisableViewerLists,
+    flagDisableApplause,
+  };
+})(SetupPageRewrite);

--- a/imports/lib/active-operator-role.js
+++ b/imports/lib/active-operator-role.js
@@ -1,0 +1,4 @@
+const ActiveOperatorRole = new Roles.Role('operator');
+ActiveOperatorRole.allow('users.makeOperator', () => true);
+
+export default ActiveOperatorRole;

--- a/imports/lib/models/announcements.js
+++ b/imports/lib/models/announcements.js
@@ -1,9 +1,11 @@
 import { huntsMatchingCurrentUser } from '../../model-helpers.js';
 import AnnouncementsSchema from '../schemas/announcements.js';
 import Base from './base.js';
+import ActiveOperatorRole from '../active-operator-role.js';
 
 const Announcements = new Base('announcements');
 Announcements.attachSchema(AnnouncementsSchema);
 Announcements.publish(huntsMatchingCurrentUser);
+ActiveOperatorRole.allow('mongo.announcements.insert', () => true);
 
 export default Announcements;

--- a/imports/lib/models/facade.js
+++ b/imports/lib/models/facade.js
@@ -8,6 +8,7 @@ import Hunts from './hunts.js';
 import PendingAnnouncements from './pending_announcements.js';
 import Profiles from './profiles.js';
 import Puzzles from './puzzles.js';
+import Settings from './settings.js';
 import Tags from './tags.js';
 
 const Models = {
@@ -21,6 +22,7 @@ const Models = {
   PendingAnnouncements,
   Profiles,
   Puzzles,
+  Settings,
   Tags,
 };
 

--- a/imports/lib/models/guess.js
+++ b/imports/lib/models/guess.js
@@ -1,9 +1,13 @@
 import { huntsMatchingCurrentUser } from '../../model-helpers.js';
 import GuessesSchema from '../schemas/guess.js';
 import Base from './base.js';
+import ActiveOperatorRole from '../active-operator-role.js';
 
 const Guesses = new Base('guesses');
 Guesses.attachSchema(GuessesSchema);
 Guesses.publish(huntsMatchingCurrentUser);
+
+// Operators can update guesses
+ActiveOperatorRole.allow('mongo.guesses.update', () => true);
 
 export default Guesses;

--- a/imports/lib/models/hunts.js
+++ b/imports/lib/models/hunts.js
@@ -9,8 +9,10 @@ Hunts.attachSchema(HuntsSchema);
 // All hunts are accessible, since they only contain metadata
 Hunts.publish();
 
-// operators are always allowed to join someone to a hunt; non-admins
-// can if they are a member and if the hunt allows open signups.
+// admins are always allowed to join someone to a hunt
+// non-admins (including operators) can if they are a member of that hunt
+// already and if the hunt allows open signups.
+// It's possible we should always allow operators to add someone to a hunt?
 Roles.loggedInRole.allow('hunt.join', (huntId) => {
   if (!_.include(Meteor.user().hunts, huntId)) {
     return false;

--- a/imports/lib/models/puzzles.js
+++ b/imports/lib/models/puzzles.js
@@ -1,9 +1,13 @@
 import { huntsMatchingCurrentUser } from '../../model-helpers.js';
 import Base from './base.js';
 import PuzzlesSchema from '../schemas/puzzles.js';
+import ActiveOperatorRole from '../active-operator-role.js';
 
 const Puzzles = new Base('puzzles');
 Puzzles.attachSchema(PuzzlesSchema);
 Puzzles.publish(huntsMatchingCurrentUser);
+
+ActiveOperatorRole.allow('mongo.puzzles.insert', () => true);
+ActiveOperatorRole.allow('mongo.puzzles.update', () => true);
 
 export default Puzzles;

--- a/imports/lib/models/settings.js
+++ b/imports/lib/models/settings.js
@@ -4,4 +4,14 @@ import SettingsSchema from '../schemas/settings.js';
 const Settings = new Base('settings');
 Settings.attachSchema(SettingsSchema);
 
+function queryModifier(q) {
+  // Only allow admins to pull down Settings.
+  if (Roles.userHasRole(this.userId, 'admin')) {
+    return q;
+  }
+
+  // Make the query evaluate to nothing
+  return { $and: [false, q] };
+}
+Settings.publish(queryModifier);
 export default Settings;

--- a/imports/lib/models/settings.js
+++ b/imports/lib/models/settings.js
@@ -1,4 +1,4 @@
-import Base from '../../lib/models/base.js';
+import Base from './base.js';
 import SettingsSchema from '../schemas/settings.js';
 
 const Settings = new Base('settings');

--- a/imports/lib/roles.js
+++ b/imports/lib/roles.js
@@ -1,4 +1,5 @@
 Roles.registerAction('gdrive.credential', true);
+Roles.registerAction('google.configureOAuth', true);
 Roles.registerAction('hunt.join', true);
 Roles.registerAction('slack.configureClient', true);
 Roles.registerAction('users.makeOperator', true);

--- a/imports/lib/roles.js
+++ b/imports/lib/roles.js
@@ -1,5 +1,6 @@
 Roles.registerAction('gdrive.credential', true);
 Roles.registerAction('hunt.join', true);
+Roles.registerAction('slack.configureClient', true);
 Roles.registerAction('users.makeOperator', true);
 
 const InactiveOperatorRole = new Roles.Role('inactiveOperator');

--- a/imports/lib/schemas/settings.js
+++ b/imports/lib/schemas/settings.js
@@ -1,5 +1,5 @@
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
-import Base from '../../lib/schemas/base.js';
+import Base from './base.js';
 
 const Settings = new SimpleSchema([
   Base,

--- a/imports/server/api_keys.js
+++ b/imports/server/api_keys.js
@@ -9,7 +9,7 @@ const userForKeyOperation = function userForKeyOperation(currentUser, forUser) {
   const canOverrideUser = Roles.userHasRole(currentUser, 'admin');
 
   if (forUser && !canOverrideUser) {
-    throw new Meteor.Error(403, 'Only operators can fetch other users\' keys');
+    throw new Meteor.Error(403, 'Only server admins can fetch other users\' keys');
   }
 
   return forUser || currentUser;

--- a/imports/server/gdrive-client-refresher.js
+++ b/imports/server/gdrive-client-refresher.js
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
 import googleapis from 'googleapis';
 import Ansible from '../ansible.js';
-import Settings from './models/settings.js';
+import Settings from '../lib/models/settings.js';
 
 class GDriveClientRefresher {
   constructor() {

--- a/imports/server/gdrive-client-refresher.js
+++ b/imports/server/gdrive-client-refresher.js
@@ -1,7 +1,4 @@
-import { Meteor } from 'meteor/meteor';
-import { Random } from 'meteor/random';
-import googleapis from 'googleapis';
-import Ansible from '../ansible.js';
+import { google } from 'googleapis';
 import Settings from '../lib/models/settings.js';
 
 class GDriveClientRefresher {
@@ -10,7 +7,6 @@ class GDriveClientRefresher {
     this.oauthClient = null;
     this.oauthConfig = null;
     this.oauthRefreshToken = null;
-    this.oauthTimer = null;
 
     // Watch for config changes, and refresh the gdrive instance if anything changes
     this.oauthConfigCursor = ServiceConfiguration.configurations.find({ service: 'google' });
@@ -28,14 +24,12 @@ class GDriveClientRefresher {
   }
 
   updateOauthConfig(doc) {
-    // console.log("updateOauthConfig", doc);
     this.oauthConfig = doc;
     this.recreateGdriveClient();
   }
 
   updateOauthCredentials(doc) {
-    // console.log("updateOauthCredentials", doc);
-    this.oauthRefreshToken = doc.value.refresh_token;
+    this.oauthRefreshToken = doc.value.refreshToken;
     this.recreateGdriveClient();
   }
 
@@ -50,14 +44,8 @@ class GDriveClientRefresher {
       return;
     }
 
-    // If there was a timer set, clear it -- we're refreshing now.
-    if (this.oauthTimer) {
-      Meteor.clearTimeout(this.oauthTimer);
-      this.oauthTimer = null;
-    }
-
     // Construct a new OAuth2 client with the app id and secret and redirect uri
-    this.oauthClient = new googleapis.auth.OAuth2(
+    this.oauthClient = new google.auth.OAuth2(
       this.oauthConfig.clientId,
       this.oauthConfig.secret,
       OAuth._redirectUri('google', this.oauthConfig)
@@ -68,17 +56,8 @@ class GDriveClientRefresher {
       refresh_token: this.oauthRefreshToken,
     });
 
-    // Exchange the refresh token for an access token
-    Ansible.log('Refreshing Google OAuth access token for Google Drive');
-    const credentials = Meteor.wrapAsync(this.oauthClient.refreshAccessToken, this.oauthClient)();
-
-    // Schedule to refresh the access token a quarter through its lifecycle
-    // (should be about every 15 minutes), with some jitter
-    const timeout = (credentials.expiry_date - (new Date()).getTime()) / 4;
-    const jitter = 5000 * Random.fraction();
-    this.oauthTimer = Meteor.setTimeout(() => this.recreateGdriveClient(), timeout - jitter);
-
-    this.gdrive = googleapis.drive({ version: 'v3', auth: this.oauthClient });
+    // Construct the drive client, using that OAuth2 client.
+    this.gdrive = google.drive({ version: 'v3', auth: this.oauthClient });
   }
 }
 

--- a/imports/server/gdrive.js
+++ b/imports/server/gdrive.js
@@ -2,9 +2,9 @@ import { Meteor } from 'meteor/meteor';
 import { _ } from 'meteor/underscore';
 import Ansible from '../ansible.js';
 import Locks from './models/lock.js';
-import Settings from './models/settings.js';
-import Documents from '../lib/models/documents.js';
 import DriveClient from './gdrive-client-refresher.js';
+import Documents from '../lib/models/documents.js';
+import Settings from '../lib/models/settings.js';
 
 const MimeTypes = {
   spreadsheet: 'application/vnd.google-apps.spreadsheet',

--- a/imports/server/gdrive.js
+++ b/imports/server/gdrive.js
@@ -22,7 +22,7 @@ function checkClientOk() {
   }
 }
 
-const createDocument = function createDocument(name, type) {
+function createDocument(name, type) {
   if (!_.has(MimeTypes, type)) {
     throw new Meteor.Error(400, `Invalid document type ${type}`);
   }
@@ -33,37 +33,37 @@ const createDocument = function createDocument(name, type) {
 
   let file;
   if (template) {
-    file = Meteor.wrapAsync(DriveClient.gdrive.files.copy)({
+    file = Meteor.wrapAsync(DriveClient.gdrive.files.copy, DriveClient.gdrive)({
       fileId: template.value.id,
       resource: { name, mimeType },
     });
   } else {
-    file = Meteor.wrapAsync(DriveClient.gdrive.files.create)({
+    file = Meteor.wrapAsync(DriveClient.gdrive.files.create, DriveClient.gdrive)({
       resource: { name, mimeType },
     });
   }
 
-  const fileId = file.id;
+  const fileId = file.data.id;
 
-  Meteor.wrapAsync(DriveClient.gdrive.permissions.create)({
+  Meteor.wrapAsync(DriveClient.gdrive.permissions.create, DriveClient.gdrive.permissions)({
     fileId,
     resource: { role: 'writer', type: 'anyone' },
   });
   return fileId;
-};
+}
 
-const renameDocument = function renameDocument(id, name) {
+function renameDocument(id, name) {
   checkClientOk();
   // It's unclear if this can ever return an error
-  Meteor.wrapAsync(DriveClient.gdrive.files.update)({
+  Meteor.wrapAsync(DriveClient.gdrive.files.update, DriveClient.gdrive)({
     fileId: id,
     resource: { name },
   });
-};
+}
 
-const grantPermission = function grantPermission(id, email, permission) {
+function grantPermission(id, email, permission) {
   checkClientOk();
-  Meteor.wrapAsync(DriveClient.gdrive.permissions.create)({
+  Meteor.wrapAsync(DriveClient.gdrive.permissions.create, DriveClient.gdrive.permissions)({
     fileId: id,
     sendNotificationEmail: false,
     resource: {
@@ -72,9 +72,9 @@ const grantPermission = function grantPermission(id, email, permission) {
       role: permission,
     },
   });
-};
+}
 
-const ensureDocument = function ensureDocument(puzzle, type = 'spreadsheet') {
+function ensureDocument(puzzle, type = 'spreadsheet') {
   let doc = Documents.findOne({ puzzle: puzzle._id });
   if (!doc) {
     checkClientOk();
@@ -99,10 +99,9 @@ const ensureDocument = function ensureDocument(puzzle, type = 'spreadsheet') {
   }
 
   return doc;
-};
+}
 
 export {
-  createDocument,
   renameDocument,
   grantPermission,
   ensureDocument,

--- a/imports/server/migrations/18-rename-gdrive-template.js
+++ b/imports/server/migrations/18-rename-gdrive-template.js
@@ -1,5 +1,5 @@
 import { Migrations } from 'meteor/percolate:migrations';
-import Settings from '../models/settings.js';
+import Settings from '../../lib/models/settings.js';
 
 Migrations.add({
   version: 18,

--- a/imports/server/models/api_keys.js
+++ b/imports/server/models/api_keys.js
@@ -4,7 +4,7 @@ import APIKeysSchema from '../schemas/api_keys.js';
 const APIKeys = new Base('api_keys');
 APIKeys.attachSchema(APIKeysSchema);
 APIKeys.publish(function (q) {
-  // Operators can access all API keys
+  // Server admins can access all API keys
   if (Roles.userHasRole(this.userId, 'admin')) {
     return q;
   }

--- a/imports/server/observability.js
+++ b/imports/server/observability.js
@@ -17,6 +17,7 @@ const onConnect = function onConnect(socket, ...rest) {
     }, {
       user: () => session.userId,
       admin: () => Roles.userHasRole(session.userId, 'admin'),
+      operator: () => Roles.userHasRole(session.userId, 'operator'),
     });
   }
 

--- a/imports/server/operator.js
+++ b/imports/server/operator.js
@@ -8,7 +8,7 @@ Meteor.methods({
     Roles.checkPermission(this.userId, 'users.makeOperator');
 
     Roles.addUserToRoles(this.userId, 'inactiveOperator');
-    Roles.removeUserFromRoles(this.userId, 'admin');
+    Roles.removeUserFromRoles(this.userId, 'operator');
   },
 
   makeOperator(targetUserId) {
@@ -20,7 +20,7 @@ Meteor.methods({
       Ansible.log('Promoting user to operator', { user: targetUserId, promoter: this.userId });
     }
 
-    Roles.addUserToRoles(targetUserId, 'admin');
+    Roles.addUserToRoles(targetUserId, 'operator');
     // This may be a noop
     Roles.removeUserFromRoles(targetUserId, 'inactiveOperator');
   },

--- a/imports/server/puzzle.js
+++ b/imports/server/puzzle.js
@@ -53,7 +53,7 @@ Meteor.methods({
     // By creating the document before we save the puzzle, we make
     // sure nobody else has a chance to create a document with the
     // wrong config
-    if (DriveClient.ready()) {
+    if (DriveClient.ready() && !Flags.active('disable.google')) {
       ensureDocument(fullPuzzle, docType);
     }
 
@@ -183,6 +183,10 @@ Meteor.methods({
     this.unblock();
 
     const doc = ensureDocument(puzzle);
+
+    if (Flags.active('disable.google')) {
+      return;
+    }
 
     if (Flags.active('disable.gdrive_permissions')) {
       return;

--- a/imports/server/setup.js
+++ b/imports/server/setup.js
@@ -4,6 +4,25 @@ import Ansible from '../ansible.js';
 import Settings from './models/settings.js';
 
 Meteor.methods({
+  setupGoogleOAuthClient(clientId, secret) {
+    check(this.userId, String);
+    check(clientId, String);
+    check(secret, String);
+    Roles.checkPermission(this.userId, 'google.configureOAuth');
+
+    Ansible.log('Configuring google oauth client', {
+      clientId,
+      user: this.userId,
+    });
+    ServiceConfiguration.configurations.upsert({ service: 'google' }, {
+      $set: {
+        clientId,
+        secret,
+        loginStyle: 'popup',
+      },
+    });
+  },
+
   setupGdriveCreds(key, secret) {
     check(this.userId, String);
     check(key, String);

--- a/imports/server/setup.js
+++ b/imports/server/setup.js
@@ -39,6 +39,15 @@ Meteor.methods({
       { $set: { value: { refreshToken, email } } });
   },
 
+  clearGdriveCreds() {
+    check(this.userId, String);
+    Roles.checkPermission(this.userId, 'gdrive.credential');
+    Ansible.log('Clearing Gdrive creds', {
+      user: this.userId,
+    });
+    Settings.remove({ name: 'gdrive.credential' });
+  },
+
   setupGdriveTemplates(spreadsheetTemplate, documentTemplate) {
     check(this.userId, String);
     check(spreadsheetTemplate, Match.Maybe(String));

--- a/imports/server/setup.js
+++ b/imports/server/setup.js
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import { Match, check } from 'meteor/check';
 import Ansible from '../ansible.js';
-import Settings from './models/settings.js';
+import Settings from '../lib/models/settings.js';
 
 Meteor.methods({
   setupGoogleOAuthClient(clientId, secret) {

--- a/imports/server/setup.js
+++ b/imports/server/setup.js
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor';
-import { check } from 'meteor/check';
+import { Match, check } from 'meteor/check';
 import Ansible from '../ansible.js';
 import Settings from './models/settings.js';
 
@@ -37,5 +37,30 @@ Meteor.methods({
     });
     Settings.upsert({ name: 'gdrive.credential' },
       { $set: { value: { refreshToken, email } } });
+  },
+
+  setupGdriveTemplates(spreadsheetTemplate, documentTemplate) {
+    check(this.userId, String);
+    check(spreadsheetTemplate, Match.Maybe(String));
+    check(documentTemplate, Match.Maybe(String));
+    // Only let the same people that can credential gdrive configure templates,
+    // which today is just admins
+    Roles.checkPermission(this.userId, 'gdrive.credential');
+
+    // In an ideal world, maybe we'd verify that the document IDs we were given
+    // are actually like valid documents that we can reach or something.
+    if (spreadsheetTemplate) {
+      Settings.upsert({ name: 'gdrive.template.spreadsheet' },
+        { $set: { value: { id: spreadsheetTemplate } } });
+    } else {
+      Settings.remove({ name: 'gdrive.template.spreadsheet' });
+    }
+
+    if (documentTemplate) {
+      Settings.upsert({ name: 'gdrive.template.document' },
+        { $set: { value: { id: documentTemplate } } });
+    } else {
+      Settings.remove({ name: 'gdrive.template.document' });
+    }
   },
 });

--- a/imports/server/slack-methods.js
+++ b/imports/server/slack-methods.js
@@ -48,4 +48,41 @@ Meteor.methods({
       throw new Meteor.Error(500, 'Something went wrong sending the invite');
     }
   },
+
+  configureSlack(apiSecretKey) {
+    check(this.userId, String);
+    Roles.checkPermission(this.userId, 'slack.configureClient');
+
+    // If given a null/undefined secret key, assume the intent is to disable
+    // the Slack integration.
+    check(apiSecretKey, Match.Maybe(String));
+
+    if (apiSecretKey) {
+      // Verify that the key works against the Slack API.
+      const result = HTTP.post('https://slack.com/api/auth.test', {
+        params: {
+          token: apiSecretKey,
+        },
+      });
+
+      if (result.statusCode !== 200) {
+        throw new Meteor.Error(400, 'The Slack API rejected the token provided');
+      }
+
+      const resultObj = JSON.parse(result.content);
+      if (resultObj.ok !== true) {
+        throw new Meteor.Error(400, `The Slack API rejected the token provided: ${resultObj.error}`);
+      }
+
+      // If successful, apply the config
+      ServiceConfiguration.configurations.upsert({ service: 'slack' }, {
+        $set: {
+          secret: apiSecretKey,
+        },
+      });
+    } else {
+      // Drop the slack configuration if there was any.
+      ServiceConfiguration.configurations.remove({ service: 'slack' });
+    }
+  },
 });

--- a/imports/server/slack-methods.js
+++ b/imports/server/slack-methods.js
@@ -2,6 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { Match, check } from 'meteor/check';
 import { HTTP } from 'meteor/http';
 import Ansible from '../ansible.js';
+import Flags from '../flags.js';
 
 Meteor.methods({
   slackInvite(userId) {
@@ -28,6 +29,11 @@ Meteor.methods({
     const config = ServiceConfiguration.configurations.findOne({ service: 'slack' });
     if (!config) {
       throw new Meteor.Error(500, 'Slack is not configured; unable to send invite');
+    }
+
+    const circuitBroken = Flags.active('disable.slack');
+    if (circuitBroken) {
+      throw new Meteor.Error(500, 'Slack integration is currently disabled by the administrator; unable to send invite');
     }
 
     this.unblock();

--- a/imports/server/slack.js
+++ b/imports/server/slack.js
@@ -1,10 +1,16 @@
 import { HTTP } from 'meteor/http';
 import Ansible from '../ansible.js';
+import Flags from '../flags.js';
 
 function postSlackMessage(message, channel, username) {
   const config = ServiceConfiguration.configurations.findOne({ service: 'slack' });
   if (!config) {
     Ansible.log('Not notifying Slack because Slack is not configured');
+    return;
+  }
+
+  if (Flags.active('disable.slack')) {
+    Ansible.log('Not notifying Slack because disable.slack circuit breaker is active');
     return;
   }
 

--- a/imports/server/users.js
+++ b/imports/server/users.js
@@ -30,8 +30,8 @@ Meteor.publish('huntMembers', function (huntId) {
 Meteor.publish('userRoles', function (targetUserId) {
   check(targetUserId, String);
 
-  // Only publish other users' roles to other operators.
-  if (!Roles.userHasRole(this.userId, 'admin')) {
+  // Only publish other users' roles to admins and other (potentially-inactive) operators.
+  if (!Roles.userHasRole(this.userId, 'admin') && !Roles.userHasPermission(this.userId, 'users.makeOperator')) {
     return [];
   }
 


### PR DESCRIPTION
This changeset does rather a lot, so I've tried to break it into a bunch of commits piece-by-piece, which is also how I suggest you review it.  The first several commits in this series are already included in #161, which fixes several bugs that I discovered while building out and testing everything in this PR.

The high-level goal of this PR is to expose in the webui most of the functionality that we've previously abused the Meteor shell to realize.

To that end, the new setup page provides:
* step-by-step guidance around the three major pieces of our Google integration: OAuth client, Drive connection, and document templates.  
* a way to configure Slack integration from the web
* circuit breakers for both the Google and Slack integrations, so you can disable them without having to blank out the credentials from the DB
* UI and explanations of the other four circuit breakers that exist in the codeline today

To make this happen, we needed to make `Settings` available client-side (so we can show what's configured, and what isn't), and to do that without exposing server secrets to everyone, we also split the `admin` role into separate `admin` and `operator` roles.

I performed extensive manual testing, which hammered down many issues (some which I introduced myself, and some which have been latent in the code since our upgrade spree).

To test the admin/operator split, I created three users: one user with the `admin` role, one user with the `operator` role, and one user with no additional roles.  I then verified that the unprivileged user could still do all the things I would expect (navigate between puzzles, add/remove tags, enter guesses), and that I could *not* access any of the sensitive `Settings` contents even when I attempted to subscribe to `mongo.settings`.  Next, I verified that the operator could still take all expected operator actions like adding/changing puzzle metadata, promoting other non-operators to operator, creating announcements, marking guesses as correct/incorrect.  I tested that the operator UI (guess submission) was appropriately hidden when the operator was in non-operating mode.

To test the Google integration, I set up my own client ID/secret, linked to my personal gdrive, and verified that templates worked.  I found some changes to the `googleapis` package broke all of our Drive functionality by placing things a bit lower down in their exports, and needing `this` to be set to the drive object or subobject.  On the upside, they appear to have made it no longer necessary to explicitly refresh the access token, so I was able to delete some timers code there.  I tested that linking/unlinking the Drive user at runtime did the appropriate things.  I only have one Google account, and Google appears to 500 if you try to create permissions on a document owned by that user, so I have *not* successfully tested the "sharing to identity reveals username in spreadsheet" functionality.  Given that everything is broken now, I'm inclined to test this elsewhere later.

To test the Slack integration, I lifted our Slack API key out of our production DB from the mongodb atlas UI, configured it locally, and enabled messaging to the #zarvox-test channel on the Death and Mayhem Slack, which worked.  The circuit breaker disabled message mirroring as desired.  I was unable to figure out quite how this key had been generated; it appears that Slack has made their developer portal far more confusing, and I couldn't find the "test app" that we originally used for our integration.

As we land this, we'll probably want to turn most of our existing production operators from admins into just operators.  There are 10 admins at present; I plan to modify the roles for the 8 who are not myself or ebroder to make them operators but not admins, which I would do before hitting the merge button on this patchset.

There's probably some nits to chase here and my CSS skills have atrophied a bit in the past two years, but given the size of this thing, the breadth of fixes included, and the amount of testing I did, I'd prefer to bias toward landing things first and iterating on that class of things once this is on master.

![screenshot_20181104_153330](https://user-images.githubusercontent.com/307325/47971489-04a4a900-e047-11e8-8dbd-d37873d75896.png)

![screenshot_20181104_153405](https://user-images.githubusercontent.com/307325/47971500-15edb580-e047-11e8-83ca-eb892634418a.png)


Fixes #121.

r? @ebroder 