### PR TITLE
Replace "(puzzle)" link with puzzle piece icon

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -46,7 +46,7 @@
   }
 
   .puzzle-link {
-    flex: 1 1 50px;
+    flex: 1 1 1em;
     display: inline-block;
     vertical-align: top;
     text-align: center;

--- a/imports/client/components/Puzzle.jsx
+++ b/imports/client/components/Puzzle.jsx
@@ -3,7 +3,7 @@ import { _ } from 'meteor/underscore';
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from 'react-bootstrap/lib/Button';
-import { faEdit } from '@fortawesome/free-solid-svg-icons';
+import { faEdit, faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 import { Link } from 'react-router';
@@ -116,9 +116,9 @@ class Puzzle extends React.PureComponent {
           <div className="puzzle-link">
             {this.props.puzzle.url ? (
               <span>
-                (
-                <a href={this.props.puzzle.url} target="_blank" rel="noopener noreferrer">puzzle</a>
-                )
+                <a href={this.props.puzzle.url} target="_blank" rel="noopener noreferrer" title="Open the puzzle">
+                  <FontAwesomeIcon icon={faPuzzlePiece} />
+                </a>
               </span>
             ) : null}
           </div>


### PR DESCRIPTION
There was a suggestion from a few years ago that this might make the view a bit more compact. I'm a little worried about learning curve (I added a title tooltip to try and tame that a bit, not sure it'll actually be enough), but it does give us some pixels back.

Here's two screenshots to compare:

![screenshot from 2019-01-01 22-03-51](https://user-images.githubusercontent.com/28167/50581809-00f88d00-0e12-11e9-8ca7-75624a04e29f.png)
![screenshot from 2019-01-01 22-09-06](https://user-images.githubusercontent.com/28167/50581811-02c25080-0e12-11e9-92dc-9fe3550fbfcd.png)

Thoughts?