### PR TITLE
Make sure list of tag IDs is unique

### DIFF
--- a/imports/lib/models/puzzles.js
+++ b/imports/lib/models/puzzles.js
@@ -1,9 +1,14 @@
+import { _ } from 'meteor/underscore';
 import { huntsMatchingCurrentUser } from '../../model-helpers.js';
 import Base from './base.js';
 import PuzzlesSchema from '../schemas/puzzles.js';
 import ActiveOperatorRole from '../active-operator-role.js';
 
-const Puzzles = new Base('puzzles');
+const Puzzles = new Base('puzzles', {
+  transform(doc) {
+    return _.extend({}, doc, { tags: _.uniq(doc.tags) });
+  },
+});
 Puzzles.attachSchema(PuzzlesSchema);
 Puzzles.publish(huntsMatchingCurrentUser);
 

--- a/imports/server/fixture.js
+++ b/imports/server/fixture.js
@@ -42,10 +42,12 @@ Meteor.methods({
       }, {
         $set: {
           hunt: huntId,
-          tags: puzzle.tags,
           title: puzzle.title,
           url: puzzle.url,
           answer: puzzle.answer,
+        },
+        $addToSet: {
+          tags: { $each: puzzle.tags },
         },
       });
     });

--- a/imports/server/puzzle.js
+++ b/imports/server/puzzle.js
@@ -48,7 +48,7 @@ Meteor.methods({
       user: this.userId,
     });
 
-    const fullPuzzle = _.extend({}, puzzle, { _id: Random.id(), tags: tagIds });
+    const fullPuzzle = _.extend({}, puzzle, { _id: Random.id(), tags: _.uniq(tagIds) });
 
     // By creating the document before we save the puzzle, we make
     // sure nobody else has a chance to create a document with the
@@ -95,7 +95,7 @@ Meteor.methods({
     });
     Puzzles.update(
       puzzleId,
-      { $set: _.extend({}, puzzle, { tags: tagIds }) },
+      { $set: _.extend({}, puzzle, { tags: _.uniq(tagIds) }) },
     );
 
     if (oldPuzzle.title !== puzzle.title) {


### PR DESCRIPTION
This tries to ensure that the list of tags doesn't end up with
duplicates, preferably on the server side, but in the worst case
cleaning them up client-side.

Fixes #180.

I ended up doing this instead of consolidating around `addTag[s]ToPuzzle` and `removeTag[s]FromPuzzle` because you'd still have to compute what you were adding/removing and that seemed annoying.