### PR TITLE
Fix glyphicons...again

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -1,5 +1,3 @@
-import '../imports/client/stylesheets/bootstrap.less';
-
 // explicitly import all the stuff from lib/ since mainModule skips autoloading
 // things
 import '../imports/lib/config/accounts.js';

--- a/client/stylesheets/bootstrap.less
+++ b/client/stylesheets/bootstrap.less
@@ -1,0 +1,1 @@
+@import "../../node_modules/bootstrap/less/bootstrap.less";

--- a/imports/client/stylesheets/bootstrap.less
+++ b/imports/client/stylesheets/bootstrap.less
@@ -1,3 +1,0 @@
-@import "../../../node_modules/bootstrap/less/bootstrap.less";
-
-@icon-font-path: "/fonts/";


### PR DESCRIPTION
This time, stop trying to import them, and instead just put them into
client/stylesheets/. This causes them to be compiled into the merged
stylesheet, instead of added dynamically via Javascript. In theory,
either should work, because we specified an absolute path for fonts.
However, in practice, it seems that the Meteor compiler is stripping the
leading slash (making the paths relative) on production builds.

This is annoying, but it's acceptable for the compiled stylesheet, since
that's served out of the root of the domain, meaning that the font files
are correctly positioned relative to it.