### PR TITLE
Make more user-provided content line-breakable

### DIFF
--- a/client/stylesheets/guessqueue.scss
+++ b/client/stylesheets/guessqueue.scss
@@ -18,6 +18,10 @@
 
 .guess-info {
   flex: 1 0 50%;
+  overflow-x: hidden;
+  .breakable {
+    word-wrap: break-word;
+  }
 }
 
 .guess-button-group {

--- a/client/stylesheets/notifications.scss
+++ b/client/stylesheets/notifications.scss
@@ -59,12 +59,17 @@ ul.notifications {
     }
 
     .content {
+      overflow-x: hidden; // overflow-wrap on children just overflows the box without this
       padding-left: 10px;
       padding-right: 10px;
       padding-top: 10px;
       padding-bottom: 10px;
       &.dismissable {
         padding-right: 32px;
+      }
+
+      .breakable {
+        word-wrap: break-word;
       }
 
       ul.actions {

--- a/imports/client/components/GuessQueuePage.jsx
+++ b/imports/client/components/GuessQueuePage.jsx
@@ -96,7 +96,7 @@ class GuessBlock extends React.Component {
           <div>
             {timestamp}
             {' from '}
-            {this.props.createdByDisplayName || '<no name given>'}
+            <span className="breakable">{this.props.createdByDisplayName || '<no name given>'}</span>
           </div>
           <div>
             {'Puzzle: '}

--- a/imports/client/components/NotificationCenter.jsx
+++ b/imports/client/components/NotificationCenter.jsx
@@ -110,10 +110,10 @@ class GuessMessage extends React.PureComponent {
             {' '}
             from
             {' '}
-            {this.props.guesser}
+            <span className="breakable">{this.props.guesser}</span>
             :
             {' '}
-            {this.props.guess.guess}
+            <span className="breakable">{this.props.guess.guess}</span>
           </div>
           <div>
             <OverlayTrigger placement="bottom" overlay={directionTooltip}>


### PR DESCRIPTION
In particular, break display names and answer queue submissions in the
notifications and the guess queue page.

Fixes #185.

Before:

![screenshot_20190117_143326](https://user-images.githubusercontent.com/307325/51353226-da1e9580-1a64-11e9-90b3-d798fd5d408e.png)

![screenshot_20190117_143342](https://user-images.githubusercontent.com/307325/51353241-e3a7fd80-1a64-11e9-993c-f1762b9177e5.png)


After:

![screenshot_20190117_143202](https://user-images.githubusercontent.com/307325/51353173-a80d3380-1a64-11e9-8a53-cffcfbc855f2.png)

![screenshot_20190117_143249](https://user-images.githubusercontent.com/307325/51353199-c3783e80-1a64-11e9-981b-e4ca7b69801d.png)
