### PR TITLE
Try to fix a render failure

### DIFF
--- a/imports/client/components/PuzzleListPage.jsx
+++ b/imports/client/components/PuzzleListPage.jsx
@@ -156,8 +156,11 @@ class PuzzleListView extends React.Component {
       let grouped = false;
       for (let j = 0; j < puzzle.tags.length; j++) {
         const tag = tagsByIndex[puzzle.tags[j]];
-        if (tag.name === 'administrivia' ||
-            tag.name.lastIndexOf('group:', 0) === 0) {
+        // On new puzzle creation, if a tag s new as well, we can receive the new Puzzle object (and
+        // rerender) before the new Tag object streams in, so it's possible that we don't have a tag
+        // object for a given ID, and that tag here will be undefined.
+        if (tag && tag.name && (tag.name === 'administrivia' ||
+            tag.name.lastIndexOf('group:', 0) === 0)) {
           grouped = true;
           if (!groupsMap[tag._id]) {
             groupsMap[tag._id] = [];


### PR DESCRIPTION
When adding new puzzles, we often create new tags at the same time.  The Puzzle
can arrive over DDP before the Tag, so there's a window where we might render
with a tag ID for which we don't have a corresponding Tag object.  Annoyingly,
this makes React drop all future rendering and the user has to refresh the page
to recover.

Attempt to work around this by guarding the dereference on the tag actually
existing.