### PR TITLE
Swap back to callback refs for `FormControl`

### DIFF
--- a/imports/client/components/PuzzleListPage.jsx
+++ b/imports/client/components/PuzzleListPage.jsx
@@ -52,11 +52,10 @@ class PuzzleListView extends React.Component {
   constructor(props) {
     super(props);
     this.addModalRef = React.createRef();
-    this.searchBarRef = React.createRef();
   }
 
   componentDidMount() {
-    this.searchBarRef.current.focus();
+    this.searchBarRef.focus();
   }
 
   onAdd = (state, callback) => {
@@ -350,7 +349,7 @@ class PuzzleListView extends React.Component {
                   <FormControl
                     id="jr-puzzle-search"
                     type="text"
-                    inputRef={this.searchBarRef}
+                    inputRef={(ref) => { this.searchBarRef = ref; }}
                     placeholder="Filter by title, answer, or tag"
                     value={this.getSearchString()}
                     onChange={this.onSearchStringChange}


### PR DESCRIPTION
It's documented at
https://react-bootstrap.github.io/components/forms/#forms-props-form-control as
only working with callback refs, so we can't use the `React.createRef()` API
here.

This was breaking autofocus on the input bar on page load.  It was also throwing a console warning on every pageload of the puzzle list page.