### PR TITLE
Add horizontal padding in side panes

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -275,7 +275,8 @@ table.puzzle-list {
 
 .chat-message {
   background-color: #f8f8f8;
-  margin-bottom: 1px;
+  padding: 0 6px;
+  margin-bottom: 2px;
   word-wrap: break-word;
   &.system-message {
     background-color: #e0e0e0;
@@ -286,6 +287,11 @@ table.puzzle-list {
   float: right;
   font-style: italic;
   margin-right: 2px;
+}
+
+// Related puzzles
+.related-puzzles-section {
+  padding: 2px 6px;
 }
 
 // Puzzle metadata

--- a/imports/client/components/PuzzlePage.jsx
+++ b/imports/client/components/PuzzlePage.jsx
@@ -414,9 +414,10 @@ const chatInputStyles = {
     // input to accomodate its contents.
     // The default Chrome stylesheet has line-height set to a plain number.
     // We work around the Chrome bug by setting an explicit sized line-height for the textarea.
-    lineHeight: '14px',
+    lineHeight: '16px',
     flex: 'none',
-    padding: '9px',
+    padding: '9px 6px',
+    borderWidth: '1px 0 0 0',
     resize: 'none',
     maxHeight: '200px',
   },


### PR DESCRIPTION
Chat was difficult to read on platforms with frameless windows, as the text ran into the window edge.  This adds slight padding to chat messages and adjusts the textarea to match.  Also applies similar padding to related puzzles.

Additionally, increases the line-height on the textarea to accommodate its font size.  Unfortunately, the textarea uses a font-size of 16px to prevent iOS Safari from zooming, so the textarea formatting doesn't precisely match the messages above it (at font-size 14px).  One workaround would be applying the 16px font-size only in mobile Safari.