### PR TITLE
Actually use retina-scale images

### DIFF
--- a/imports/client/components/App.jsx
+++ b/imports/client/components/App.jsx
@@ -34,7 +34,7 @@ class SharedNavbar extends React.Component {
         <Navbar.Header>
           <Navbar.Brand>
             <Link to="/">
-              <img src="/images/brand.png" alt="Jolly Roger logo" />
+              <img src="/images/brand.png" alt="Jolly Roger logo" srcSet="/images/brand.png 1x, /images/brand@2x.png 2x" />
             </Link>
           </Navbar.Brand>
           <this.context.navAggregator.NavBar />

--- a/imports/client/components/SplashPage.jsx
+++ b/imports/client/components/SplashPage.jsx
@@ -14,7 +14,7 @@ class SplashPage extends React.Component {
     return (
       <div className="container">
         <Jumbotron id="jr-login">
-          <Image src="/images/hero.png" className="center-block" responsive />
+          <Image src="/images/hero.png" className="center-block" responsive srcSet="/images/hero.png 1x, /images/hero@2x.png 2x" />
           <div className="container">
             <Row>
               <Col md={6} mdOffset={3}>


### PR DESCRIPTION
As it turns out, browsers don't automatically fetch @2x images; you have
to tell them to do it. This mirrors how we handled retina image tags for
the Head Hunters website.