### PR TITLE
Improved functionality on tablets.

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -379,8 +379,14 @@ table.puzzle-list {
 }
 
 .puzzle-document > .gdrive-embed {
-  width: 100%;
-  height: 100%;
+  /* Workaround for unusual sizing behavior of iframes in iOS Safari */
+  /* Width and height need to be specified in px then adjusted by min and max */
+  width: 0px;
+  height: 0px;
+  min-width: 100%;
+  max-width: 100%;
+  min-height: 100%;
+  max-height: 100%;
   position: absolute;
   top: 0;
   right: 0;

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -140,10 +140,12 @@ table.puzzle-list {
 }
 
 .tag {
-  display: inline-block;
-  margin: 2px;
-  padding: 2px;
-  border-radius: 2px;
+  display: inline-flex;
+  align-items: center;
+  line-height: 24px;
+  margin: 2px 4px 2px 0;
+  padding: 0 6px;
+  border-radius: 4px;
   background-color: #ddd;
   color: #000;
   &.tag-administrivia {
@@ -179,7 +181,7 @@ table.puzzle-list {
   display: inline-block;
   vertical-align: middle;
   text-align: center;
-  margin: 0 0 0 4px;
+  margin: 0 0 0 6px;
 }
 
 /*Guessing and History Modal */
@@ -310,10 +312,6 @@ table.puzzle-list {
   justify-content: space-between;
 }
 
-.puzzle-metadata-title-set {
-  flex:1;
-}
-
 .puzzle-metadata-title {
   font-weight: bold;
 }
@@ -322,30 +320,25 @@ table.puzzle-list {
   cursor: pointer;
 }
 
-.puzzle-metadata-answer, .puzzle-metadata .tag {
+.puzzle-metadata-answer {
   display: flex;
   align-items: center;
   line-height: 24px;
   margin: 2px 0;
   padding: 0 6px;
   border-radius: 4px;
-}
-
-.puzzle-metadata-answer {
   background-color: #00ff00;
   color: #000000;
 }
 
 .puzzle-metadata .tag-list {
   display: flex;
+  flex-grow: 1;
   justify-content: flex-start;
   align-items: flex-start;
   align-content: flex-start;
   flex-wrap: wrap;
-}
-
-.puzzle-metadata .tag {
-  margin-right: 4px;
+  margin-left: 4px;
 }
 
 .puzzle-metadata-row .btn {

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -182,10 +182,6 @@ table.puzzle-list {
   margin: 0 0 0 4px;
 }
 
-.tag-list .btn.tag-modify-button {
-  margin: 0;
-}
-
 /*Guessing and History Modal */
 .guess-history-table td.answer {
   word-break: break-all;
@@ -289,6 +285,10 @@ table.puzzle-list {
   margin-right: 2px;
 }
 
+.chat-section textarea {
+  border-radius: 0;
+}
+
 // Related puzzles
 .related-puzzles-section {
   padding: 2px 6px;
@@ -297,58 +297,21 @@ table.puzzle-list {
 // Puzzle metadata
 .puzzle-metadata {
   flex: none;
-  padding-bottom: 2px;
+  padding: 2px 4px;
 }
 
 .puzzle-metadata-row {
   display: flex;
-  min-height: 26px;
-  padding: 0 4px;
-  vertical-align: middle;
+  width: 100%;
+  font-size: 14px;
+  line-height: 28px;
+  align-items: flex-start;
+  align-content: flex-start;
+  justify-content: space-between;
 }
 
-.puzzle-metadata-tag-editor-row {
-  min-height: 46px;
-  align-items: center;
-}
-
-.puzzle-metadata-left {
-  flex: 1 1 auto;
-  padding: 4px;
-  order: 1;
-}
-
-.puzzle-metadata-right {
-  flex: 1 .2 auto;
-  margin: 4px;
-  text-align: right;
-  order: 2;
-}
-
-.puzzle-metadata-tags {
-  display: inline-block;
-  height: 24px;
-}
-
-.puzzle-metadata-answer {
-  display: inline-block;
-  padding: 2px;
-  border-radius: 2px;
-  background-color: #00ff00;
-  color: #000000;
-  margin: 0 4px;
-}
-
-.puzzle-metadata-row .btn {
-  height: 24px;
-  padding: 2px 4px;
-  display: inline-block;
-  margin: 2px;
-}
-
-.puzzle-metadata-external-link-button, .gdrive-button {
-  display: inline-block;
-  font-weight: bold;
+.puzzle-metadata-title-set {
+  flex:1;
 }
 
 .puzzle-metadata-title {
@@ -359,8 +322,47 @@ table.puzzle-list {
   cursor: pointer;
 }
 
+.puzzle-metadata-answer, .puzzle-metadata .tag {
+  display: flex;
+  align-items: center;
+  line-height: 24px;
+  margin: 2px 0;
+  padding: 0 6px;
+  border-radius: 4px;
+}
+
+.puzzle-metadata-answer {
+  background-color: #00ff00;
+  color: #000000;
+}
+
+.puzzle-metadata .tag-list {
+  display: flex;
+  justify-content: flex-start;
+  align-items: flex-start;
+  align-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.puzzle-metadata .tag {
+  margin-right: 4px;
+}
+
+.puzzle-metadata-row .btn {
+  line-height: 22px;
+  padding: 0 6px;
+  margin: 2px 0;
+  border-width: 1px;
+  display: inline-block;
+}
+
+.puzzle-metadata .puzzle-metadata-external-link-button, .puzzle-metadata .gdrive-button {
+  display: inline-block;
+  font-weight: bold;
+}
+
 @media (any-pointer: fine) {
-  .tablet-only {
+  .puzzle-metadata .tablet-only {
     display: none;
   }
 }

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -359,6 +359,12 @@ table.puzzle-list {
   cursor: pointer;
 }
 
+@media (any-pointer: fine) {
+  .tablet-only {
+    display: none;
+  }
+}
+
 .puzzle-document {
   width: 100%;
   height: 100%;

--- a/imports/client/components/DeepLink.jsx
+++ b/imports/client/components/DeepLink.jsx
@@ -19,7 +19,8 @@ class DeepLink extends React.Component {
     }
   };
 
-  onClick = () => {
+  onClick = (e) => {
+    e.preventDefault();
     // window.orientation is a good proxy for mobile device
     if (window.orientation) {
       this.setState({ state: 'attemptingNative', startNativeLoad: new Date() });

--- a/imports/client/components/Documents.jsx
+++ b/imports/client/components/Documents.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import Button from 'react-bootstrap/lib/Button';
 import DeepLink from './DeepLink';
 import DocumentsSchema from '../../lib/schemas/documents';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 
 class GoogleDocumentDisplay extends React.Component {
   static propTypes = {
@@ -40,6 +42,8 @@ class GoogleDocumentDisplay extends React.Component {
           <DeepLink className="gdrive-button" nativeUrl={deepUrl} browserUrl={url}>
             <a href="#">
               {title}
+              {' '}
+              <FontAwesomeIcon fixedWidth icon={faExternalLinkAlt} />
             </a>
           </DeepLink>
         );

--- a/imports/client/components/Documents.jsx
+++ b/imports/client/components/Documents.jsx
@@ -1,10 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Button from 'react-bootstrap/lib/Button';
-import DeepLink from './DeepLink';
-import DocumentsSchema from '../../lib/schemas/documents';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
+import DeepLink from './DeepLink';
+import DocumentsSchema from '../../lib/schemas/documents';
 
 class GoogleDocumentDisplay extends React.Component {
   static propTypes = {
@@ -40,7 +39,7 @@ class GoogleDocumentDisplay extends React.Component {
       case 'link':
         return (
           <DeepLink className="gdrive-button" nativeUrl={deepUrl} browserUrl={url}>
-            <a href="#">
+            <a href={url} target="new">
               {title}
               {' '}
               <FontAwesomeIcon fixedWidth icon={faExternalLinkAlt} />

--- a/imports/client/components/Documents.jsx
+++ b/imports/client/components/Documents.jsx
@@ -18,11 +18,11 @@ class GoogleDocumentDisplay extends React.Component {
       case 'spreadsheet':
         url = `https://docs.google.com/spreadsheets/d/${this.props.document.value.id}/edit?ui=2&rm=embedded#gid=0`;
         deepUrl = `googlesheets://${url}`;
-        title = 'worksheet';
+        title = 'Worksheet';
         break;
       case 'document':
         url = `https://docs.google.com/document/d/${this.props.document.value.id}/edit?ui=2&rm=embedded#gid=0`;
-        title = 'document';
+        title = 'Document';
         break;
       default:
         return (
@@ -38,11 +38,9 @@ class GoogleDocumentDisplay extends React.Component {
       case 'link':
         return (
           <DeepLink className="gdrive-button" nativeUrl={deepUrl} browserUrl={url}>
-            <Button>
-              Open
-              {' '}
+            <a href="#">
               {title}
-            </Button>
+            </a>
           </DeepLink>
         );
       case 'embed':

--- a/imports/client/components/Documents.jsx
+++ b/imports/client/components/Documents.jsx
@@ -46,8 +46,9 @@ class GoogleDocumentDisplay extends React.Component {
           </DeepLink>
         );
       case 'embed':
+        /* To workaround iOS Safari iframe behavior, scrolling should be "no" */
         return (
-          <iframe title="document" className="gdrive-embed" src={url} />
+          <iframe title="document" className="gdrive-embed" scrolling="no" src={url} />
         );
       default:
         return (

--- a/imports/client/components/PuzzlePage.jsx
+++ b/imports/client/components/PuzzlePage.jsx
@@ -15,8 +15,8 @@ import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Table from 'react-bootstrap/lib/Table';
 import Tooltip from 'react-bootstrap/lib/Tooltip';
 import DocumentTitle from 'react-document-title';
-import { faEdit } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEdit, faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import classnames from 'classnames';
 import marked from 'marked';
 import moment from 'moment';
@@ -684,12 +684,10 @@ class PuzzlePageMetadata extends React.Component {
     const isAdministrivia = _.findWhere(tags, { name: 'administrivia' });
     const answerComponent = this.props.puzzle.answer ? (
       <span className="puzzle-metadata-answer">
-        Solved:
-        {' '}
         <span className="answer">{this.props.puzzle.answer}</span>
       </span>
     ) : null;
-    const hideViewCount = this.props.puzzle.answer || this.props.subcountersDisabled;
+    const hideViewCount = this.props.subcountersDisabled;
     const guessesString = `${this.props.guesses.length ? this.props.guesses.length : 'no'} guesses`;
     return (
       <div className="puzzle-metadata">
@@ -701,61 +699,54 @@ class PuzzlePageMetadata extends React.Component {
           tags={this.props.allTags}
           onSubmit={this.onEdit}
         />
-        <div>
-          <div className="puzzle-metadata-row">
-            <div className="puzzle-metadata-right">
-              {this.props.document && (
-                <span className={classnames(this.props.isDesktop && 'tablet-only')}>
-                  <DocumentDisplay document={this.props.document} displayMode="link" />
-                </span>
-              )}
-              {this.props.puzzle.url && (
-                <a
-                  className="puzzle-metadata-external-link-button"
-                  href={this.props.puzzle.url}
-                  target="_blank"
-                  rel="noreferrer noopener"
-                >
-                  Puzzle
-                </a>
-              )}
-            </div>
-            <div className="puzzle-metadata-left">
-              {this.editButton()}
-              {' '}
-              {this.props.isDesktop &&
-                <span className="puzzle-metadata-title">{this.props.puzzle.title}</span>}
-              {' '}
-              {this.props.puzzle.answer && answerComponent}
-              {' '}
-              {!hideViewCount && (
-                <ViewCountDisplayContainer
-                  count={this.props.viewCount}
-                  name={`puzzle:${this.props.puzzle._id}`}
-                />
-              )}
-            </div>
-          </div>
-          <div className={classnames('puzzle-metadata-row', this.props.isDesktop && 'puzzle-metadata-tag-editor-row')}>
-            {!isAdministrivia && (
-              <div className="puzzle-metadata-right">
-                <Button className="puzzle-metadata-guess-button" onClick={this.showGuessModal}>
-                  {this.props.puzzle.answer ? `View ${guessesString}` : `Submit answer (${guessesString})`}
-                </Button>
-              </div>
-            )}
-            <div className="puzzle-metadata-left">
-              <span className="puzzle-metadata-tags">Tags:</span>
-              <TagList
-                puzzleId={this.props.puzzle._id}
-                tags={tags}
-                onCreateTag={this.onCreateTag}
-                onRemoveTag={this.onRemoveTag}
-                linkToSearch={false}
-                showControls={this.props.isDesktop}
+        <div className="puzzle-metadata-row">
+          <div className="puzzle-metadata-title-set">
+            {this.editButton()}
+            {' '}
+            <span className="puzzle-metadata-title">{this.props.puzzle.title}</span>
+            {' '}
+            {!hideViewCount && (
+              <ViewCountDisplayContainer
+                count={this.props.viewCount}
+                name={`puzzle:${this.props.puzzle._id}`}
               />
-            </div>
+            )}
           </div>
+          {this.props.puzzle.answer && answerComponent}
+        </div>
+        <div className={classnames('puzzle-metadata-row', this.props.isDesktop && 'puzzle-metadata-tag-editor-row')}>
+          <TagList
+            puzzleId={this.props.puzzle._id}
+            tags={tags}
+            onCreateTag={this.onCreateTag}
+            onRemoveTag={this.onRemoveTag}
+            linkToSearch={false}
+            showControls={this.props.isDesktop}
+          />
+        </div>
+        <div className="puzzle-metadata-row">
+          {this.props.puzzle.url && (
+            <a
+              className="puzzle-metadata-external-link-button"
+              href={this.props.puzzle.url}
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              Puzzle
+              {' '}
+              <FontAwesomeIcon fixedWidth icon={faExternalLinkAlt} />
+            </a>
+          )}
+          {this.props.document && (
+            <span className={classnames(this.props.isDesktop && 'tablet-only')}>
+              <DocumentDisplay document={this.props.document} displayMode="link" />
+            </span>
+          )}
+          {!isAdministrivia && (
+            <Button className="puzzle-metadata-guess-button" onClick={this.showGuessModal}>
+              {this.props.puzzle.answer ? `View ${guessesString}` : `Submit answer (${guessesString})`}
+            </Button>
+          )}
         </div>
         <PuzzleGuessModal
           ref={this.guessModalRef}

--- a/imports/client/components/PuzzlePage.jsx
+++ b/imports/client/components/PuzzlePage.jsx
@@ -715,6 +715,7 @@ class PuzzlePageMetadata extends React.Component {
           {this.props.puzzle.answer && answerComponent}
         </div>
         <div className={classnames('puzzle-metadata-row', this.props.isDesktop && 'puzzle-metadata-tag-editor-row')}>
+          <div className="puzzle-metadata-tags-label">Tags: </div>
           <TagList
             puzzleId={this.props.puzzle._id}
             tags={tags}

--- a/imports/client/components/PuzzlePage.jsx
+++ b/imports/client/components/PuzzlePage.jsx
@@ -704,6 +704,11 @@ class PuzzlePageMetadata extends React.Component {
         <div>
           <div className="puzzle-metadata-row">
             <div className="puzzle-metadata-right">
+              {this.props.document && (
+                <span className={classnames(this.props.isDesktop && 'tablet-only')}>
+                  <DocumentDisplay document={this.props.document} displayMode="link" />
+                </span>
+              )}
               {this.props.puzzle.url && (
                 <a
                   className="puzzle-metadata-external-link-button"
@@ -720,8 +725,6 @@ class PuzzlePageMetadata extends React.Component {
               {' '}
               {this.props.isDesktop &&
                 <span className="puzzle-metadata-title">{this.props.puzzle.title}</span>}
-              {!this.props.isDesktop && this.props.document &&
-                <DocumentDisplay document={this.props.document} displayMode="link" />}
               {' '}
               {this.props.puzzle.answer && answerComponent}
               {' '}


### PR DESCRIPTION
Addresses #192.

On tablets and phones, Google loads a static html view in browsers, instead of the live editable version and I have found no way to force it do otherwise.  (On phones this makes no difference as there isn't space for the document anyway.)  As a workaround, this offers a link to open the document in the native app.  The link is not shown on devices with fine pointer control and is always shown on windows too small to load the document (as it always was).  On iPads, it's then possible to keep Safari open in narrow mode side-by-side with the native Sheets app, replicating the full JR experience.

(The static view unfortunately also renders slightly incorrectly, but this appears to simply be a bug in Google Sheets: The tab switcher is absolutely positioned as through the title bar were present, but that seems to be automatically hidden when embedded.)

Unrelatedly, iOS has unusual rules for sizing iframes.  This created scrolling problems on tablets for the static view that Google loads.  This is worked around with some odd CSS sizing and a scrolling=no attribute.

Finally, because the addition of this link made the puzzle metadata pane even more crowded, it's been reorganized somewhat and cleaned up with more consistent sizing and layout.  It is difficult to adjust the height of the react-select used to add tags, so the appearance is disrupted somewhat when that element is visible, and I would appreciate an assist with that if time permits.

Tested in narrow, wide (tablet), and wide (desktop) modes.  Open to suggestions, of course.