### PR TITLE
Make it possible to link directly to guess submission page

### DIFF
--- a/imports/client/components/HuntListPage.jsx
+++ b/imports/client/components/HuntListPage.jsx
@@ -55,6 +55,7 @@ class HuntModalForm extends React.Component {
         mailingLists: this.props.hunt.mailingLists.join(', ') || '',
         signupMessage: this.props.hunt.signupMessage || '',
         openSignups: this.props.hunt.openSignups || false,
+        submitTemplate: this.props.hunt.submitTemplate || '',
         firehoseSlackChannel: this.props.hunt.firehoseSlackChannel || '',
         puzzleHooksSlackChannel: this.props.hunt.puzzleHooksSlackChannel || '',
       });
@@ -64,6 +65,7 @@ class HuntModalForm extends React.Component {
         mailingLists: '',
         signupMessage: '',
         openSignups: false,
+        submitTemplate: '',
         firehoseSlackChannel: '',
         puzzleHooksSlackChannel: '',
       });
@@ -93,6 +95,12 @@ class HuntModalForm extends React.Component {
       openSignups: e.target.checked,
     });
   };
+
+  onSubmitTemplateChanged = (e) => {
+    this.setState({
+      submitTemplate: e.target.value,
+    });
+  }
 
   onFirehoseSlackChannelChanged = (e) => {
     this.setState({
@@ -209,6 +217,45 @@ class HuntModalForm extends React.Component {
             </HelpBlock>
           </div>
         </FormGroup>
+
+        <FormGroup>
+          <ControlLabel htmlFor={`${idPrefix}submit-template`} className="col-xs-3">
+            Submit URL template
+          </ControlLabel>
+          <div className="col-xs-9">
+            <FormControl
+              id={`${idPrefix}submit-template`}
+              type="text"
+              value={this.state.submitTemplate}
+              onChange={this.onSubmitTemplateChanged}
+              disabled={disableForm}
+            />
+            <HelpBlock>
+              If provided, this
+              {' '}
+              <a href="https://mustache.github.io/mustache.5.html">Mustache template</a>
+              {' '}
+              is used to generate the link to the guess submission page. It gets as context a
+              {' '}
+              <a href="https://developer.mozilla.org/en-US/docs/Web/API/URL">parsed URL</a>
+              {', '}
+              providing variables like
+              {' '}
+              <code>hostname</code>
+              {' '}
+              or
+              {' '}
+              <code>pathname</code>
+              {'. '}
+              Because this will be used as a link directly, make sure to use &quot;triple-mustaches&quot; so that the URL components aren&apos;t escaped. As an example, setting this to
+              {' '}
+              <code>{'{{{origin}}}/submit{{{pathname}}}'}</code>
+              {' '}
+              would work for the 2018 Mystery Hunt. If not specified, the puzzle URL is used as the link to the guess submission page.
+            </HelpBlock>
+          </div>
+        </FormGroup>
+
 
         <FormGroup>
           <ControlLabel htmlFor={`${idPrefix}firehose-slack-channel`} className="col-xs-3">

--- a/imports/lib/schemas/hunts.js
+++ b/imports/lib/schemas/hunts.js
@@ -33,6 +33,16 @@ const Hunts = new SimpleSchema({
     defaultValue: false,
   },
 
+  // If this is provided, then this is used to generate links to puzzles' guess
+  // submission pages. The format is interpreted as a Mustache template
+  // (https://mustache.github.io/). It's passed as context a parsed URL
+  // (https://nodejs.org/api/url.html#url_class_url), which provides variables
+  // like "host" and "pathname".
+  submitTemplate: {
+    type: String,
+    optional: true,
+  },
+
   // If this is provided, then any message sent in chat for a puzzle
   // associated with this hunt will also be mirrored to a Slack channel
   // with the specified name.

--- a/imports/model-helpers.js
+++ b/imports/model-helpers.js
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { _ } from 'meteor/underscore';
+import Mustache from 'mustache';
 
 
 const answerify = function (answer) {
@@ -35,4 +36,13 @@ const huntsMatchingCurrentUser = function (origQuery) {
   return q;
 };
 
-export { answerify, huntsMatchingCurrentUser };
+const guessURL = function (hunt, puzzle) {
+  if (!hunt.submitTemplate) {
+    return puzzle.url;
+  }
+
+  const url = new URL(puzzle.url);
+  return Mustache.render(hunt.submitTemplate, url);
+};
+
+export { answerify, huntsMatchingCurrentUser, guessURL };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2572,6 +2572,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "mustache": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
+      "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA=="
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "logfmt": "^1.2.0",
     "marked": "^0.5.2",
     "moment": "^2.23.0",
+    "mustache": "^3.0.1",
     "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-addons-pure-render-mixin": "^15.2.1",


### PR DESCRIPTION
I decided to use Mustache because it felt better than coming up with my own variable substitution code. I think that this does accomplish what we need, although it's not the most user-friendly thing imaginable. Maybe that's OK.

Minor note: It looks like the [API in question](https://developer.mozilla.org/en-US/docs/Web/API/URL) may not be supported in IE11, so we may want to grab a polyfill (a la https://www.npmjs.com/package/url-polyfill)

Fixes #181.