### PR TITLE
Upgrade to simpl-schema v1.5.3

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -8,8 +8,9 @@ ecmascript@0.12.0
 ecmascript-collections
 accounts-password@1.5.1
 audit-argument-checks@1.0.7
-aldeed:collection2
-aldeed:simple-schema
+aldeed:collection2@3.0.0
+aldeed:schema-deny
+aldeed:schema-index
 nicolaslopezj:roles
 meteor-base@1.4.0
 mobile-experience@1.0.5

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -1,10 +1,8 @@
 accounts-base@1.4.3
 accounts-password@1.5.1
-aldeed:collection2@2.10.0
-aldeed:collection2-core@1.2.0
-aldeed:schema-deny@1.1.0
-aldeed:schema-index@1.1.1
-aldeed:simple-schema@1.5.4
+aldeed:collection2@3.0.1
+aldeed:schema-deny@3.0.0
+aldeed:schema-index@3.0.0
 allow-deny@1.1.0
 audit-argument-checks@1.0.7
 autoupdate@1.5.0
@@ -46,7 +44,6 @@ less@2.8.0
 livedata@1.0.18
 localstorage@1.2.0
 logging@1.1.20
-mdg:validation-error@0.2.0
 meteor@1.9.2
 meteor-base@1.4.0
 meteorhacks:cluster@1.6.9

--- a/imports/client/components/ProfilePage.jsx
+++ b/imports/client/components/ProfilePage.jsx
@@ -232,9 +232,9 @@ class OwnProfilePage extends React.Component {
       return null;
     }
 
-    const valid = ProfilesSchema.namedContext().validateOne({
+    const valid = ProfilesSchema.namedContext().validate({
       slackHandle: this.state.slackHandleValue,
-    }, 'slackHandle');
+    }, { keys: ['slackHandle'] });
     return valid ? 'success' : 'error';
   };
 

--- a/imports/lib/schemas/announcements.js
+++ b/imports/lib/schemas/announcements.js
@@ -1,21 +1,19 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 import Base from './base.js';
 
 // A broadcast message from a hunt operator to be displayed
 // to all participants in the specified hunt.
