### PR TITLE
Require Slack handle in profile form

### DIFF
--- a/imports/client/components/ProfilePage.jsx
+++ b/imports/client/components/ProfilePage.jsx
@@ -349,25 +349,9 @@ class OwnProfilePage extends React.Component {
           </HelpBlock>
         </FormGroup>
 
-        <FormGroup>
-          <ControlLabel htmlFor="jr-profile-edit-phone">
-            Phone number (optional)
-          </ControlLabel>
-          <FormControl
-            id="jr-profile-edit-phone"
-            type="text"
-            value={this.state.phoneNumberValue}
-            disabled={shouldDisableForm}
-            onChange={this.handlePhoneNumberFieldChange}
-          />
-          <HelpBlock>
-            In case we need to reach you via phone.
-          </HelpBlock>
-        </FormGroup>
-
         <FormGroup validationState={this.getSlackHandleValidationState()}>
           <ControlLabel htmlFor="jr-profile-edit-slack">
-            Slack handle (optional)
+            Slack handle
           </ControlLabel>
           <FormControl
             id="jr-profile-edit-slack"
@@ -381,6 +365,22 @@ class OwnProfilePage extends React.Component {
             {' '}
             <code>@</code>
             .)
+          </HelpBlock>
+        </FormGroup>
+
+        <FormGroup>
+          <ControlLabel htmlFor="jr-profile-edit-phone">
+            Phone number (optional)
+          </ControlLabel>
+          <FormControl
+            id="jr-profile-edit-phone"
+            type="text"
+            value={this.state.phoneNumberValue}
+            disabled={shouldDisableForm}
+            onChange={this.handlePhoneNumberFieldChange}
+          />
+          <HelpBlock>
+            In case we need to reach you via phone.
           </HelpBlock>
         </FormGroup>
 

--- a/imports/lib/schemas/profiles.js
+++ b/imports/lib/schemas/profiles.js
@@ -32,7 +32,6 @@ const Profiles = new SimpleSchema({
     // Also, possibly this should be stored as Slack ID instead, and we look up your ID from your
     // claimed handle on save with a Slack API call?
     type: String,
-    optional: true,
     // Format of handles is documented at
     // https://get.slack.help/hc/en-us/articles/216360827-Change-your-username
     regEx: /^[-A-Za-z0-9._]{0,21}$/,

--- a/imports/lib/schemas/profiles.js
+++ b/imports/lib/schemas/profiles.js
@@ -32,6 +32,7 @@ const Profiles = new SimpleSchema({
     // Also, possibly this should be stored as Slack ID instead, and we look up your ID from your
     // claimed handle on save with a Slack API call?
     type: String,
+    optional: true,
     // Format of handles is documented at
     // https://get.slack.help/hc/en-us/articles/216360827-Change-your-username
     regEx: /^[-A-Za-z0-9._]{0,21}$/,


### PR DESCRIPTION
Per Slack conversation with @ebroder:

In practice, JR requires Slack handles.  Update the profile form to reflect this.  Also, move Slack handle above (still optional) phone number.