### PR TITLE
Loosen the types on collection.insert

### DIFF
--- a/imports/lib/models/base.ts
+++ b/imports/lib/models/base.ts
@@ -31,6 +31,13 @@ class Base<T extends BaseType> extends Mongo.Collection<T> {
     this.attachRoles(`mongo.${name}`);
   }
 
+  // Because the Mongo.Collection doesn't know about SimpleSchema autovalues, it
+  // doesn't know which fields are actually required. This is a coarse
+  // workaround, but it's hard to pick the autoValue out from just the types.
+  insert(doc: Partial<T>, callback?: Function): string {
+    return super.insert(<any>doc, callback);
+  }
+
   // All models have a destroy method which performs any cascading
   // required (though since all models also have a "deleted" property
   // that hides all children, the default implementation usually


### PR DESCRIPTION
Because we're using SimpleSchema autoValues in a lot of cases, those
fields aren't actually required for inserts. But the type specification
for insert requires a full object, and there's no way to communicate
through the types that some types are auto-populated (i.e. required to
be present on read, but not on write).

Work around this by overriding the type for insert to be significantly
looser. This is actually loose to the point of being technically unsafe,
but there's no way in the type layer to tell which fields have autoValue
specified and which don't.