### PR TITLE
Minor improvements to chat style

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -271,7 +271,7 @@ table.puzzle-list {
   overflow-y: auto;
 }
 
-.chat-message {
+.chat-message, .chat-placeholder {
   padding: 0 4px;
   margin-bottom: 2px;
   word-wrap: break-word;

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -481,7 +481,7 @@ const chatInputStyles = {
     // input to accomodate its contents.
     // The default Chrome stylesheet has line-height set to a plain number.
     // We work around the Chrome bug by setting an explicit sized line-height for the textarea.
-    lineHeight: '16px',
+    lineHeight: '20px',
     flex: 'none',
     padding: '9px 4px',
     borderWidth: '1px 0 0 0',

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -450,7 +450,7 @@ class ChatHistory extends React.PureComponent<ChatHistoryProps> {
   render() {
     return (
       <div ref={this.ref} className="chat-history" onScroll={this.onScroll}>
-        {this.props.chatMessages.length === 0 && <span key="no-message">No chatter yet. Say something?</span>}
+        {this.props.chatMessages.length === 0 && <div className="chat-placeholder" key="no-message"><span>No chatter yet. Say something?</span></div>}
         {this.props.chatMessages.map((msg, index, messages) => {
           const displayName = (msg.sender !== undefined) ? this.props.displayNames[msg.sender] : 'jolly-roger';
           // Only suppress sender and timestamp if:


### PR DESCRIPTION
- Increase the lineHeight in the chat textarea to improve consistency and legibility
- Adds padding to the placeholder text that appears when the chat history is empty (missed in #213)