### PR TITLE
Minor improvements to puzzle metadata style

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -331,6 +331,7 @@ table.puzzle-list {
   border-radius: 4px;
   background-color: #00ff00;
   color: #000000;
+  word-break: break-all;
 }
 
 .puzzle-metadata .tag-list {

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -359,9 +359,8 @@ table.puzzle-list {
   display: inline-block;
   font-weight: bold;
   white-space: nowrap;
-  /* On very small touch screens or split view, desperately try to prevent line wrap */
-  /* Revisit this */
-  @media (max-width: 320px) and (pointer: coarse) {
+  /* On very narrow windows, desperately try to prevent line wrap */
+  @media (max-width: 320px) {
     svg {
       display: none;
     }


### PR DESCRIPTION
- Correct an overly restrictive media query from #225, used to minimize content for very narrow windows.
- Allow answers to break. Previously, long answers could force the title to wrap poorly. While not a perfect solution, simply allowing the answer to break (combined with the existing flex behavior) results in a reasonable layout. This change primarily affects mobile and puzzles with exceptionally long answers.