### PR TITLE
Tweak chat pane

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -272,10 +272,10 @@ table.puzzle-list {
 }
 
 .chat-message {
-  background-color: #f8f8f8;
-  padding: 0 6px;
+  padding: 0 4px;
   margin-bottom: 2px;
   word-wrap: break-word;
+  font-size: 14px;
   &.system-message {
     background-color: #e0e0e0;
   }
@@ -284,7 +284,8 @@ table.puzzle-list {
 .chat-timestamp {
   float: right;
   font-style: italic;
-  margin-right: 2px;
+  font-size: 12px;
+  color: #666666;
 }
 
 .chat-section textarea {
@@ -293,7 +294,7 @@ table.puzzle-list {
 
 // Related puzzles
 .related-puzzles-section {
-  padding: 2px 6px;
+  padding: 2px 4px;
 }
 
 // Puzzle metadata


### PR DESCRIPTION
Addresses #214.

* Drop that kinda-grey background; it's not helpful.
* Steal a couple pixels back from the gutters.
* Also steal those pixels back from the related puzzles section.
* Make chat timestamps less emphasized -- smaller text, lighter grey

We should also increase the template google spreadsheet's default font size to ~14px (10.5pt).