### PR TITLE
Fix rendering of breadcrumbs, broken in #256

### DIFF
--- a/client/stylesheets/breadcrumbs.scss
+++ b/client/stylesheets/breadcrumbs.scss
@@ -31,7 +31,7 @@
   }
 }
 
-.jolly-roger .nav-breadcrumbs * {
+.jolly-roger .nav-breadcrumbs li {
   display: inline-block; // Apply ellipsis as needed to make fit on mobile
   white-space: nowrap;
   overflow: hidden;

--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -58,7 +58,7 @@ class SharedNavbar extends React.Component<SharedNavbarProps> {
                       );
                     } else {
                       return (
-                        <RRBS.LinkContainer key={crumb.path} to={crumb.path}>
+                        <RRBS.LinkContainer key={crumb.path} to={crumb.path} onlyActiveOnIndex>
                           <BreadcrumbItem active={false}>
                             {crumb.title}
                           </BreadcrumbItem>


### PR DESCRIPTION
LinkContainer decides whether or not a given link is active, and then
forces a value for the active prop onto its child (ugh). By default, it
considers itself "active" even when its on a child page, but
onlyActiveOnIndex overrides that behavior, ensuring that it only
considers itself active unless we're actually on /hunts/:hunt (which we
never are - we always redirect to puzzles, but it's easy to go from
active=false to active=true and hard to go the other way).

(Also fix the styling, which was getting mis-applied to the wrong
elements)