### PR TITLE
Guard more instances of tag name lookup by id against weird load order

### DIFF
--- a/imports/client/components/Puzzle.jsx
+++ b/imports/client/components/Puzzle.jsx
@@ -73,8 +73,8 @@ class Puzzle extends React.PureComponent {
     const linkTarget = `/hunts/${this.props.puzzle.hunt}/puzzles/${this.props.puzzle._id}`;
     const tagIndex = _.indexBy(this.props.allTags, '_id');
     const shownTags = _.difference(this.props.puzzle.tags, this.props.suppressTags || []);
-    const ownTags = shownTags.map((tagId) => { return tagIndex[tagId]; });
-    const isAdministrivia = _.find(this.props.puzzle.tags, (t) => { return tagIndex[t].name === 'administrivia'; });
+    const ownTags = _.compact(shownTags.map((tagId) => { return tagIndex[tagId]; }));
+    const isAdministrivia = _.find(this.props.puzzle.tags, (t) => { return tagIndex[t] && tagIndex[t].name === 'administrivia'; });
 
     const puzzleClasses = classnames('puzzle',
       this.props.puzzle.answer ? 'solved' : 'unsolved',

--- a/imports/client/components/PuzzleListPage.jsx
+++ b/imports/client/components/PuzzleListPage.jsx
@@ -96,8 +96,9 @@ class PuzzleListView extends React.Component {
         }
 
         for (let j = 0; j < puzzle.tags.length; j++) {
-          const tagName = tagNames[puzzle.tags[j]].name;
-          if (tagName.indexOf(key) !== -1) {
+          const tag = tagNames[puzzle.tags[j]];
+          const tagName = tag && tag.name;
+          if (tagName && tagName.indexOf(key) !== -1) {
             return true;
           }
         }

--- a/imports/client/components/PuzzleListPage.jsx
+++ b/imports/client/components/PuzzleListPage.jsx
@@ -233,15 +233,21 @@ class PuzzleListView extends React.Component {
       const puzzle = puzzles[i];
       for (let j = 0; j < puzzle.tags.length; j++) {
         const tag = indexedTags[puzzle.tags[j]];
-        if (metaForTag && tag.name === metaForTag) {
-          // This puzzle is meta-for: the group.
-          if (puzzle.answer) {
-            return 2;
-          } else {
-            return -2;
+
+        if (tag) {
+          // tag may be undefined if we get tag IDs before the new Tag arrives from the server;
+          // ignore such tags for sorting purposes
+
+          if (metaForTag && tag.name === metaForTag) {
+            // This puzzle is meta-for: the group.
+            if (puzzle.answer) {
+              return 2;
+            } else {
+              return -2;
+            }
+          } else if ((tag.name === 'is:meta' || tag.name.lastIndexOf('meta-for:', 0) === 0) && !puzzle.answer) {
+            hasUnsolvedMeta = true;
           }
-        } else if ((tag.name === 'is:meta' || tag.name.lastIndexOf('meta-for:', 0) === 0) && !puzzle.answer) {
-          hasUnsolvedMeta = true;
         }
       }
     }

--- a/imports/client/components/PuzzlePage.jsx
+++ b/imports/client/components/PuzzlePage.jsx
@@ -685,7 +685,7 @@ class PuzzlePageMetadata extends React.Component {
 
   render() {
     const tagsById = _.indexBy(this.props.allTags, '_id');
-    const tags = this.props.puzzle.tags.map((tagId) => { return tagsById[tagId]; });
+    const tags = _.compact(this.props.puzzle.tags.map((tagId) => { return tagsById[tagId]; }));
     const isAdministrivia = _.findWhere(tags, { name: 'administrivia' });
     const answerComponent = this.props.puzzle.answer ? (
       <span className="puzzle-metadata-answer">

--- a/imports/client/components/RelatedPuzzleGroups.jsx
+++ b/imports/client/components/RelatedPuzzleGroups.jsx
@@ -78,9 +78,9 @@ class RelatedPuzzleGroups extends React.Component {
 
     // TODO: sort the tag groups by tag interestingness, which should probably be related to meta
     // presence/absence, tag group size, and number of solved/unsolved?
-    const activePuzzleTags = this.sortedTagsForRelatedPuzzles(_.map(this.props.activePuzzle.tags, (tagId) => {
+    const activePuzzleTags = this.sortedTagsForRelatedPuzzles(_.compact(_.map(this.props.activePuzzle.tags, (tagId) => {
       return tagIndex[tagId];
-    }));
+    })));
 
     for (let tagi = 0; tagi < activePuzzleTags.length; tagi++) {
       const tag = activePuzzleTags[tagi];

--- a/imports/client/components/puzzleInterestingness.js
+++ b/imports/client/components/puzzleInterestingness.js
@@ -11,22 +11,31 @@ function puzzleInterestingness(puzzle, indexedTags, group) {
 
   for (let i = 0; i < puzzle.tags.length; i++) {
     const tag = indexedTags[puzzle.tags[i]];
-    if (tag.name.lastIndexOf('group:', 0) === 0) {
-      isGroup = true;
-    }
-    if (tag.name === 'administrivia') {
-      // First comes any administrivia
-      minScore = Math.min(-4, minScore);
-      isAdministrivia = true;
-    } else if (desiredTagName && tag.name === desiredTagName) {
-      // Matching meta gets sorted top.
-      minScore = Math.min(-3, minScore);
-    } else if (tag.name === 'is:metameta') {
-      // Metameta sorts above meta.
-      minScore = Math.min(-2, minScore);
-    } else if (tag.name === 'is:meta') {
-      // Meta sorts above non-meta.
-      minScore = Math.min(-1, minScore);
+
+    if (tag) {
+      // Sometimes tag IDs load on puzzles before the Tag documents make it to the client.  In this
+      // case, tag will wind up undefined.  It'll get fixed on rerender as soon as the tag object
+      // loads, so just pretend that tag doesn't exist if the join from id -> Tag object here
+      // comes back undefined.
+
+      if (tag.name.lastIndexOf('group:', 0) === 0) {
+        isGroup = true;
+      }
+
+      if (tag.name === 'administrivia') {
+        // First comes any administrivia
+        minScore = Math.min(-4, minScore);
+        isAdministrivia = true;
+      } else if (desiredTagName && tag.name === desiredTagName) {
+        // Matching meta gets sorted top.
+        minScore = Math.min(-3, minScore);
+      } else if (tag.name === 'is:metameta') {
+        // Metameta sorts above meta.
+        minScore = Math.min(-2, minScore);
+      } else if (tag.name === 'is:meta') {
+        // Meta sorts above non-meta.
+        minScore = Math.min(-1, minScore);
+      }
     }
   }
   // Sort general administrivia above administrivia with a group


### PR DESCRIPTION
I've seen both of these callsites crash the React renderer.  I'm hopeful
they're the last for this particular failure mode; I don't think I see other
places where we're doing the client-side join from tag id -> `Tag`.