### PR TITLE
Puzzle list control CSS fixes.

### DIFF
--- a/client/stylesheets/puzzlelist.scss
+++ b/client/stylesheets/puzzlelist.scss
@@ -24,6 +24,10 @@
       padding-left: 12px;
       margin-bottom: 8px;
     }
+
+    .puzzle-view-controller {
+      width: 100%;
+    }
   }
 }
 
@@ -38,7 +42,7 @@
 
   .form-group {
     flex: 1 1 auto;
-    min-width: 250px;
+    width: 250px;
   }
 }
 


### PR DESCRIPTION
Fixes two glitches in puzzle list controls CSS:
- On Safari, the text field always started on the next line instead of flowing alongside the buttons.
- The text field did not expand to fill available space when the window was narrower than 768px but still wide enough for the buttons and text field on the same line.