### PR TITLE
Lighten announcement and guess subscriptions

### DIFF
--- a/imports/client/components/AnnouncementsPage.tsx
+++ b/imports/client/components/AnnouncementsPage.tsx
@@ -181,12 +181,8 @@ const crumb = withBreadcrumb(({ params }: AnnouncementsPageParamsProps) => {
   return { title: 'Announcements', path: `/hunts/${params.huntId}/announcements` };
 });
 const tracker = withTracker(({ params }: AnnouncementsPageParamsProps) => {
-  // We already have subscribed to mongo.announcements on the main page, since we want to be able
-  // to show them on any page.  So we don't *need* to make the subscription here...
-  // ...except that we might want to wait to render until we've received all of them?  IDK.
-  const announcementsHandle = subsCache.subscribe('mongo.announcements', { hunt: params.huntId });
-  const displayNamesHandle = Profiles.subscribeDisplayNames(subsCache);
-  const ready = announcementsHandle.ready() && displayNamesHandle.ready();
+  const announcementsHandle = subsCache.subscribe('announcements.all', params.huntId);
+  const ready = announcementsHandle.ready();
 
   let announcements: AnnouncementType[];
   let displayNames: Record<string, string>;

--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -199,17 +199,8 @@ const crumb = withBreadcrumb(({ params }: GuessQueuePageParams) => {
   return { title: 'Guess queue', path: `/hunts/${params.huntId}/guesses` };
 });
 const tracker = withTracker(({ params }: GuessQueuePageParams) => {
-  const huntHandle = subsCache.subscribe('mongo.hunts', {
-    _id: params.huntId,
-  });
-  const guessesHandle = subsCache.subscribe('mongo.guesses', {
-    hunt: params.huntId,
-  });
-  const puzzlesHandle = subsCache.subscribe('mongo.puzzles', {
-    hunt: params.huntId,
-  });
-  const displayNamesHandle = Profiles.subscribeDisplayNames(subsCache);
-  const ready = huntHandle.ready() && guessesHandle.ready() && puzzlesHandle.ready() && displayNamesHandle.ready();
+  const guessesHandle = subsCache.subscribe('guesses.all');
+  const ready = guessesHandle.ready();
   const data: Pick<GuessQueuePageProps, Exclude<keyof GuessQueuePageProps, keyof GuessQueuePageParams>> = {
     ready,
     guesses: [],

--- a/imports/lib/schemas/puzzles.ts
+++ b/imports/lib/schemas/puzzles.ts
@@ -26,7 +26,7 @@ const PuzzleFieldsOverrides: Overrides<t.TypeOf<typeof PuzzleFields>> = {
   },
   answer: {
     autoValue() {
-      if (this.isSet && this.value) {
+      if (this.isSet && this.operator !== '$unset' && this.value) {
         return answerify(this.value);
       }
 


### PR DESCRIPTION
Historically, we've made overly broad subscriptions to have information
ambiently available to us. But that results in fairly heavy data fetches
on initial page load (e.g. we fetch all puzzles just in case there's a
pending guess).

By pushing some of the logic to the server, and having a more specific
subscription, we can significantly tighten the scope of data that we
have to fetch.