### PR TITLE
Suppress 4 eslint warnings for react/no-danger

### DIFF
--- a/imports/client/components/AnnouncementsPage.tsx
+++ b/imports/client/components/AnnouncementsPage.tsx
@@ -110,7 +110,10 @@ class Announcement extends React.Component<AnnouncementProps> {
           <div className="announcement-timestamp">{moment(ann.createdAt).calendar()}</div>
           <div>{this.props.displayNames[ann.createdBy]}</div>
         </div>
-        <div dangerouslySetInnerHTML={{ __html: marked(DOMPurify.sanitize(ann.message)) }} />
+        <div
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: marked(DOMPurify.sanitize(ann.message)) }}
+        />
       </div>
     );
   }

--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -91,7 +91,10 @@ class HuntMemberError extends React.PureComponent<HuntMemberErrorProps> {
           ) yet.
         </Alert>
 
-        <div dangerouslySetInnerHTML={{ __html: msg }} />
+        <div
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: msg }}
+        />
 
         <ButtonToolbar>
           <Button bsStyle="default" onClick={this.props.router.goBack}>

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -251,7 +251,10 @@ class AnnouncementMessage extends React.PureComponent<AnnouncementMessageProps> 
       <li>
         <MessengerSpinner />
         <MessengerContent dismissable>
-          <div dangerouslySetInnerHTML={{ __html: marked(DOMPurify.sanitize(this.props.announcement.message)) }} />
+          <div
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: marked(DOMPurify.sanitize(this.props.announcement.message)) }}
+          />
           <footer>
             {'- '}
             {this.props.createdByDisplayName}

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -317,7 +317,10 @@ class ChatMessage extends React.PureComponent<ChatMessageProps> {
       <div className={classes}>
         {!this.props.suppressSender && <span className="chat-timestamp">{ts}</span>}
         {!this.props.suppressSender && <strong>{this.props.senderDisplayName}</strong>}
-        <span dangerouslySetInnerHTML={{ __html: marked(DOMPurify.sanitize(this.props.message.text)) }} />
+        <span
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: marked(DOMPurify.sanitize(this.props.message.text)) }}
+        />
       </div>
     );
   }


### PR DESCRIPTION
Per conversation with @ebroder we aren't likely to change these four uses of dangerouslySetInnerHTML, so the warnings being generated aren't drawing attention to anything useful. I suggest adding the eslint-disable as an acknowledgment of the issue and moving on without the warnings.