### PR TITLE
Switch meteor method arguments to unknown

### DIFF
--- a/imports/flags.ts
+++ b/imports/flags.ts
@@ -8,9 +8,9 @@ if (Meteor.isClient) {
 }
 
 const Flags = {
-  active(name: string, shard?: string) {
+  active(name: unknown, shard?: unknown) {
     check(name, String);
-    check(shard, Match.Optional(String));
+    check(shard, Match.Maybe(String));
 
     const flag = FeatureFlags.findOne({ name });
     if (!flag) {

--- a/imports/server/announcements.ts
+++ b/imports/server/announcements.ts
@@ -6,7 +6,7 @@ import Announcements from '../lib/models/announcements';
 import PendingAnnouncements from '../lib/models/pending_announcements';
 
 Meteor.methods({
-  postAnnouncement(huntId, message) {
+  postAnnouncement(huntId: unknown, message: unknown) {
     check(this.userId, String);
     check(huntId, String);
     check(message, String);

--- a/imports/server/ansible.ts
+++ b/imports/server/ansible.ts
@@ -2,7 +2,8 @@ import { Meteor } from 'meteor/meteor';
 import { Match, check } from 'meteor/check';
 import logfmt from 'logfmt';
 
-const logLevels = new Set(['log', 'info', 'error', 'warn']);
+type LogLevels = 'log' | 'info' | 'error' | 'warn';
+const logLevels: Set<LogLevels> = new Set(['log', 'info', 'error', 'warn']);
 
 Meteor.methods({
   // ansible just lets clients generate log messages on the server,
@@ -10,18 +11,14 @@ Meteor.methods({
   //
   // Log lines are output using `logfmt` to make parsing and analysis
   // easier.
-  ansible(level: 'log' | 'info' | 'error' | 'warn', line: string, obj: object) {
-    check(level, String);
+  ansible(level: unknown, line: unknown, obj: unknown) {
+    check(level, Match.OneOf(...logLevels));
     check(line, String);
     check(obj, Match.Optional(Object));
 
     // this.connection is null for server calls, which we allow
     if (!this.userId && this.connection) {
       throw new Meteor.Error(403, 'Server logging is only allowed for logged in users');
-    }
-
-    if (!logLevels.has(level)) {
-      throw new Meteor.Error(400, 'Invalid log level');
     }
 
     let msg = '';

--- a/imports/server/api_keys.ts
+++ b/imports/server/api_keys.ts
@@ -17,7 +17,7 @@ const userForKeyOperation = function userForKeyOperation(currentUser: string, fo
 };
 
 Meteor.methods({
-  fetchAPIKey(forUser = undefined) {
+  fetchAPIKey(forUser: unknown = undefined) {
     check(this.userId, String);
     check(forUser, Match.Optional(String));
 
@@ -47,7 +47,7 @@ Meteor.methods({
     return key!.key;
   },
 
-  rollAPIKey(forUser = undefined) {
+  rollAPIKey(forUser: unknown = undefined) {
     check(this.userId, String);
     check(forUser, Match.Optional(String));
 

--- a/imports/server/chat.ts
+++ b/imports/server/chat.ts
@@ -7,11 +7,10 @@ import Profiles from '../lib/models/profiles';
 import Puzzles from '../lib/models/puzzles';
 
 Meteor.methods({
-  sendChatMessage(puzzleId: string, message: string) {
+  sendChatMessage(puzzleId: unknown, message: unknown) {
     check(this.userId, String);
     check(puzzleId, String);
     check(message, String);
-    if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
 
     const puzzle = Puzzles.findOne(puzzleId);
     if (!puzzle) {

--- a/imports/server/feature_flags.ts
+++ b/imports/server/feature_flags.ts
@@ -4,7 +4,7 @@ import { Roles } from 'meteor/nicolaslopezj:roles';
 import FeatureFlags from '../lib/models/feature_flags';
 
 Meteor.methods({
-  setFeatureFlag(name: string, type: "off" | "on" | "random_by", random: number | undefined = undefined) {
+  setFeatureFlag(name: unknown, type: unknown, random: unknown = undefined) {
     check(this.userId, String);
     check(name, String);
     check(type, Match.OneOf('off', 'on', 'random_by'));

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -55,7 +55,7 @@ function transitionGuess(guess: GuessType, newState: GuessType['state']) {
 }
 
 Meteor.methods({
-  addGuessForPuzzle(puzzleId: string, guess: string, direction: number, confidence: number) {
+  addGuessForPuzzle(puzzleId: unknown, guess: unknown, direction: unknown, confidence: unknown) {
     check(this.userId, String);
     check(puzzleId, String);
     check(guess, String);
@@ -86,7 +86,7 @@ Meteor.methods({
     });
   },
 
-  markGuessPending(guessId: string) {
+  markGuessPending(guessId: unknown) {
     check(guessId, String);
     Roles.checkPermission(this.userId, 'mongo.guesses.update');
     const guess = Guesses.findOne(guessId);
@@ -98,7 +98,7 @@ Meteor.methods({
     transitionGuess(guess, 'pending');
   },
 
-  markGuessCorrect(guessId: string) {
+  markGuessCorrect(guessId: unknown) {
     check(guessId, String);
     Roles.checkPermission(this.userId, 'mongo.guesses.update');
     const guess = Guesses.findOne(guessId);
@@ -110,7 +110,7 @@ Meteor.methods({
     transitionGuess(guess, 'correct');
   },
 
-  markGuessIncorrect(guessId: string) {
+  markGuessIncorrect(guessId: unknown) {
     check(guessId, String);
     Roles.checkPermission(this.userId, 'mongo.guesses.update');
     const guess = Guesses.findOne(guessId);
@@ -122,7 +122,7 @@ Meteor.methods({
     transitionGuess(guess, 'incorrect');
   },
 
-  markGuessRejected(guessId: string) {
+  markGuessRejected(guessId: unknown) {
     check(guessId, String);
     Roles.checkPermission(this.userId, 'mongo.guesses.update');
     const guess = Guesses.findOne(guessId);

--- a/imports/server/hunts.ts
+++ b/imports/server/hunts.ts
@@ -37,10 +37,10 @@ const existingJoinEmail = (user: Meteor.User | null, hunt: HuntType, joinerName:
 };
 
 Meteor.methods({
-  addToHunt(huntId: string, email: string) {
+  addToHunt(huntId: unknown, email: unknown) {
     check(huntId, String);
     check(email, String);
-    if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
+    check(this.userId, String);
 
     const hunt = Hunts.findOne(huntId);
     if (!hunt) {

--- a/imports/server/operator.ts
+++ b/imports/server/operator.ts
@@ -6,14 +6,14 @@ import Ansible from '../ansible';
 Meteor.methods({
   // Temporarily de-op yourself
   stopOperating() {
-    if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
+    check(this.userId, String);
     Roles.checkPermission(this.userId, 'users.makeOperator');
 
     Roles.addUserToRoles(this.userId, 'inactiveOperator');
     Roles.removeUserFromRoles(this.userId, 'operator');
   },
 
-  makeOperator(targetUserId: string) {
+  makeOperator(targetUserId: unknown) {
     check(targetUserId, String);
 
     Roles.checkPermission(this.userId, 'users.makeOperator');

--- a/imports/server/profile.ts
+++ b/imports/server/profile.ts
@@ -5,12 +5,7 @@ import Ansible from '../ansible';
 import Profiles from '../lib/models/profiles';
 
 Meteor.methods({
-  saveProfile(newProfile: {
-    displayName: string,
-    phoneNumber: string,
-    slackHandle: string,
-    muteApplause: boolean,
-  }) {
+  saveProfile(newProfile: unknown) {
     // Allow users to update/upsert profile data.
     check(this.userId, String);
     check(newProfile, {
@@ -19,7 +14,6 @@ Meteor.methods({
       slackHandle: String,
       muteApplause: Boolean,
     });
-    if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
     const user = Meteor.users.findOne(this.userId)!;
     const primaryEmail = user.emails && user.emails[0].address;
 
@@ -40,11 +34,10 @@ Meteor.methods({
     });
   },
 
-  linkUserGoogleAccount(key: string, secret: string) {
+  linkUserGoogleAccount(key: unknown, secret: unknown) {
     check(this.userId, String);
     check(key, String);
     check(secret, String);
-    if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
 
     // We don't care about actually capturing the credential - we're
     // not going to do anything with it (and with only identity
@@ -62,7 +55,6 @@ Meteor.methods({
 
   unlinkUserGoogleAccount() {
     check(this.userId, String);
-    if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
     Profiles.update(this.userId, { $unset: { googleAccount: 1 } });
   },
 });

--- a/imports/server/puzzle.ts
+++ b/imports/server/puzzle.ts
@@ -35,16 +35,10 @@ function getOrCreateTagByName(huntId: string, name: string): {
 }
 
 Meteor.methods({
-  createPuzzle(
-    puzzle: {hunt: string, title: string, tags: string[]},
-    docType: keyof typeof MimeTypes
-  ) {
+  createPuzzle(puzzle: unknown, docType: unknown) {
     check(this.userId, String);
-    if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
-    // Note: tag names, not tag IDs. We don't need to validate other
-    // fields because SimpleSchema will validate the rest
-    check(puzzle, Match.ObjectIncluding({ hunt: String, tags: [String] }));
-    check(docType, Match.OneOf(...Object.keys(MimeTypes)));
+    check(puzzle, Match.ObjectIncluding({ hunt: String, title: String, tags: [String] }));
+    check(docType, Match.OneOf(...Object.keys(MimeTypes) as (keyof typeof MimeTypes)[]));
 
     Roles.checkPermission(this.userId, 'mongo.puzzles.insert');
 
@@ -79,11 +73,11 @@ Meteor.methods({
     return fullPuzzle._id;
   },
 
-  updatePuzzle(puzzleId: string, puzzle: {hunt: string, title: string, tags: string[]}) {
+  updatePuzzle(puzzleId: unknown, puzzle: unknown) {
     check(this.userId, String);
     check(puzzleId, String);
     // Note: tags names, not tag IDs
-    check(puzzle, Match.ObjectIncluding({ tags: [String] }));
+    check(puzzle, Match.ObjectIncluding({ hunt: String, title: String, tags: [String] }));
 
     Roles.checkPermission(this.userId, 'mongo.puzzles.update');
 
@@ -119,7 +113,7 @@ Meteor.methods({
     }
   },
 
-  addTagToPuzzle(puzzleId: string, newTagName: string) {
+  addTagToPuzzle(puzzleId: unknown, newTagName: unknown) {
     // addTagToPuzzle takes a tag name, rather than a tag ID,
     // so we can avoid doing two round-trips for tag creation.
     check(this.userId, String);
@@ -148,7 +142,7 @@ Meteor.methods({
     });
   },
 
-  removeTagFromPuzzle(puzzleId: string, tagId: string) {
+  removeTagFromPuzzle(puzzleId: unknown, tagId: unknown) {
     // Note that removeTagFromPuzzle takes a tagId rather than a tag name,
     // since the client should already know the tagId.
     check(this.userId, String);
@@ -165,7 +159,7 @@ Meteor.methods({
     });
   },
 
-  renameTag(tagId: string, newName: string) {
+  renameTag(tagId: unknown, newName: unknown) {
     check(this.userId, String);
     check(tagId, String);
     check(newName, String);
@@ -183,9 +177,8 @@ Meteor.methods({
     }
   },
 
-  ensureDocumentAndPermissions(puzzleId: string) {
+  ensureDocumentAndPermissions(puzzleId: unknown) {
     check(this.userId, String);
-    if (!this.userId) throw new Meteor.Error(401, 'Unauthorized');
     check(puzzleId, String);
 
     const user = Meteor.users.findOne(this.userId)!;

--- a/imports/server/setup.ts
+++ b/imports/server/setup.ts
@@ -7,7 +7,7 @@ import Ansible from '../ansible';
 import Settings from '../lib/models/settings';
 
 Meteor.methods({
-  setupGoogleOAuthClient(clientId: string, secret: string) {
+  setupGoogleOAuthClient(clientId: unknown, secret: unknown) {
     check(this.userId, String);
     check(clientId, String);
     check(secret, String);
@@ -26,7 +26,7 @@ Meteor.methods({
     });
   },
 
-  setupGdriveCreds(key: string, secret: string) {
+  setupGdriveCreds(key: unknown, secret: unknown) {
     check(this.userId, String);
     check(key, String);
     check(secret, String);
@@ -51,10 +51,7 @@ Meteor.methods({
     Settings.remove({ name: 'gdrive.credential' });
   },
 
-  setupGdriveTemplates(
-    spreadsheetTemplate: string | undefined,
-    documentTemplate: string | undefined
-  ) {
+  setupGdriveTemplates(spreadsheetTemplate: unknown, documentTemplate: unknown) {
     check(this.userId, String);
     check(spreadsheetTemplate, Match.Maybe(String));
     check(documentTemplate, Match.Maybe(String));

--- a/imports/server/slack-methods.ts
+++ b/imports/server/slack-methods.ts
@@ -51,7 +51,7 @@ Meteor.methods({
     }
   },
 
-  configureSlack(apiSecretKey?: string) {
+  configureSlack(apiSecretKey: unknown) {
     check(this.userId, String);
     Roles.checkPermission(this.userId, 'slack.configureClient');
 

--- a/imports/server/subscribers.ts
+++ b/imports/server/subscribers.ts
@@ -80,7 +80,7 @@ Meteor.publish('subscribers.counts', function (q: Record<string, any>) {
   }
 
   const query: Record<string, any> = {};
-  _.each(q, (v, k) => {
+  Object.entries(q).forEach(([k, v]) => {
     if (k.startsWith('$')) {
       throw new Meteor.Error(400, 'Special query terms are not allowed');
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -938,9 +938,9 @@
       }
     },
     "@types/meteor": {
-      "version": "1.4.38",
-      "resolved": "https://registry.npmjs.org/@types/meteor/-/meteor-1.4.38.tgz",
-      "integrity": "sha512-8aIIDS3CeYLozniSBLAn8ellhSBF4+fxtlW/pN5wX1xdElrpu9Rn3WTgdcD3EDHkGtQVkw7AOsInln6hf/Trbg==",
+      "version": "1.4.39",
+      "resolved": "https://registry.npmjs.org/@types/meteor/-/meteor-1.4.39.tgz",
+      "integrity": "sha512-9Q7j/x4sajgelT224Vj1U0CVEPtwhWCPCsd1Za1JcwnhS0iOXa1FJAbBBKiMouLI/yAA7fU0jBEpgZWyDUnvEA==",
       "dev": true,
       "requires": {
         "@types/connect": "*",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@types/logfmt": "^1.2.0",
     "@types/marked": "^0.6.5",
     "@types/md5": "^2.1.33",
-    "@types/meteor": "^1.4.38",
+    "@types/meteor": "^1.4.39",
     "@types/mustache": "^0.8.32",
     "@types/react": "^16.8.22",
     "@types/react-bootstrap": "^0.32.15",


### PR DESCRIPTION
Now that `check` is annotated as an assertion function, we can get
sufficient type information just from the check calls. By annotating the
argument types to unknown, we can more accurately reflect that we don't
yet know the types.