### PR TITLE
Suggestion: Automatically collapse related puzzles if unlikely to be useful

### DIFF
--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -287,7 +287,7 @@ class RelatedPuzzleSection extends React.PureComponent<RelatedPuzzleSectionProps
   render() {
     return (
       <div className="related-puzzles-section">
-        <div>Related puzzles:</div>
+        <div>Related:</div>
         <RelatedPuzzleGroups
           activePuzzle={this.props.activePuzzle}
           allPuzzles={this.props.allPuzzles}
@@ -1097,7 +1097,7 @@ class PuzzlePage extends React.Component<PuzzlePageProps, PuzzlePageState> {
       const puzzleTagIds = (activePuzzle && activePuzzle.tags) || [];
       const puzzleTagNames = puzzleTagIds.map((tagId) => (tagId in tagsById ? tagsById[tagId].name : ''));
       const isRelatable = puzzleTagNames.some((tagName: string) => {
-        return ['is:meta', 'is:metameta'].includes(tagName) || tagName.startsWith('meta-for:');
+        return ['is:meta', 'is:metameta', 'administrivia'].includes(tagName) || tagName.startsWith('meta-for:');
       });
       return {
         defaultsAppliedForPuzzle: props.params.puzzleId,


### PR DESCRIPTION
Per Issue #234, related puzzles are most useful for meta puzzles. For other puzzles, the information should be available, but the space may be better devoted to chat.

This automatically collapses related puzzles for puzzles without meta-related tags. When navigating between puzzles, related puzzles will never be collapsed automatically (so related puzzles stays open when navigating from a meta to a puzzle), but may be expanded (so related puzzles is opened automatically when navigating from a puzzle to a meta, though currently there are no links to other puzzles other than in the related pane, so it was almost certainly already open).

As an example, clicking Spotted Tower from the hunt landing page will cause the related puzzles pane to open, but clicking Topsy Turvy from the same page will leave it collapsed. However, navigating to Topsy Turvy from Spotted Tower will result in the pane staying open.

This behavior is just a suggestion and is quite open to discussion. (We may even decide to close issue #234 with no changes.)