-const Announcements = new SimpleSchema([
-  Base,
-  {
-    hunt: {
-      // The hunt this announcement comes from.
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    message: {
-      // The message to be broadcast.
-      type: String,
-    },
+const Announcements = new SimpleSchema({
+  hunt: {
+    // The hunt this announcement comes from.
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
   },
-]);
+  message: {
+    // The message to be broadcast.
+    type: String,
+  },
+});
+Announcements.extend(Base);
 
 export default Announcements;

--- a/imports/lib/schemas/base.js
+++ b/imports/lib/schemas/base.js
@@ -1,4 +1,4 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 
 /* eslint-disable consistent-return */
 

--- a/imports/lib/schemas/chats.js
+++ b/imports/lib/schemas/chats.js
@@ -1,33 +1,31 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 import Base from './base.js';
 
 // A single chat message
-const ChatMessages = new SimpleSchema([
-  Base,
-  {
-    hunt: {
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    puzzle: {
-      // The puzzle to which this chat was sent.
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    text: {
-      // The message body. Plain text.
-      type: String,
-    },
-    sender: {
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-      optional: true, // If absent, this message is considered a "system" message
-    },
-    timestamp: {
-      // The date this message was sent.  Used for ordering chats in the log.
-      type: Date,
-    },
+const ChatMessages = new SimpleSchema({
+  hunt: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
   },
-]);
+  puzzle: {
+    // The puzzle to which this chat was sent.
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  text: {
+    // The message body. Plain text.
+    type: String,
+  },
+  sender: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+    optional: true, // If absent, this message is considered a "system" message
+  },
+  timestamp: {
+    // The date this message was sent.  Used for ordering chats in the log.
+    type: Date,
+  },
+});
+ChatMessages.extend(Base);
 
 export default ChatMessages;

--- a/imports/lib/schemas/document_permissions.js
+++ b/imports/lib/schemas/document_permissions.js
@@ -1,23 +1,21 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 import Base from './base.js';
 
-const DocumentPermissions = new SimpleSchema([
-  Base,
-  {
-    document: {
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    user: {
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    // This can change, so capture which one we gave permissions to
-    googleAccount: {
-      type: String,
-      regEx: SimpleSchema.RegEx.Email,
-    },
+const DocumentPermissions = new SimpleSchema({
+  document: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
   },
-]);
+  user: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  // This can change, so capture which one we gave permissions to
+  googleAccount: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Email,
+  },
+});
+DocumentPermissions.extend(Base);
 
 export default DocumentPermissions;

--- a/imports/lib/schemas/documents.js
+++ b/imports/lib/schemas/documents.js
@@ -1,30 +1,28 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 import Base from './base.js';
 
-const Documents = new SimpleSchema([
-  Base,
-  {
-    hunt: {
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    puzzle: {
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    provider: {
-      type: String,
-      allowedValues: ['google'],
-    },
-    // This is opaque to the specific provider.
-    //
-    // For provider=google, this consists of a "type" ("sheets" or
-    // "docs") and an id
-    value: {
-      type: Object,
-      blackbox: true,
-    },
+const Documents = new SimpleSchema({
+  hunt: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
   },
-]);
+  puzzle: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  provider: {
+    type: String,
+    allowedValues: ['google'],
+  },
+  // This is opaque to the specific provider.
+  //
+  // For provider=google, this consists of a "type" ("sheets" or
+  // "docs") and an id
+  value: {
+    type: Object,
+    blackbox: true,
+  },
+});
+Documents.extend(Base);
 
 export default Documents;

--- a/imports/lib/schemas/feature_flags.js
+++ b/imports/lib/schemas/feature_flags.js
@@ -1,28 +1,26 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 import Base from './base.js';
 
-const FeatureFlags = new SimpleSchema([
-  Base,
-  {
-    name: {
-      type: String,
-    },
-
-    // type represents the mode of a feature flag. If a feature flag
-    // with a given name doesn't exist, it's assumed to be of type
-    // "off"
-    type: {
-      type: String,
-      allowedValues: ['off', 'on', 'random_by'],
-    },
-
-    // random is the fraction of values that are on if type is
-    // random_by
-    random: {
-      type: Number,
-      optional: true,
-    },
+const FeatureFlags = new SimpleSchema({
+  name: {
+    type: String,
   },
-]);
+
+  // type represents the mode of a feature flag. If a feature flag
+  // with a given name doesn't exist, it's assumed to be of type
+  // "off"
+  type: {
+    type: String,
+    allowedValues: ['off', 'on', 'random_by'],
+  },
+
+  // random is the fraction of values that are on if type is
+  // random_by
+  random: {
+    type: Number,
+    optional: true,
+  },
+});
+FeatureFlags.extend(Base);
 
 export default FeatureFlags;

--- a/imports/lib/schemas/guess.js
+++ b/imports/lib/schemas/guess.js
@@ -1,59 +1,57 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 import { answerify } from '../../model-helpers.js';
 import Base from './base.js';
 
-const Guesses = new SimpleSchema([
-  Base,
-  {
-    hunt: {
-      // Denormalized in so subscriptions can filter on hunt without having to join on Puzzles
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    puzzle: {
-      // The puzzle this guess is for.
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    guess: {
-      // The text of this guess.
-      type: String,
-      autoValue() {
-        if (this.isSet) {
-          return answerify(this.value);
-        }
+const Guesses = new SimpleSchema({
+  hunt: {
+    // Denormalized in so subscriptions can filter on hunt without having to join on Puzzles
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  puzzle: {
+    // The puzzle this guess is for.
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  guess: {
+    // The text of this guess.
+    type: String,
+    autoValue() {
+      if (this.isSet) {
+        return answerify(this.value);
+      }
 
-        return undefined;
-      },
-    },
-    direction: {
-      // Whether this was forward solved (10), backwards solved (-10),
-      // or somewhere in between
-      type: Number,
-      min: -10,
-      max: 10,
-      // only optional in that old data won't have it
-      optional: true,
-    },
-    confidence: {
-      // Submitted-evaluated probability that the answer is right
-      type: Number,
-      min: 0,
-      max: 100,
-      // only optional in that old data won't have it
-      optional: true,
-    },
-    state: {
-      // The state of this guess, as handled by the operators:
-      // * 'pending' means "shows up in the operator queue"
-      // * 'correct', "incorrect", and "rejected" all mean "no longer in the operator queue"
-      // * 'incorrect' answers should be listed or at least discoverable on the puzzle page
-      // * 'correct' answers should be accompanied by an update to the corresponding puzzle's answer
-      //   field.
-      type: String,
-      allowedValues: ['pending', 'correct', 'incorrect', 'rejected'],
+      return undefined;
     },
   },
-]);
+  direction: {
+    // Whether this was forward solved (10), backwards solved (-10),
+    // or somewhere in between
+    type: SimpleSchema.Integer,
+    min: -10,
+    max: 10,
+    // only optional in that old data won't have it
+    optional: true,
+  },
+  confidence: {
+    // Submitted-evaluated probability that the answer is right
+    type: SimpleSchema.Integer,
+    min: 0,
+    max: 100,
+    // only optional in that old data won't have it
+    optional: true,
+  },
+  state: {
+    // The state of this guess, as handled by the operators:
+    // * 'pending' means "shows up in the operator queue"
+    // * 'correct', "incorrect", and "rejected" all mean "no longer in the operator queue"
+    // * 'incorrect' answers should be listed or at least discoverable on the puzzle page
+    // * 'correct' answers should be accompanied by an update to the corresponding puzzle's answer
+    //   field.
+    type: String,
+    allowedValues: ['pending', 'correct', 'incorrect', 'rejected'],
+  },
+});
+Guesses.extend(Base);
 
 export default Guesses;

--- a/imports/lib/schemas/hunts.js
+++ b/imports/lib/schemas/hunts.js
@@ -1,52 +1,54 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 import Base from './base.js';
 
-const Hunts = new SimpleSchema([
-  Base,
-  {
-    name: {
-      type: String,
-    },
-
-    // Everyone that joins the hunt will be added to these mailing
-    // lists
-    mailingLists: {
-      type: [String],
-      defaultValue: [],
-    },
-
-    // This message is displayed (as markdown) to users that are not
-    // members of this hunt. It should include instructions on how to
-    // join
-    signupMessage: {
-      type: String,
-      optional: true,
-    },
-
-    // If this is true, then any member of this hunt is allowed to add
-    // others to it. Otherwise, you must be an operator to add someone
-    // to the hunt.
-    openSignups: {
-      type: Boolean,
-      defaultValue: false,
-    },
-
-    // If this is provided, then any message sent in chat for a puzzle
-    // associated with this hunt will also be mirrored to a Slack channel
-    // with the specified name.
-    // Example value: "#firehose"
-    firehoseSlackChannel: {
-      type: String,
-      optional: true,
-    },
-
-    // If provided, then on puzzle creation and puzzle solve, we will
-    // send a message to the specified slack channel about it.
-    puzzleHooksSlackChannel: {
-      type: String,
-      optional: true,
-    },
+const Hunts = new SimpleSchema({
+  name: {
+    type: String,
   },
-]);
+
+  // Everyone that joins the hunt will be added to these mailing
+  // lists
+  mailingLists: {
+    type: Array,
+    defaultValue: [],
+  },
+
+  'mailingLists.$': {
+    type: String,
+  },
+
+  // This message is displayed (as markdown) to users that are not
+  // members of this hunt. It should include instructions on how to
+  // join
+  signupMessage: {
+    type: String,
+    optional: true,
+  },
+
+  // If this is true, then any member of this hunt is allowed to add
+  // others to it. Otherwise, you must be an operator to add someone
+  // to the hunt.
+  openSignups: {
+    type: Boolean,
+    defaultValue: false,
+  },
+
+  // If this is provided, then any message sent in chat for a puzzle
+  // associated with this hunt will also be mirrored to a Slack channel
+  // with the specified name.
+  // Example value: "#firehose"
+  firehoseSlackChannel: {
+    type: String,
+    optional: true,
+  },
+
+  // If provided, then on puzzle creation and puzzle solve, we will
+  // send a message to the specified slack channel about it.
+  puzzleHooksSlackChannel: {
+    type: String,
+    optional: true,
+  },
+});
+Hunts.extend(Base);
 
 export default Hunts;

--- a/imports/lib/schemas/pending_announcements.js
+++ b/imports/lib/schemas/pending_announcements.js
@@ -1,24 +1,22 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 import Base from './base.js';
 
 // Broadcast announcements that have not yet been viewed by a given
 // user
-const PendingAnnouncements = new SimpleSchema([
-  Base,
-  {
-    hunt: {
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    announcement: {
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    user: {
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
+const PendingAnnouncements = new SimpleSchema({
+  hunt: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
   },
-]);
+  announcement: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  user: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+});
+PendingAnnouncements.extend(Base);
 
 export default PendingAnnouncements;

--- a/imports/lib/schemas/profiles.js
+++ b/imports/lib/schemas/profiles.js
@@ -1,49 +1,47 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 import Base from './base.js';
 
 // A profile for a user.
 // Note that we're using a separate schema from users.$.profile, because there are weird
 // non-overridable allow/deny rules that mean we can't trust them to have any useful schema.
-const Profiles = new SimpleSchema([
-  Base,
-  {
-    _id: {
-      // To pass in a specific id, it must be declared in the schema.
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    primaryEmail: {
-      // Autopopulated with the first of the user's email addresses?
-      type: String,
-    },
-    googleAccount: {
-      type: String,
-      optional: true,
-    },
-    displayName: {
-      // Initial value: "".
-      type: String,
-    },
-    phoneNumber: {
-      type: String,
-      optional: true,
-    },
-    slackHandle: {
-      // Do we want to enforce that you can only have one Slack handle?  Uniqueness here might be
-      // beneficial for integration where you want to look up chat participation.
-      // Also, possibly this should be stored as Slack ID instead, and we look up your ID from your
-      // claimed handle on save with a Slack API call?
-      type: String,
-      optional: true,
-      // Format of handles is documented at
-      // https://get.slack.help/hc/en-us/articles/216360827-Change-your-username
-      regEx: /^[-A-Za-z0-9._]{0,21}$/,
-    },
-    muteApplause: {
-      type: Boolean,
-      optional: true, // lazily initialized
-    },
+const Profiles = new SimpleSchema({
+  _id: {
+    // To pass in a specific id, it must be declared in the schema.
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
   },
-]);
+  primaryEmail: {
+    // Autopopulated with the first of the user's email addresses?
+    type: String,
+  },
+  googleAccount: {
+    type: String,
+    optional: true,
+  },
+  displayName: {
+    // Initial value: "".
+    type: String,
+  },
+  phoneNumber: {
+    type: String,
+    optional: true,
+  },
+  slackHandle: {
+    // Do we want to enforce that you can only have one Slack handle?  Uniqueness here might be
+    // beneficial for integration where you want to look up chat participation.
+    // Also, possibly this should be stored as Slack ID instead, and we look up your ID from your
+    // claimed handle on save with a Slack API call?
+    type: String,
+    optional: true,
+    // Format of handles is documented at
+    // https://get.slack.help/hc/en-us/articles/216360827-Change-your-username
+    regEx: /^[-A-Za-z0-9._]{0,21}$/,
+  },
+  muteApplause: {
+    type: Boolean,
+    optional: true, // lazily initialized
+  },
+});
+Profiles.extend(Base);
 
 export default Profiles;

--- a/imports/lib/schemas/puzzles.js
+++ b/imports/lib/schemas/puzzles.js
@@ -1,38 +1,39 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 import { answerify } from '../../model-helpers.js';
 import Base from './base.js';
 
-const Puzzles = new SimpleSchema([
-  Base,
-  {
-    hunt: {
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    tags: {
-      type: [String],
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    title: {
-      type: String,
-    },
-    url: {
-      type: String,
-      optional: true,
-      regEx: SimpleSchema.RegEx.Url,
-    },
-    answer: {
-      type: String,
-      optional: true,
-      autoValue() {
-        if (this.isSet) {
-          return answerify(this.value);
-        }
+const Puzzles = new SimpleSchema({
+  hunt: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  tags: {
+    type: Array,
+  },
+  'tags.$': {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  title: {
+    type: String,
+  },
+  url: {
+    type: String,
+    optional: true,
+    regEx: SimpleSchema.RegEx.Url,
+  },
+  answer: {
+    type: String,
+    optional: true,
+    autoValue() {
+      if (this.isSet) {
+        return answerify(this.value);
+      }
 
-        return undefined;
-      },
+      return undefined;
     },
   },
-]);
+});
+Puzzles.extend(Base);
 
 export default Puzzles;

--- a/imports/lib/schemas/settings.js
+++ b/imports/lib/schemas/settings.js
@@ -1,17 +1,15 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 import Base from './base.js';
 
-const Settings = new SimpleSchema([
-  Base,
-  {
-    name: {
-      type: String,
-    },
-    value: {
-      type: Object,
-      blackbox: true,
-    },
+const Settings = new SimpleSchema({
+  name: {
+    type: String,
   },
-]);
+  value: {
+    type: Object,
+    blackbox: true,
+  },
+});
+Settings.extend(Base);
 
 export default Settings;

--- a/imports/lib/schemas/tags.js
+++ b/imports/lib/schemas/tags.js
@@ -1,18 +1,16 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 import Base from './base.js';
 
-const Tags = new SimpleSchema([
-  Base,
-  {
-    name: {
-      type: String,
-    },
-
-    hunt: {
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
+const Tags = new SimpleSchema({
+  name: {
+    type: String,
   },
-]);
+
+  hunt: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
+  },
+});
+Tags.extend(Base);
 
 export default Tags;

--- a/imports/lib/schemas/users.js
+++ b/imports/lib/schemas/users.js
@@ -1,4 +1,4 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 
 // Does not inherit from Base
 const User = new SimpleSchema({
@@ -8,7 +8,10 @@ const User = new SimpleSchema({
     regEx: /^[a-z0-9A-Z_]{3,15}$/,
   },
   emails: {
-    type: [Object],
+    type: Array,
+  },
+  'emails.$': {
+    type: Object,
   },
   'emails.$.address': {
     type: String,
@@ -30,17 +33,24 @@ const User = new SimpleSchema({
     blackbox: true,
   },
   roles: {
-    type: [String],
+    type: Array,
     optional: true,
   },
+  'roles.$': {
+    type: String,
+  },
   hunts: {
-    type: [String],
+    type: Array,
     defaultValue: [],
+  },
+  'hunts.$': {
+    type: String,
     regEx: SimpleSchema.RegEx.Id,
   },
 
   profile: {
     type: Object,
+    defaultValue: {},
   },
   'profile.operating': {
     type: Boolean,

--- a/imports/server/schemas/api_keys.js
+++ b/imports/server/schemas/api_keys.js
@@ -1,18 +1,16 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 import Base from '../../lib/schemas/base.js';
 
-const APIKeys = new SimpleSchema([
-  Base,
-  {
-    user: {
-      type: String,
-      regEx: SimpleSchema.RegEx.Id,
-    },
-    key: {
-      type: String,
-      regEx: /^[A-Za-z0-9]{32}$/,
-    },
+const APIKeys = new SimpleSchema({
+  user: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Id,
   },
-]);
+  key: {
+    type: String,
+    regEx: /^[A-Za-z0-9]{32}$/,
+  },
+});
+APIKeys.extend(Base);
 
 export default APIKeys;

--- a/imports/server/schemas/lock.js
+++ b/imports/server/schemas/lock.js
@@ -1,4 +1,4 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 
 const Lock = new SimpleSchema({
   name: {

--- a/imports/server/schemas/servers.js
+++ b/imports/server/schemas/servers.js
@@ -1,4 +1,4 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 
 const Servers = new SimpleSchema({
   // unlike most updatedAt values, this one also gets set on created

--- a/imports/server/schemas/subscribers.js
+++ b/imports/server/schemas/subscribers.js
@@ -1,4 +1,4 @@
-import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import SimpleSchema from 'simpl-schema';
 
 const Subscribers = new SimpleSchema({
   server: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -647,6 +647,11 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2225,10 +2230,215 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
+    "lodash._basecallback": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
+      "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
+      "requires": {
+        "lodash._baseisequal": "^3.0.0",
+        "lodash._bindcallback": "^3.0.0",
+        "lodash.isarray": "^3.0.0",
+        "lodash.pairs": "^3.0.0"
+      }
+    },
+    "lodash._baseeach": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash._baseeach/-/lodash._baseeach-3.0.4.tgz",
+      "integrity": "sha1-z4cGVyyhROjZ11InyZDamC+TKvM=",
+      "requires": {
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._basefind": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basefind/-/lodash._basefind-3.0.0.tgz",
+      "integrity": "sha1-srugXMZF+XLeLPkl+iv2Og9gyK4="
+    },
+    "lodash._basefindindex": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/lodash._basefindindex/-/lodash._basefindindex-3.6.0.tgz",
+      "integrity": "sha1-8IM2ChsCJBjtgbyJm+sxLiHnSk8="
+    },
+    "lodash._baseisequal": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
+      "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+      "requires": {
+        "lodash.isarray": "^3.0.0",
+        "lodash.istypedarray": "^3.0.0",
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash._baseismatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lodash._baseismatch/-/lodash._baseismatch-3.1.3.tgz",
+      "integrity": "sha1-Byj8SO+hFpnT1fLXMEnyqxPED9U=",
+      "requires": {
+        "lodash._baseisequal": "^3.0.0"
+      }
+    },
+    "lodash._basematches": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._basematches/-/lodash._basematches-3.2.0.tgz",
+      "integrity": "sha1-9H4D8H7CB4SrCWjQy2y1l+IQEVg=",
+      "requires": {
+        "lodash._baseismatch": "^3.0.0",
+        "lodash.pairs": "^3.0.0"
+      }
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
+      "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
+    },
+    "lodash.every": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.every/-/lodash.every-4.6.0.tgz",
+      "integrity": "sha1-64mYS+vENkJ5uzrvu9HKGb+mxqc="
+    },
+    "lodash.find": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
+    },
+    "lodash.findwhere": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.findwhere/-/lodash.findwhere-3.1.0.tgz",
+      "integrity": "sha1-eTfTTz6sgY3sf6lOjKXib9uhz8E=",
+      "requires": {
+        "lodash._basematches": "^3.0.0",
+        "lodash.find": "^3.0.0"
+      },
+      "dependencies": {
+        "lodash.find": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-3.2.1.tgz",
+          "integrity": "sha1-BG4xnzrOkSrGySRsf2g8XsB7Nq0=",
+          "requires": {
+            "lodash._basecallback": "^3.0.0",
+            "lodash._baseeach": "^3.0.0",
+            "lodash._basefind": "^3.0.0",
+            "lodash._basefindindex": "^3.0.0",
+            "lodash.isarray": "^3.0.0",
+            "lodash.keys": "^3.0.0"
+          }
+        }
+      }
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "http://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+    },
+    "lodash.isobject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
+    },
     "lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.istypedarray": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.istypedarray/-/lodash.istypedarray-3.0.6.tgz",
+      "integrity": "sha1-yaR3SYYHUB2OhJTSg7h8OSgc72I="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
+      }
+    },
+    "lodash.merge": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
+      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ=="
+    },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
+    "lodash.pairs": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
+      "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
+      "requires": {
+        "lodash.keys": "^3.0.0"
+      }
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
+    },
+    "lodash.template": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
+      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
+      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "requires": {
+        "lodash._reinterpolate": "~3.0.0"
+      }
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "lodash.without": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz",
+      "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
     },
     "logfmt": {
       "version": "1.2.1",
@@ -2276,6 +2486,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "message-box": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/message-box/-/message-box-0.2.0.tgz",
+      "integrity": "sha512-SPLfVDEM2YcAgV2IB0B5vOGjvqXSSw7ZibEeXcff8HYpxyG1Uj+XjgnGUGyR1C0EQCvPI3MBx3p7opt2CIQ2hw==",
+      "requires": {
+        "lodash.merge": "^4.6.0",
+        "lodash.template": "^4.4.0"
+      }
     },
     "methods": {
       "version": "1.1.2",
@@ -2331,6 +2550,17 @@
       "version": "2.23.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.23.0.tgz",
       "integrity": "sha512-3IE39bHVqFbWWaPOMHZF98Q9c3LDKGTmypMiTM2QygGXXElkFWIH7GxfmlwmY2vwa+wmNsoYZmG2iusf1ZjJoA=="
+    },
+    "mongo-object": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/mongo-object/-/mongo-object-0.1.3.tgz",
+      "integrity": "sha512-m3vs+a1JkvRXELJMe2ieMmBe03NUy6bctGjWicRhReYj8brDi0ojKHLKLmXWr/RupNaFP8Q7/x8xG8GpFtp9wg==",
+      "requires": {
+        "lodash.foreach": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isobject": "^3.0.2",
+        "lodash.without": "^4.4.0"
+      }
     },
     "ms": {
       "version": "2.0.0",
@@ -3360,6 +3590,27 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simpl-schema": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/simpl-schema/-/simpl-schema-1.5.3.tgz",
+      "integrity": "sha512-J24gSh39gBc3TYRFgaWx81bRf9unNML9u3dTAgxL1KI3F9JOv+Z29yEbosJFqmHfuuZ3K7ET/tTQKX4r4+f8/w==",
+      "requires": {
+        "clone": "^2.1.1",
+        "extend": "^3.0.1",
+        "lodash.every": "^4.6.0",
+        "lodash.find": "^4.6.0",
+        "lodash.findwhere": "^3.1.0",
+        "lodash.includes": "^4.3.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isobject": "^3.0.2",
+        "lodash.omit": "^4.5.0",
+        "lodash.pick": "^4.4.0",
+        "lodash.union": "^4.6.0",
+        "lodash.uniq": "^4.5.0",
+        "message-box": "^0.2.0",
+        "mongo-object": "^0.1.3"
+      }
     },
     "slice-ansi": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-select": "^2.2.0",
     "react-split-pane": "^0.1.85",
     "react-textarea-autosize": "^7.1.0",
+    "simpl-schema": "^1.5.3",
     "url": "^0.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The aldeed:simple-schema atmosphere package has been replaced with the simpl-schema NPM package. Catch us up and make the requisite API updates for a few rounds of backwards-incompatible changes.

The version numbering here is kind of confusing - when the package moved to NPM, the version numbering reset, so simpl-schema v1.5.3 is actually 2 major version bumps ahead of the version we're currently running (aldeed:simple-schema@1.5.4 :see_no_evil:).

The requisite changlog entries are the [2.0.0 pseudo-update for the atmosphere package](https://github.com/aldeed/meteor-simple-schema/blob/master/CHANGELOG.md#200), and the [full changelog for the NPM package](https://github.com/aldeed/simple-schema-js/blob/master/CHANGELOG.md).

Here's a quick run through of how those translated to code changes:
- Schemas can no longer inherit in the constructor; chaining has to happen by explicitly calling `schema.extend(...)`.
- Schemas no longer support the `type: [String]` syntax. Instead you have to declare an array, and the type of array members.
- There's some weirdness around `defaultValue` and object types - the tl;dr is that if you want a default value on a sub-object key, the sub-object itself has to be declared as `defaultValue: {}`
- There's no longer a `validateOne` method.
- Schemas using regexes are materialized using simpl-schema's union type support, so we can't dig into them as easily for `asReactPropTypes`. I handled this by switching to the [`getQuickTypeForKey` method](https://github.com/aldeed/simple-schema-js/blob/6213070e0e1bcb8b1e2cb515cba51dc3b5abfeb6/package/lib/SimpleSchema.js#L253-L262) which has all the precision we had before.

This looks worse than it is, and is definitely best reviewed with `?w=1`