### PR TITLE
Add gravatars to profile page

### DIFF
--- a/imports/client/components/Gravatar.jsx
+++ b/imports/client/components/Gravatar.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import md5 from 'blueimp-md5';
+
+function gravatarHash(emailAddress) {
+  return md5(emailAddress.trim().toLowerCase());
+}
+
+class Gravatar extends React.PureComponent {
+  static propTypes = {
+    email: PropTypes.string.isRequired,
+  };
+
+  render() {
+    return (
+      <div>
+        <img
+          src={`https://www.gravatar.com/avatar/${gravatarHash(this.props.email)}?d=identicon`}
+          alt="Avatar"
+        />
+      </div>
+    );
+  }
+}
+
+export default Gravatar;

--- a/imports/client/components/ProfilePage.jsx
+++ b/imports/client/components/ProfilePage.jsx
@@ -15,6 +15,7 @@ import navAggregatorType from './navAggregatorType.jsx';
 import ProfilesSchema from '../../lib/schemas/profiles.js';
 import Profiles from '../../lib/models/profiles.js';
 import Flags from '../../flags.js';
+import Gravatar from './Gravatar.jsx';
 
 /* eslint-disable max-len */
 
@@ -30,7 +31,6 @@ class OthersProfilePage extends React.Component {
   };
 
   render() {
-    // TODO: figure out something for profile pictures - gravatar?
     const profile = this.props.profile;
     const showOperatorBadge = this.props.targetIsOperator;
     const showMakeOperatorButton = this.props.viewerCanMakeOperator && !this.props.targetIsOperator;
@@ -39,6 +39,7 @@ class OthersProfilePage extends React.Component {
         <h1>{profile.displayName}</h1>
         {showOperatorBadge && <Label>operator</Label>}
         {showMakeOperatorButton && <Button onClick={this.makeOperator}>Make operator</Button>}
+        <Gravatar email={profile.primaryEmail} />
         <div>
           Email:
           {' '}
@@ -181,6 +182,7 @@ class GoogleLinkBlock extends React.Component {
           Linking your Google account isn&apos;t required, but this will
           let other people see who you are on puzzles&apos; Google
           Spreadsheet docs (instead of being an
+          {' '}
           <a
             href="https://support.google.com/docs/answer/2494888?visit_id=1-636184745566842981-35709989&hl=en&rd=1"
             rel="noopener noreferrer"
@@ -300,7 +302,6 @@ class OwnProfilePage extends React.Component {
       <div>
         <h1>Account information</h1>
         {this.props.canMakeOperator ? <Checkbox type="checkbox" checked={this.props.operating} onChange={this.toggleOperating}>Operating</Checkbox> : null}
-        {/* TODO: picture/gravatar */}
         <FormGroup>
           <ControlLabel htmlFor="jr-profile-edit-email">
             Email address
@@ -312,8 +313,12 @@ class OwnProfilePage extends React.Component {
             disabled
           />
           <HelpBlock>
-            This is the email address associated with your account.
+            This is the email address associated with your account.  The profile picture below is the image associated with that email address from
+            {' '}
+            <a href="https://gravatar.com">gravatar.com</a>
+            .
           </HelpBlock>
+          <Gravatar email={this.props.initialProfile.primaryEmail} />
         </FormGroup>
         {this.state.submitState === 'submitting' ? <Alert bsStyle="info">Saving...</Alert> : null}
         {this.state.submitState === 'success' ? <Alert bsStyle="success" onDismiss={this.dismissAlert}>Saved changes.</Alert> : null}

--- a/package-lock.json
+++ b/package-lock.json
@@ -532,6 +532,11 @@
         "inherits": "~2.0.0"
       }
     },
+    "blueimp-md5": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.10.0.tgz",
+      "integrity": "sha512-EkNUOi7tpV68TqjpiUz9D9NcT8um2+qtgntmMbi5UKssVX2m/2PLqotcric0RE63pB3HPN/fjf3cKHN2ufGSUQ=="
+    },
     "body-parser": {
       "version": "1.18.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.6.3",
     "@fortawesome/react-fontawesome": "^0.1.3",
     "bcrypt": "^1.0.3",
+    "blueimp-md5": "^2.10.0",
     "bootstrap": "^3.4.0",
     "classnames": "^2.2.5",
     "element-resize-detector": "^1.1.14",


### PR DESCRIPTION
We already have email addresses from profiles, so to get profile pictures from gravatar we basically just have to add an MD5 implementation (~4kB).  While many people have Google accounts which they link to their jolly-roger accounts, we don't explicitly require them, and a Google integration might involve serverside pieces, whereas the gravatar integration could be entirely clientside, so I favored using gravatars over Google profile pictures for a first-pass profile image.  If we decide we want to, we could always build such a Google integration in as well for people who link Google accounts.

I don't actually feel strongly about if this is useful or not, but I found an old TODO and figured this was low-hanging fruit so I threw it together.