### PR TITLE
Rewrite SplitPanePlus as fully controlled

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -409,7 +409,7 @@ table.puzzle-list {
   left: 0;
 }
 
-.SplitPane.collapsing1 > .Pane1:before, .SplitPane.collapsing2 > .Pane2:before {
+.SplitPane > .Pane.collapsing:before {
   content: "";
   display: block;
   height: 100%;
@@ -447,7 +447,7 @@ table.puzzle-list {
   z-index: 2003;
 }
 
-.SplitPane.collapsed1:not(.dragging) > .Resizer.horizontal {
+.SplitPane > .Resizer.horizontal.collapsedAdjacent {
   height: 17px;
   min-height: 17px;
   background-color: #666;
@@ -459,37 +459,21 @@ table.puzzle-list {
     height: 0;
     border-left: 6px solid transparent;
     border-right: 6px solid transparent;
-    border-top: 4px solid white;
     position: absolute;
     margin-left: -6px;
     left: 50%;
     top: 2px;
     z-index: 2;
   }
-}
-
-.SplitPane.collapsed2:not(.dragging) > .Resizer.horizontal {
-  height: 17px;
-  min-height: 17px;
-  background-color: #666;
-  position: relative;
-  &:after {
-    content: '';
-    display: block;
-    width: 0;
-    height: 0;
-    border-left: 6px solid transparent;
-    border-right: 6px solid transparent;
+  &.collapsedPrevious:after {
+    border-top: 4px solid white;
+  }
+  &.collapsedNext:after {
     border-bottom: 4px solid white;
-    position: absolute;
-    margin-left: -6px;
-    left: 50%;
-    bottom: 2px;
-    z-index: 2;
   }
 }
 
-.SplitPane.collapsed1:not(.dragging) > .Resizer.vertical {
+.SplitPane > .Resizer.vertical.collapsedAdjacent {
   width: 17px;
   min-width: 17px;
   background-color: #666;
@@ -501,33 +485,17 @@ table.puzzle-list {
     height: 0;
     border-top: 6px solid transparent;
     border-bottom: 6px solid transparent;
-    border-left: 4px solid white;
     position: absolute;
     margin-top: -6px;
     top: 50%;
     left: 2px;
     z-index: 2;
   }
-}
-
-.SplitPane.collapsed2:not(.dragging) > .Resizer.vertical {
-  width: 17px;
-  min-width: 17px;
-  background-color: #666;
-  position: relative;
-  &:after {
-    content: '';
-    display: block;
-    width: 0;
-    height: 0;
-    border-top: 6px solid transparent;
-    border-bottom: 6px solid transparent;
+  &.collapsedPrevious:after {
+    border-left: 4px solid white;
+  }
+  &.collapsedNext:after {
     border-right: 4px solid white;
-    position: absolute;
-    margin-top: -6px;
-    top: 50%;
-    right: 2px;
-    z-index: 2;
   }
 }
 
@@ -540,10 +508,9 @@ table.puzzle-list {
   z-index: 1;
   box-sizing: border-box;
   background-clip: padding-box;
-}
-
-.Resizer:hover {
-  transition: border 2s ease;
+  &:hover {
+    transition: border 0.8s ease;
+  }
 }
 
 .Resizer.horizontal {
@@ -553,11 +520,10 @@ table.puzzle-list {
   border-bottom: 5px solid rgba(255, 255, 255, 0);
   cursor: row-resize;
   width: 100%;
-}
-
-.Resizer.horizontal:hover {
-  border-top: 5px solid rgba(0, 0, 0, 0.1);
-  border-bottom: 5px solid rgba(0, 0, 0, 0.1);
+  &:hover {
+    border-top: 5px solid rgba(0, 0, 0, 0.1);
+    border-bottom: 5px solid rgba(0, 0, 0, 0.1);
+  }
 }
 
 .Resizer.vertical {
@@ -566,17 +532,27 @@ table.puzzle-list {
   border-left: 5px solid rgba(255, 255, 255, 0);
   border-right: 5px solid rgba(255, 255, 255, 0);
   cursor: col-resize;
+  &:hover {
+    border-left: 5px solid rgba(0, 0, 0, 0.1);
+    border-right: 5px solid rgba(0, 0, 0, 0.1);
+  }
 }
 
-.Resizer.vertical:hover {
-  border-left: 5px solid rgba(0, 0, 0, 0.1);
-  border-right: 5px solid rgba(0, 0, 0, 0.1);
+/* Needed to keep the cursor during the drag
+   Not really sure why the Resizer style doesn't work during the drag */
+.SplitPane.dragging {
+  cursor: move;
+  &.horizontal {
+    cursor: row-resize;
+  }
+  &.vertical {
+    cursor: col-resize;
+  }
 }
 
 Resizer.disabled {
   cursor: not-allowed;
-}
-
-Resizer.disabled:hover {
-  border-color: transparent;
+  &:hover {
+    border-color: transparent;
+  }
 }

--- a/imports/client/components/SplitPanePlus.tsx
+++ b/imports/client/components/SplitPanePlus.tsx
@@ -1,92 +1,130 @@
 import { _ } from 'meteor/underscore';
+import classnames from 'classnames';
 import elementResizeDetectorMaker from 'element-resize-detector';
 import React from 'react';
 import SplitPane, { Props as SplitPaneProps } from 'react-split-pane';
 
 /*
-  Wraps react-split-pane with a few extra features:
-    Improved Styles for Better Cross Browser Support:
-      Changes default pane1Style and pane2Style, but can still be overridden by passing props
-    Automatic Collapse on Drag or Resize:
-      Collapse does not occur if programmatically set to sizes which would cause collapse during
-      drag.  Adds classes Collapsing1 and Collapsing2 as respective panes are dragged through the
-      collapse range, which is useful to style a warning.  Adds classes Collapsed1 and Collapsed2
-      as respective panes are actively collapsed (reduced to 0 size), which is useful to hide
-      Resizer if no further adjustment is desired.
-    Relative Scaling Option:
+  Provides two panes with a user draggable divider featuring snap-to-collapse. Fully controlled.
+
+  Notable features:
+    Automatic collapse on drag or resize:
+      Collapse is requested via the on PaneChanged callback.  Collapse does not occur if
+      a size which would cause collapse during drag is passed directly as a prop.
+    Min and max size respected during resize:
+      While resizing in absolute or relative mode, minSize and maxSize still have effect.
+    Relative scaling option:
       Preserves relative sizes of the two panes during resize instead of absolute size of the
       primary.
-    Dragging Class:
-      Identifies a SplitPane currently being dragged with a 'dragging' class, which can be used to
-      style the Resizer, for instance
+    Applies useful classes:
+      .dragging          - Applied to the SplitPane during dragging
+      .collapsing        - Applied to a pane during drag while it is within its autoCollapse range
+      .collapsed         - Applied to a pane when it is collapsed
+      .collapsedAdjacent - Applied to a resizer when either pane is collapsed
+      .collapsedPrevious - Applied to a resizer when the pane before it is collapsed
+      .collapsedNext     - Applied to a resizer when the pane after it is collapsed
 
-  New Props:
-    autoCollapse1     - Number of pixels (from center of Resizer) in Pane1 or Pane2 before
-    autoCollapse2       collapsing.  Set 0 or negative to
-                        disable (If 0, collapse flags will still set if dragged to extremes).
-                        Defaults to 50.
-    collapsed         - If 1 or 2, collapses the appropriate pane.  Ignored if size is set.
-                        Defaults to 0.
-    scaling           - If 'absolute' (default) maintains fixed size during resizes of the parent.
-                        If 'relative' maintains fixed percentage.
-    onCollapseChanged - Callback triggered when a pane collapses as a result of user input.
-                        Argument is 0 if uncollapsed and 1 or 2 indicating the pane that
-                        collapsed.
-
-  Prop Changes:
-    pane1Style        - Default now includes overflow: auto in both panes as well as maxHeight:
-    pane2Style          100% or maxWidth: 100% as
-                        appropriate in the primary pane
-    minSize           - Default is now 0
-    maxSize           - Default is now 0
-    onDragFinished    - Callback arguments are now (size, collapsed) where collapsed is 0 if
-                        uncollapsed and 1 or 2 indicating the pane that collapsed.  If collapsed,
-                        the size reported is the position when the drag finished (before the
-                        automatic collapse).
-    size              - If size is specified , the appropriate panes are collapsed only if the
-                        setting is exactly '0%', '100%', 0, or the Pane size.  It is possible to
-                        set size within the automatic collapse zone without triggering a collapse.
+  Props:
+    size: number
+      Size in pixels of the primary pane. Size has no effect during drag or if collapsed is other
+      than 0. If size is set to a value normally prohibited by minSize or maxSize or within any
+      autoCollapse range, the primary pane will still render at the requested size. If size is
+      larger than the container, the primary pane will fill the container. In no event does size
+      alone trigger collapse.
+    collapsed?: 0 | 1 | 2 = 0
+      Which pane is currently collapsed (reduced to size 0 with appropriate classes applied).
+      If 0, neither pane is collapsed and normal dragging behavior is present.
+    primary?: 'first' | 'second' = 'first'
+      Which pane the size property is applied to
+    split?: 'vertical' | 'horizontal' = 'vertical'
+      Orientation of the dividing line. 'vertical' is side-by-side and 'horizontal' is stacked.
+    allowResize?: boolean = true
+      True to enable user drag.
+    minSize?: number = 0
+      Minimum size of the primary pane. Respected by drag and resize.
+    maxSize?: number = 0
+      Maximum size of the primary pane. Respected by drag and resize. If zero or negative,
+      interpreted as minimum size of secondary pane.
+    autoCollapse1?, autoCollapse2?: number = 50
+      Size in pixels below which a pane is automatically collapsed. Respected by drag and resize.
+      Set negative to disable.
+    scaling?: 'absolute' | 'relative' = 'absolute'
+      If 'relative', primary and secondary panes will retain their proportions during resize.
+    step?: number
+      Step size when dragging
+    onPaneChanged?: (size: number, collapsed: 0 | 1 | 2, cause: 'drag' | 'resize') => void
+      Callback triggered to request a change to size or collapsed state. Drag events will call
+      this once, at the end of the event. Resize events will call this whenever the currently
+      implied condition does not match the existing props.
+    className?: string
+      Class names applied to the parent div, in addition to 'SplitPane' and 'Vertical' or
+      'Horizontal' (depending on split)
+    style?: React.CSSProperties
+      Styles applied to the parent div
+    paneClassName?, pane1ClassName?, pane2ClassName?: string
+      Class names applied to both, the first, and the second pane respectively, in addition to
+      'Pane', 'Pane1', and 'Pane2' as well as 'Vertical' or 'Horizontal' (depending on split)
+    paneStyle?, pane1Style?, pane2Style?: React.CSSProperties
+      Styles applied to both, the first, and the second pane respectively
+    resizerClassName?: string
+      Class names applied to the resizer, in addition to 'Resizer' as well as 'Vertical' or
+      'Horizontal' (depending on split)
+    resizerStyle?: React.CSSProperties
+      Styles applied to the resizer
 */
 
-interface SplitPanePlusProps extends SplitPaneProps {
-  autoCollapse1?: number;
-  autoCollapse2?: number;
-  collapsed?: 0 | 1 | 2;
-  scaling?: 'absolute' | 'relative';
-  onCollapseChanged?: (collapse: 0 | 1 | 2) => void;
-  onDragFinished?: (size: number, collapse?: 0 | 1 | 2) => void;
+interface SplitPanePlusProps {
+  children: React.ReactNode[],
+  size: number,
+  collapsed: 0 | 1 | 2,
+  primary: 'first' | 'second',
+  split: 'vertical' | 'horizontal',
+  allowResize: boolean,
+  minSize: number,
+  maxSize: number,
+  autoCollapse1: number,
+  autoCollapse2: number,
+  scaling: 'absolute' | 'relative',
+  onPaneChanged?: (size: number, collapsed: 0 | 1 | 2, cause: 'drag' | 'resize') => void,
+  step?: number,
+  className?: string,
+  style?: React.CSSProperties,
+  paneClassName?: string,
+  paneStyle?: React.CSSProperties,
+  pane1ClassName?: string,
+  pane1Style?: React.CSSProperties,
+  pane2ClassName?: string,
+  pane2Style?: React.CSSProperties,
+  resizerClassName?: string,
+  resizerStyle?: React.CSSProperties,
 }
 
 interface SplitPanePlusState {
   collapseWarning: 0 | 1 | 2;
-  lastSize: number;
-  lastRelSize: number;
   dragInProgress: boolean;
 }
 
 class SplitPanePlus extends React.Component<SplitPanePlusProps, SplitPanePlusState> {
-  ref: React.RefObject<HTMLDivElement>
+  private ref: React.RefObject<HTMLDivElement>
 
-  erd?: elementResizeDetectorMaker.Erd
+  private erd?: elementResizeDetectorMaker.Erd
 
-  static defaultProps = _.extend({}, (SplitPane as any).defaultProps, {
+  static defaultProps: Partial<SplitPanePlusProps> = {
+    collapsed: 0,
+    primary: 'first',
+    split: 'vertical',
+    allowResize: true,
     minSize: 0,
     maxSize: 0,
-    className: '',
     autoCollapse1: 50,
     autoCollapse2: 50,
-    collapsed: 0,
     scaling: 'absolute',
-  });
+  };
 
   constructor(props: SplitPanePlusProps) {
     super(props);
     this.state = {
-      // collapseWarning and collapsed are equal to the number of the pane being collapsed
-      // or 0 if none
       collapseWarning: 0,
-      lastSize: NaN,
-      lastRelSize: NaN,
       dragInProgress: false,
     };
     this.ref = React.createRef();
@@ -95,9 +133,14 @@ class SplitPanePlus extends React.Component<SplitPanePlusProps, SplitPanePlusSta
   componentDidMount() {
     this.erd = elementResizeDetectorMaker({ strategy: 'scroll' });
     this.erd.listenTo(this.splitPaneNode()!, _.throttle(this.onResize, 50));
-    // Measure to handle relative defaultSize correctly
-    if (this.props.collapsed === 0) {
-      this.recordSize(this.measure(this.primaryPaneNode()!));
+    // This is an inelegant way of preventing the browser from going into selection mode and
+    // overriding the cursor. It also has to be accompanied by additional cursor styles for the
+    // pane below (in puzzle.scss).
+    if (this.ref && this.ref.current) {
+      const resizerEl = this.ref.current.querySelector(':scope > .SplitPane > .Resizer');
+      if (resizerEl) {
+        resizerEl.addEventListener('mousedown', (ev) => { ev.preventDefault(); });
+      }
     }
   }
 
@@ -111,113 +154,92 @@ class SplitPanePlus extends React.Component<SplitPanePlusProps, SplitPanePlusSta
     if (!this.splitPaneNode()) {
       return;
     }
-    if (this.props.collapsed === 0) {
-      // Actively measure instead of using lastSize to capture the relative case correctly
-      this.attemptCollapse(this.measure(this.primaryPaneNode()!));
+    let newSize: number = this.measure(this.primaryPaneNode());
+    const fullSize = this.measure(this.splitPaneNode());
+    const fullMax = this.props.maxSize <= 0 ? fullSize + this.props.maxSize : this.props.maxSize;
+    newSize = Math.min(Math.max(this.props.minSize, newSize), fullMax);
+    const newCollapsed = this.calculateCollapse(newSize);
+    if (newSize !== this.props.size || newCollapsed !== this.props.collapsed) {
+      if (this.props.onPaneChanged) {
+        this.props.onPaneChanged(newSize, newCollapsed, 'resize');
+      }
+      this.forceUpdate();
     }
   }
 
   onChange = (size: number) => {
-    this.setState({ collapseWarning: this.calculateCollapse(size) });
-    if (this.props.onChange) {
-      this.props.onChange(size);
-    }
+    // Setting dragInProgress in onDragStarted creates a frame of strangeness
+    this.setState({ dragInProgress: true, collapseWarning: this.calculateCollapse(size) });
   }
 
-  onDragStarted = () => {
-    this.setState({
-      dragInProgress: true,
-    });
-    if (this.props.onDragStarted) {
-      this.props.onDragStarted();
-    }
-  }
-
-  onDragFinished = (size: number) => {
+  onDragFinished = (rawSize: number | string) => {
     this.setState({
       collapseWarning: 0,
       dragInProgress: false,
     });
-    this.attemptCollapse(size);
-    if (this.props.collapsed === 0) {
-      this.recordSize(size);
+    // May be called with a number or a string representing a percentage
+    let size: number = Number(rawSize);
+    if (typeof rawSize === 'string') {
+      const rawSizeAsPercent: number = Number(rawSize.slice(0, -1));
+      if (rawSize.slice(-1) === '%' && !Number.isNaN(rawSizeAsPercent)) {
+        size = (rawSizeAsPercent * this.measure(this.splitPaneNode())) / 100.0;
+      }
     }
-    if (this.props.onDragFinished) {
-      this.props.onDragFinished(size, this.props.collapsed);
-    }
-  }
-
-  recordSize(size: number) {
-    this.setState({
-      lastSize: size,
-      lastRelSize: size / this.measure(this.splitPaneNode()!),
-    });
-  }
-
-  attemptCollapse(size: number) {
-    const oldCollapsed = this.props.collapsed;
-    const newCollapsed = this.calculateCollapse(size);
-    if (oldCollapsed !== newCollapsed && this.props.onCollapseChanged) {
-      this.props.onCollapseChanged(newCollapsed);
+    if (!Number.isNaN(size) && this.props.onPaneChanged) {
+      this.props.onPaneChanged(size, this.calculateCollapse(size), 'drag');
     }
   }
 
   calculateCollapse(size: number) {
-    const fullSize = this.measure(this.splitPaneNode()!);
-    const halfResizerSize = this.measure(this.resizerNode()!) / 2;
-    let autoCollapsePrimary = this.props.autoCollapse1!;
-    let autoCollapseSecondary = this.props.autoCollapse2!;
+    const fullSize = this.measure(this.splitPaneNode());
+    let autoCollapsePrimary = this.props.autoCollapse1;
+    let autoCollapseSecondary = this.props.autoCollapse2;
     if (this.props.primary !== 'first') {
-      autoCollapsePrimary = this.props.autoCollapse2!;
-      autoCollapseSecondary = this.props.autoCollapse1!;
+      autoCollapsePrimary = this.props.autoCollapse2;
+      autoCollapseSecondary = this.props.autoCollapse1;
     }
-    if (size + halfResizerSize <= autoCollapsePrimary) {
-      // Collapse Primary
+    if (autoCollapsePrimary >= 0 && size <= autoCollapsePrimary) {
       return this.props.primary === 'first' ? 1 : 2;
-    } else if (size + halfResizerSize >= fullSize - autoCollapseSecondary) {
-      // Collapse Secondary
+    } else if (autoCollapseSecondary >= 0 && size >= fullSize - autoCollapseSecondary) {
       return this.props.primary === 'first' ? 2 : 1;
     }
     return 0;
   }
 
   splitPaneNode(): HTMLElement | null {
-    if (!this.ref.current) {
-      return null;
-    }
-    if (!(this.ref.current.firstChild instanceof HTMLElement)) {
+    if (!this.ref.current || !(this.ref.current.firstChild instanceof HTMLElement)) {
       return null;
     }
     return this.ref.current.firstChild;
   }
 
-  primaryPaneNode() {
+  primaryPaneNode(): HTMLElement | null {
     const root = this.splitPaneNode();
     const className = `Pane${this.props.primary === 'first' ? 1 : 2}`;
     return root ? _.find(root.childNodes, (n) => (
       n instanceof Element &&
       n.classList.contains(className)
-    )) as Element : null;
+    )) as HTMLElement : null;
   }
 
-  secondaryPaneNode() {
+  secondaryPaneNode(): HTMLElement | null {
     const root = this.splitPaneNode();
     const className = `Pane${this.props.primary === 'first' ? 2 : 1}`;
     return root ? _.find(root.childNodes, (n) => (
       n instanceof Element &&
       n.classList.contains(className)
-    )) as Element : null;
+    )) as HTMLElement : null;
   }
 
-  resizerNode() {
+  resizerNode(): HTMLElement | null {
     const root = this.splitPaneNode();
     return root ? _.find(root.childNodes, (n) => (
       n instanceof Element &&
       n.classList.contains('Resizer')
-    )) as Element : null;
+    )) as HTMLElement : null;
   }
 
-  measure(elem: Element) {
+  measure(elem: HTMLElement | null): number {
     if (!elem) {
       return NaN;
     }
@@ -225,54 +247,82 @@ class SplitPanePlus extends React.Component<SplitPanePlusProps, SplitPanePlusSta
   }
 
   render() {
-    const paneProps: SplitPaneProps = _.extend({}, this.props);
-
-    const defaultPaneStyles = { overflow: 'auto' };
-    const maxRangeStyles = (this.props.split === 'vertical' ?
-      { maxWidth: '100%' } :
-      { maxHeight: '100%' }
+    const paneProps: { [key: string]: any; } = _.pick(
+      this.props,
+      'children',
+      'primary',
+      'split',
+      'allowResize',
+      'step',
+      'minSize',
+      'maxSize',
+      'className',
+      'style',
+      'paneClassName',
+      'paneStyle',
+      'pane1ClassName',
+      'pane1Style',
+      'pane2ClassName',
+      'pane2Style',
+      'resizerClassName',
+      'resizerStyle',
     );
-    paneProps.pane1Style = _.extend({},
-      defaultPaneStyles,
-      this.props.primary === 'first' ? maxRangeStyles : {},
-      this.props.pane1Style);
-    paneProps.pane2Style = _.extend({},
-      defaultPaneStyles,
-      this.props.primary === 'first' ? {} : maxRangeStyles,
-      this.props.pane2Style);
-
+    const defaultPaneStyle: React.CSSProperties = { overflow: 'auto' };
+    paneProps.paneStyle = _.extend(defaultPaneStyle, this.props.paneStyle);
+    // Prevents the flexbox from overfilling, accommodating large size passed as prop
+    // Also allows use of 100% width in collapse (even though resizer takes up some space)
+    const defaultPrimaryPaneStyle: React.CSSProperties = { flexShrink: 1 };
+    if (this.props.primary === 'first') {
+      paneProps.pane1Style = _.extend(defaultPrimaryPaneStyle, this.props.pane1Style);
+    } else {
+      paneProps.pane2Style = _.extend(defaultPrimaryPaneStyle, this.props.pane2Style);
+    }
+    paneProps.className = classnames(paneProps.className, { dragging: this.state.dragInProgress });
+    paneProps.pane1ClassName = classnames(paneProps.pane1ClassName, {
+      collapsing: this.state.collapseWarning === 1,
+      collapsed: this.props.collapsed === 1 && !this.state.dragInProgress,
+    });
+    paneProps.pane2ClassName = classnames(paneProps.pane2ClassName, {
+      collapsing: this.state.collapseWarning === 2,
+      collapsed: this.props.collapsed === 2 && !this.state.dragInProgress,
+    });
+    paneProps.resizerClassName = classnames(paneProps.resizerClassName, {
+      collapsedAdjacent: this.props.collapsed > 0 && !this.state.dragInProgress,
+      collapsedPrevious: this.props.collapsed === 1 && !this.state.dragInProgress,
+      collapsedNext: this.props.collapsed === 2 && !this.state.dragInProgress,
+    });
+    // If no resizerClassName is provided to SplitPane, a default is used, but if '' is provided,
+    // no class is assigned. Any other provided string is appended to the default.
+    // Work around this by never passing '' as resizerClassName.
+    if (paneProps.resizerClassName === '') {
+      delete paneProps.resizerClassName;
+    }
+    // The docs suggest that maxSize <= 0 should limit the primary pane to the the container
+    // (representing size of the secondary). While this works with negative maxSize, it doesn't
+    // seem to work with 0. This workaround using epsilon isn't ideal, but is good enough in
+    // practice.
+    if (paneProps.maxSize === 0) {
+      paneProps.maxSize = -Number.MIN_VALUE;
+    }
     paneProps.onDragFinished = this.onDragFinished;
-    paneProps.onDragStarted = this.onDragStarted;
     paneProps.onChange = this.onChange;
-
-    if (this.state.collapseWarning > 0) {
-      paneProps.className = `${paneProps.className} collapsing${this.state.collapseWarning}`;
-    }
-    if (this.props.collapsed! > 0) {
-      paneProps.className = `${paneProps.className} collapsed${this.props.collapsed}`;
-      if (this.props.collapsed === 1) {
-        // Collapse Pane1
-        paneProps.size = this.props.primary === 'first' ? '0%' : '100%';
+    if (!this.state.dragInProgress) {
+      if (this.props.collapsed > 0) {
+        if (this.props.collapsed === 1) {
+          paneProps.size = this.props.primary === 'first' ? '0%' : '100%';
+        } else {
+          paneProps.size = this.props.primary === 'first' ? '100%' : '0%';
+        }
+      } else if (this.props.scaling === 'relative' && this.splitPaneNode()) {
+        const relativeSize: number = this.props.size / this.measure(this.splitPaneNode());
+        paneProps.size = `${relativeSize * 100.0}%`;
       } else {
-        // Collapse Pane2
-        paneProps.size = this.props.primary === 'first' ? '100%' : '0%';
-      }
-    } else if (!('size' in this.props)) {
-      if (this.props.scaling === 'relative' && !Number.isNaN(this.state.lastRelSize)) {
-        paneProps.size = `${this.state.lastRelSize * 100}%`;
-      } else if (!Number.isNaN(this.state.lastSize)) {
-        paneProps.size = this.state.lastSize;
+        paneProps.size = this.props.size;
       }
     }
-    if (!('size' in paneProps)) {
-      paneProps.size = this.props.defaultSize;
-    }
-
-    paneProps.className = `${paneProps.className}${this.state.dragInProgress ? ' dragging' : ''}`;
-
     return (
       <div className="SplitPanePlus" ref={this.ref}>
-        <SplitPane {...paneProps} />
+        <SplitPane {...paneProps as SplitPaneProps} />
       </div>
     );
   }


### PR DESCRIPTION
Rewrite SplitPanePlus to be fully controlled, with associtated rewiring of PuzzlePage. SplitPanePlus now has somewhat different (but hopefully more intuitive) behaviors around the size prop than the underlying SplitPane. Automatic classes are now assigned to individual collapsed panes and the resizer instead of to the parent SplitPane. Min and max sizes are now respected during resize.

Fixes several bugs (The first three could occur whenever Related Puzzles was collapsed):
- Clicking and immediately releasing the resizer when a secondary pane is collapsed no longer clears the collapse state.
- Dragging a collapsed pane and releasing it within the auto-collapse zone no longer clears the collapse state.
- The primary pane no longer overfills the parent container when the secondary pane is collapsed. (This resulted in the bottom of the chat input being cropped whenever Related Puzzles was collapsed.)
- The resizing cursor persists during the drag. (The fix for this was quite inelegant and I'm very open to suggestions.)

Also improves default sizing for various panes on PuzzlePage and reduces the time for the resizer fade effect.