### PR TITLE
Redesign view filters / top UI on puzzle list page

### DIFF
--- a/client/stylesheets/puzzlelist.scss
+++ b/client/stylesheets/puzzlelist.scss
@@ -2,8 +2,44 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: space-between;
   flex-wrap: wrap;
+
+  ul {
+    margin-bottom: 0;
+  }
+}
+
+.puzzle-view-controller {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+@media (max-width: 767px) {
+  .puzzle-list-controls {
+    flex-direction: column-reverse;
+    align-items: flex-start;
+
+    ul {
+      padding-left: 12px;
+      margin-bottom: 8px;
+    }
+  }
+}
+
+.puzzle-view-controls {
+  display: flex;
+  flex-wrap: wrap;
+
+  .btn-toolbar {
+    margin-right: 4px;
+    margin-bottom: 4px;
+  }
+
+  .form-group {
+    flex: 1 1 auto;
+    min-width: 250px;
+  }
 }
 
 .puzzle-list-show-solved {
@@ -11,6 +47,12 @@
   flex-direction: column;
   align-items: left;
   justify-content: flex-start;
+}
+
+.add-puzzle-content {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
 }
 
 .puzzle-list-ungrouped {

--- a/imports/client/components/PuzzleListPage.jsx
+++ b/imports/client/components/PuzzleListPage.jsx
@@ -3,13 +3,13 @@ import { _ } from 'meteor/underscore';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Button from 'react-bootstrap/lib/Button';
-import Checkbox from 'react-bootstrap/lib/Checkbox';
+import ButtonToolbar from 'react-bootstrap/lib/ButtonToolbar';
 import ControlLabel from 'react-bootstrap/lib/ControlLabel';
 import FormControl from 'react-bootstrap/lib/FormControl';
 import FormGroup from 'react-bootstrap/lib/FormGroup';
 import InputGroup from 'react-bootstrap/lib/InputGroup';
-import Nav from 'react-bootstrap/lib/Nav';
-import NavItem from 'react-bootstrap/lib/NavItem';
+import ToggleButton from 'react-bootstrap/lib/ToggleButton';
+import ToggleButtonGroup from 'react-bootstrap/lib/ToggleButtonGroup';
 import { Link, browserHistory } from 'react-router';
 import { withTracker } from 'meteor/react-meteor-data';
 import subsCache from '../subsCache.js';
@@ -258,10 +258,10 @@ class PuzzleListView extends React.Component {
     });
   };
 
