### PR TITLE
Exclude the _id field from the SimpleSchema

### DIFF
--- a/imports/lib/schemas/base.ts
+++ b/imports/lib/schemas/base.ts
@@ -4,6 +4,8 @@ import SimpleSchema from 'simpl-schema';
 import { buildSchema, Overrides } from './typedSchemas';
 
 export const BaseCodec = t.type({
+  // Note: _id is part of the type, but does not get copied into the schema
+  // because it creates weird behavior (c.f. aldeed/meteor-collection2#124)
   _id: t.string,
   deleted: t.boolean,
   createdAt: date,
@@ -15,9 +17,6 @@ export const BaseCodec = t.type({
 export type BaseType = t.TypeOf<typeof BaseCodec>;
 
 export const BaseOverrides: Overrides<BaseType> = {
-  _id: {
-    regEx: SimpleSchema.RegEx.Id,
-  },
   deleted: {
     autoValue() {
       if (this.isSet) {

--- a/imports/lib/schemas/typedSchemas.ts
+++ b/imports/lib/schemas/typedSchemas.ts
@@ -220,6 +220,11 @@ export const buildSchema = function <
 ): SimpleSchema {
   const schema: Record<string, FieldDefinition<any>> = {};
   Object.keys(schemaCodec.props).forEach((k) => {
+    // Don't include the _id field in the schema, as it makes some operations
+    // validate strangely (c.f. aldeed/meteor-collection2#124)
+    if (k === '_id') {
+      return;
+    }
     const fields = buildField(k, schemaCodec.props[k], overrides[k]);
     fields.forEach(([name, definition]) => {
       schema[name] = definition;


### PR DESCRIPTION
We need to have _id as part of the type so that we can access the field,
but we don't want to declare it as part of the schema. The validation
logic in collection2 doesn't handle the fact that _id is auto-populated
well, so it causes spurious validation errors.