### PR TITLE
Fix breadcrumbs and guess queue announcement whitespace

### DIFF
--- a/imports/client/components/AllProfileListPage.jsx
+++ b/imports/client/components/AllProfileListPage.jsx
@@ -30,6 +30,7 @@ class AllProfileListPage extends React.Component {
         itemKey="users"
         to="/users"
         label="Users"
+        depth={0}
       >
         {body}
       </this.context.navAggregator.NavItem>

--- a/imports/client/components/AnnouncementsPage.jsx
+++ b/imports/client/components/AnnouncementsPage.jsx
@@ -147,6 +147,7 @@ class AnnouncementsPage extends React.Component {
         itemKey="announcements"
         to={`/hunts/${this.props.params.huntId}/announcements`}
         label="Announcements"
+        depth={2}
       >
         {this.renderPage()}
       </this.context.navAggregator.NavItem>

--- a/imports/client/components/GuessQueuePage.jsx
+++ b/imports/client/components/GuessQueuePage.jsx
@@ -160,8 +160,9 @@ class GuessQueuePage extends React.Component {
     return (
       <this.context.navAggregator.NavItem
         itemKey="guessqueue"
-        to={`/hunts/${this.props.params.huntId}/announcements`}
+        to={`/hunts/${this.props.params.huntId}/guesses`}
         label="Guess queue"
+        depth={2}
       >
         {this.renderPage()}
       </this.context.navAggregator.NavItem>

--- a/imports/client/components/HuntListPage.jsx
+++ b/imports/client/components/HuntListPage.jsx
@@ -451,6 +451,7 @@ class HuntListPage extends React.Component {
         itemKey="hunts"
         to="/hunts"
         label="Hunts"
+        depth={0}
       >
         <div id="jr-hunts">
           <h1>Hunts</h1>

--- a/imports/client/components/HuntProfileListPage.jsx
+++ b/imports/client/components/HuntProfileListPage.jsx
@@ -42,6 +42,7 @@ class HuntProfileListPage extends React.Component {
         itemKey="hunters"
         to={`/hunts/${this.props.params.huntId}/hunters`}
         label="Hunters"
+        depth={2}
       >
         {this.renderBody()}
       </this.context.navAggregator.NavItem>

--- a/imports/client/components/NotificationCenter.jsx
+++ b/imports/client/components/NotificationCenter.jsx
@@ -101,8 +101,11 @@ class GuessMessage extends React.PureComponent {
         <MessengerContent dismissable>
           <div>
             Guess for
+            {' '}
             <a href={this.props.puzzle.url} target="_blank" rel="noopener noreferrer">{this.props.puzzle.title}</a>
+            {' '}
             from
+            {' '}
             {this.props.guesser}
             :
             {' '}

--- a/imports/client/components/SetupPage.jsx
+++ b/imports/client/components/SetupPage.jsx
@@ -790,6 +790,7 @@ class SetupPageRewrite extends React.Component {
         itemKey="setup"
         to="/setup"
         label="Server setup"
+        depth={0}
       >
         {this.renderBody()}
       </this.context.navAggregator.NavItem>


### PR DESCRIPTION
I give up on trying to rely on mount order to determine breadcrumb sorting.  Let's just hardcode the sort orders everywhere we register breadcrumbs, since we don't even reuse page layouts at different places in the routes hierarchy.  (We might want to do that for the user profile route, but we don't right now, and it probably doesn't matter much.)

There was a breadcrumb that actually linked to the wrong page, but it never got used as a link so nobody ever noticed, until it was sorted out of order and then I clicked the link and it went the wrong place and I noticed.

Also, the guess-queue announcement used to not have breaking whitespace between a number of spans which looked bad.  I added spaces so they don't look ridiculous and can line-break.