### PR TITLE
Switch to withRouter

### DIFF
--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -4,28 +4,24 @@ import { withTracker } from 'meteor/react-meteor-data';
 import { _ } from 'meteor/underscore';
 import DOMPurify from 'dompurify';
 import marked from 'marked';
-import PropTypes from 'prop-types';
 import React from 'react';
 import Alert from 'react-bootstrap/lib/Alert';
 import Button from 'react-bootstrap/lib/Button';
 import ButtonToolbar from 'react-bootstrap/lib/ButtonToolbar';
 import { withBreadcrumb } from 'react-breadcrumbs-context';
 import DocumentTitle from 'react-document-title';
+import { WithRouterProps, withRouter } from 'react-router';
 import Hunts from '../../lib/models/hunts';
 import { HuntType } from '../../lib/schemas/hunts';
 import subsCache from '../subsCache';
 import CelebrationCenter from './CelebrationCenter';
 
-interface HuntDeletedErrorProps {
+type HuntDeletedErrorProps = WithRouterProps & {
   hunt: HuntType;
   canUndestroy: boolean;
 }
 
 class HuntDeletedError extends React.PureComponent<HuntDeletedErrorProps> {
-  static contextTypes = {
-    router: PropTypes.object.isRequired,
-  };
-
   undestroy = () => {
     Hunts.undestroy(this.props.hunt._id);
   };
@@ -49,7 +45,7 @@ class HuntDeletedError extends React.PureComponent<HuntDeletedErrorProps> {
         </Alert>
 
         <ButtonToolbar>
-          <Button bsStyle="default" onClick={this.context.router.goBack}>
+          <Button bsStyle="default" onClick={this.props.router.goBack}>
             Whoops! Get me out of here
           </Button>
           {this.undestroyButton()}
@@ -59,16 +55,14 @@ class HuntDeletedError extends React.PureComponent<HuntDeletedErrorProps> {
   }
 }
 
-interface HuntMemberErrorProps {
+const HuntDeletedErrorWithRouter = withRouter(HuntDeletedError);
+
+type HuntMemberErrorProps = WithRouterProps & {
   hunt: HuntType;
   canJoin: boolean;
 }
 
 class HuntMemberError extends React.PureComponent<HuntMemberErrorProps> {
-  static contextTypes = {
-    router: PropTypes.object.isRequired,
-  };
-
   join = () => {
     const user = Meteor.user();
     if (!user || !user.emails) {
@@ -101,7 +95,7 @@ class HuntMemberError extends React.PureComponent<HuntMemberErrorProps> {
         <div dangerouslySetInnerHTML={{ __html: msg }} />
 
         <ButtonToolbar>
-          <Button bsStyle="default" onClick={this.context.router.goBack}>
+          <Button bsStyle="default" onClick={this.props.router.goBack}>
             Whoops! Get me out of here
           </Button>
           {this.joinButton()}
@@ -110,6 +104,8 @@ class HuntMemberError extends React.PureComponent<HuntMemberErrorProps> {
     );
   }
 }
+
+const HuntMemberErrorWithRouter = withRouter(HuntMemberError);
 
 interface HuntAppParams {
   params: {huntId: string};
@@ -135,11 +131,16 @@ class HuntApp extends React.Component<HuntAppProps> {
     }
 
     if (this.props.hunt.deleted) {
-      return <HuntDeletedError hunt={this.props.hunt} canUndestroy={this.props.canUndestroy} />;
+      return (
+        <HuntDeletedErrorWithRouter
+          hunt={this.props.hunt}
+          canUndestroy={this.props.canUndestroy}
+        />
+      );
     }
 
     if (!this.props.member) {
-      return <HuntMemberError hunt={this.props.hunt} canJoin={this.props.canJoin} />;
+      return <HuntMemberErrorWithRouter hunt={this.props.hunt} canJoin={this.props.canJoin} />;
     }
 
     return React.Children.only(this.props.children);

--- a/imports/client/components/UserInvitePage.tsx
+++ b/imports/client/components/UserInvitePage.tsx
@@ -1,5 +1,4 @@
 import { Meteor } from 'meteor/meteor';
-import PropTypes from 'prop-types';
 import React from 'react';
 import Alert from 'react-bootstrap/lib/Alert';
 import Button from 'react-bootstrap/lib/Button';
@@ -8,8 +7,9 @@ import ControlLabel from 'react-bootstrap/lib/ControlLabel';
 import FormControl from 'react-bootstrap/lib/FormControl';
 import FormGroup from 'react-bootstrap/lib/FormGroup';
 import Row from 'react-bootstrap/lib/Row';
+import { withRouter, WithRouterProps } from 'react-router';
 
-interface UserInvitePageProps {
+interface UserInvitePageProps extends WithRouterProps {
   params: {huntId: string};
 }
 
@@ -20,10 +20,6 @@ interface UserInvitePageState {
 }
 
 class UserInvitePage extends React.Component<UserInvitePageProps, UserInvitePageState> {
-  static contextTypes = {
-    router: PropTypes.object.isRequired,
-  };
-
   constructor(props: UserInvitePageProps) {
     super(props);
     this.state = {
@@ -47,7 +43,7 @@ class UserInvitePage extends React.Component<UserInvitePageProps, UserInvitePage
       if (error) {
         this.setState({ error });
       } else {
-        this.context.router.push(`/hunts/${this.props.params.huntId}`);
+        this.props.router.push(`/hunts/${this.props.params.huntId}`);
       }
     });
   };
@@ -112,4 +108,4 @@ class UserInvitePage extends React.Component<UserInvitePageProps, UserInvitePage
   }
 }
 
-export default UserInvitePage;
+export default withRouter(UserInvitePage);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3552,7 +3552,7 @@
     },
     "load-json-file": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
       "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
       "dev": true,
       "requires": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "md5": "^2.2.1",
     "moment": "^2.23.0",
     "mustache": "^3.0.1",
-    "prop-types": "^15.6.2",
     "react": "^16.7.0",
     "react-addons-pure-render-mixin": "^15.2.1",
     "react-bootstrap": "^0.32.3",


### PR DESCRIPTION
This lets us get rid of our direct dependency on prop-types, although it doesn't remove it from the bundle since most React libraries ship with prop-types definitions.

(I could be convinced that this isn't worth merging, since it doesn't actually shrink the bundle at all, but it seems like a nice cleanup, and gets rid of the last usage of legacy context)