### PR TITLE
Bump bootstrap version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1207,9 +1207,9 @@
       }
     },
     "bootstrap": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.0.tgz",
-      "integrity": "sha512-F1yTDO9OHKH0xjl03DsOe8Nu1OWBIeAugGMhy3UTIYDdbbIPesQIhCEbj+HEr6wqlwweGAlP8F3OBC6kEuhFuw=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+      "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@fortawesome/react-fontawesome": "^0.1.3",
     "bcrypt": "^1.0.3",
     "blueimp-md5": "^2.10.0",
-    "bootstrap": "^3.4.0",
+    "bootstrap": "^3.4.1",
     "classnames": "^2.2.5",
     "element-resize-detector": "^1.1.14",
     "express": "^4.14.0",


### PR DESCRIPTION
Addresses [CVE-2019-8331](https://nvd.nist.gov/vuln/detail/CVE-2019-8331), which I think probably doesn't affect us, but this will make Github stop yelling at me.