### PR TITLE
Reduce puzzle list padding, set min height, center

### DIFF
--- a/client/stylesheets/puzzle.css
+++ b/client/stylesheets/puzzle.css
@@ -1,3 +1,0 @@
-.puzzle-group-header:hover {
-    cursor: pointer;
-}

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -6,6 +6,10 @@
 
 .puzzle-group-header {
   display: block;
+  &:hover {
+    cursor: pointer;
+  }
+  min-height: 32px;
 }
 
 .puzzle-list-wrapper {
@@ -33,9 +37,10 @@
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
-  align-items: baseline;
+  align-items: center;
   justify-content: flex-start;
-  padding: 4px;
+  padding-left: 4px;
+  min-height: 32px;
 
   .puzzle-title {
     flex: 1 0 35%;


### PR DESCRIPTION
Why was there a separate puzzle.css file?  I'm not sure, but I've folded it's
contents back into the .scss file.

All the rows should now be 32px tall, whether they have tags or not.

Fixes #189.

Before:
![screenshot_20190113_005951](https://user-images.githubusercontent.com/307325/51083407-87dd1d80-16ce-11e9-9316-52aa2bb4250d.png)


After:
![screenshot_20190113_005928](https://user-images.githubusercontent.com/307325/51083401-7ac02e80-16ce-11e9-8f14-b41e06093f54.png)

