### PR TITLE
Fix CSS glitches involving breaks and wrapping

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -319,6 +319,7 @@ table.puzzle-list {
 
 .puzzle-metadata .view-count {
   cursor: pointer;
+  white-space: nowrap;
 }
 
 .puzzle-metadata-answer {
@@ -350,9 +351,21 @@ table.puzzle-list {
   display: inline-block;
 }
 
+.puzzle-metadata-action-row {
+  flex-wrap: wrap;
+}
+
 .puzzle-metadata .puzzle-metadata-external-link-button, .puzzle-metadata .gdrive-button {
   display: inline-block;
   font-weight: bold;
+  white-space: nowrap;
+  /* On very small touch screens or split view, desperately try to prevent line wrap */
+  /* Revisit this */
+  @media (max-width: 320px) and (pointer: coarse) {
+    svg {
+      display: none;
+    }
+  }
 }
 
 @media (any-pointer: fine) {

--- a/imports/client/components/PuzzlePage.jsx
+++ b/imports/client/components/PuzzlePage.jsx
@@ -422,7 +422,7 @@ const chatInputStyles = {
     // We work around the Chrome bug by setting an explicit sized line-height for the textarea.
     lineHeight: '16px',
     flex: 'none',
-    padding: '9px 6px',
+    padding: '9px 4px',
     borderWidth: '1px 0 0 0',
     resize: 'none',
     maxHeight: '200px',
@@ -731,7 +731,7 @@ class PuzzlePageMetadata extends React.Component {
             showControls={this.props.isDesktop}
           />
         </div>
-        <div className="puzzle-metadata-row">
+        <div className="puzzle-metadata-row puzzle-metadata-action-row">
           {this.props.puzzle.url && (
             <a
               className="puzzle-metadata-external-link-button"


### PR DESCRIPTION
Three fixes:
- Viewer count and external links can no longer be broken by line wraps
- The metadata action row could be slightly too long on narrow phones (or iPad split view).  Adjusted the flex to wrap in the worst case and solve the problem in most cases by simply hiding the external link icons.  (I would rather hide the number of guesses so far, but that's actually a little trickier, so this is fine for now.)
- Match the chat textarea padding to the content above it.