### PR TITLE
Debounce connection status refresh

### DIFF
--- a/imports/client/components/ConnectionStatus.jsx
+++ b/imports/client/components/ConnectionStatus.jsx
@@ -11,6 +11,14 @@ class ConnectionStatus extends React.Component {
     meteorStatus: PropTypes.object,
   };
 
+  refresh() {
+    // Mark this timeout as completed
+    if (this.timeoutId) {
+      this.timeoutId = undefined;
+    }
+    this.forceUpdate();
+  }
+
   render() {
     switch (this.props.meteorStatus.status) {
       case 'connecting':
@@ -32,8 +40,10 @@ class ConnectionStatus extends React.Component {
         const now = Date.now();
         const timeToRetry = Math.ceil((this.props.meteorStatus.retryTime - now) / 1000);
 
-        // Trigger a refresh in a second.  TODO: debounce this?
-        window.setTimeout(() => this.forceUpdate(), 1000);
+        // If we have no refresh scheduled yet, trigger a refresh in a second.
+        if (this.timeoutId === undefined) {
+          this.timeoutId = window.setTimeout(() => this.refresh(), 1000);
+        }
         return (
           <Alert bsStyle="warning">
             We can&apos;t connect to Jolly Roger right now. We&apos;ll try again in


### PR DESCRIPTION
If we rendered more than once a second, we might trigger very frequent
repaints.  This change makes sure that we don't auto-repaint from timeout
triggers more than once a second, closing out an old TODO item.