-  changeShowSolved = (event) => {
-    this.setState({
-      showSolved: event.target.checked,
-    });
+  changeShowSolved = () => {
+    this.setState(oldState => ({
+      showSolved: !oldState.showSolved,
+    }));
   };
 
   showAddModal = () => {
@@ -316,7 +316,7 @@ class PuzzleListView extends React.Component {
       }
     }
     const addPuzzleContent = this.props.canAdd && (
-      <div>
+      <div className="add-puzzle-content">
         <Button bsStyle="primary" onClick={this.showAddModal}>Add a puzzle</Button>
         <PuzzleModalForm
           huntId={this.props.huntId}
@@ -329,49 +329,48 @@ class PuzzleListView extends React.Component {
     return (
       <div>
         <div className="puzzle-list-controls">
-          <span>View puzzles by:</span>
-          <Nav activeKey={this.state.displayMode} bsStyle="pills" onSelect={this.switchView}>
-            <NavItem eventKey="group">Group</NavItem>
-            <NavItem eventKey="unlock">Unlock order</NavItem>
-          </Nav>
-          <div className="puzzle-list-show-solved">
-            <div>
-              <Checkbox checked={this.state.showSolved} onChange={this.changeShowSolved}>
-                Show solved
-              </Checkbox>
+          <div className="puzzle-view-controller">
+            <ControlLabel htmlFor="jr-puzzle-search">View puzzles by:</ControlLabel>
+            <div className="puzzle-view-controls">
+              <ButtonToolbar>
+                <ToggleButtonGroup type="radio" name="puzzle-view" defaultValue="group" value={this.state.displayMode} onChange={this.switchView}>
+                  <ToggleButton value="group">Group</ToggleButton>
+                  <ToggleButton value="unlock">Unlock</ToggleButton>
+                </ToggleButtonGroup>
+                <ToggleButtonGroup
+                  type="checkbox"
+                  value={this.state.showSolved}
+                  onChange={this.changeShowSolved}
+                >
+                  <ToggleButton value>Show solved</ToggleButton>
+                </ToggleButtonGroup>
+              </ButtonToolbar>
+              <FormGroup>
+                <InputGroup>
+                  <FormControl
+                    id="jr-puzzle-search"
+                    type="text"
+                    inputRef={this.searchBarRef}
+                    placeholder="Filter by title, answer, or tag"
+                    value={this.getSearchString()}
+                    onChange={this.onSearchStringChange}
+                  />
+                  <InputGroup.Button>
+                    <Button onClick={this.clearSearch}>
+                      Clear
+                    </Button>
+                  </InputGroup.Button>
+                </InputGroup>
+              </FormGroup>
             </div>
           </div>
-          {addPuzzleContent}
-          <div>
-            <ul>
-              <li><Link to={`/hunts/${this.props.huntId}/announcements`}>Announcements</Link></li>
-              <li><Link to={`/hunts/${this.props.huntId}/guesses`}>Guesses</Link></li>
-              <li><Link to={`/hunts/${this.props.huntId}/hunters`}>Hunters</Link></li>
-            </ul>
-          </div>
+          <ul>
+            <li><Link to={`/hunts/${this.props.huntId}/announcements`}>Announcements</Link></li>
+            <li><Link to={`/hunts/${this.props.huntId}/guesses`}>Guesses</Link></li>
+            <li><Link to={`/hunts/${this.props.huntId}/hunters`}>Hunters</Link></li>
+          </ul>
         </div>
-
-        <FormGroup>
-          <ControlLabel htmlFor="jr-puzzle-search">
-            Search
-          </ControlLabel>
-          <InputGroup>
-            <FormControl
-              id="jr-puzzle-search"
-              type="text"
-              inputRef={this.searchBarRef}
-              placeholder="search by title, answer, or tag"
-              value={this.getSearchString()}
-              onChange={this.onSearchStringChange}
-            />
-            <InputGroup.Button>
-              <Button onClick={this.clearSearch}>
-                Clear
-              </Button>
-            </InputGroup.Button>
-          </InputGroup>
-        </FormGroup>
-
+        {addPuzzleContent}
         {bodyComponent}
       </div>
     );


### PR DESCRIPTION
Search bar is moved inline with the other view filters. View filters all
become toggle buttons instead of the nav pills + checkbox thing previously.

Add puzzle button is now on its own row.

On small screens, the announcements/guesses/hunters links move to the top.

Before, mobile:
<img width="403" alt="screen shot 2019-01-12 at 22 28 49" src="https://user-images.githubusercontent.com/689247/51082341-14c9ac00-16ba-11e9-91b8-396e905c1ea3.png">

After, mobile:
<img width="447" alt="screen shot 2019-01-12 at 22 28 34" src="https://user-images.githubusercontent.com/689247/51082339-0a0f1700-16ba-11e9-8700-cb813386bd25.png">

Before, desktop:
<img width="1331" alt="screen shot 2019-01-12 at 22 29 00" src="https://user-images.githubusercontent.com/689247/51082345-1eebaa80-16ba-11e9-8dc4-70d62a863a08.png">

After, desktop:
<img width="1331" alt="screen shot 2019-01-12 at 22 29 15" src="https://user-images.githubusercontent.com/689247/51082346-257a2200-16ba-11e9-8c89-9ca8e95dba65.png">
