### PR TITLE
Relocate viewers in puzzle metadata

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -361,8 +361,8 @@ table.puzzle-list {
   font-weight: bold;
   white-space: nowrap;
   /* On very narrow windows, desperately try to prevent line wrap */
-  @media (max-width: 320px) {
-    svg {
+  @media (max-width: 374px) {
+    .linkLabel {
       display: none;
     }
   }

--- a/imports/client/components/Documents.tsx
+++ b/imports/client/components/Documents.tsx
@@ -1,4 +1,5 @@
-import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
+import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import { faTable, faFileAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import { DocumentType } from '../../lib/schemas/documents';
@@ -6,7 +7,7 @@ import DeepLink from './DeepLink';
 
 interface DocumentDisplayProps {
   document: DocumentType;
-  displayMode: 'link' | 'embed'
+  displayMode: 'link' | 'embed';
 }
 
 class GoogleDocumentDisplay extends React.Component<DocumentDisplayProps> {
@@ -14,16 +15,19 @@ class GoogleDocumentDisplay extends React.Component<DocumentDisplayProps> {
     let url: string;
     let deepUrl: string;
     let title: string;
+    let icon: IconDefinition;
     switch (this.props.document.value.type) {
       case 'spreadsheet':
         url = `https://docs.google.com/spreadsheets/d/${this.props.document.value.id}/edit?ui=2&rm=embedded#gid=0`;
         deepUrl = `googlesheets://${url}`;
-        title = 'Worksheet';
+        title = 'Sheet';
+        icon = faTable;
         break;
       case 'document':
         url = `https://docs.google.com/document/d/${this.props.document.value.id}/edit?ui=2&rm=embedded#gid=0`;
         deepUrl = `googledocs://${url}`;
-        title = 'Document';
+        title = 'Doc';
+        icon = faFileAlt;
         break;
       default:
         return (
@@ -40,9 +44,11 @@ class GoogleDocumentDisplay extends React.Component<DocumentDisplayProps> {
         return (
           <DeepLink className="gdrive-button" nativeUrl={deepUrl} browserUrl={url}>
             <a href={url} target="new">
-              {title}
-              {' '}
-              <FontAwesomeIcon fixedWidth icon={faExternalLinkAlt} />
+              <span className="linkLabel">
+                {title}
+                {' '}
+              </span>
+              <FontAwesomeIcon fixedWidth icon={icon} />
             </a>
           </DeepLink>
         );

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -231,9 +231,12 @@ class ViewersModal extends React.Component<ViewersModalProps, ViewersModalState>
   }
 }
 
-interface ViewCountDisplayProps {
+interface ViewCountDisplayParams {
   count: number;
   name: string;
+}
+
+interface ViewCountDisplayProps extends ViewCountDisplayParams {
   subfetchesDisabled: boolean;
 }
 
@@ -250,29 +253,21 @@ class ViewCountDisplay extends React.Component<ViewCountDisplayProps> {
   };
 
   render() {
-    const text = `(${this.props.count} viewing)`;
+    const text = `See ${this.props.count} ${this.props.count === 1 ? 'hunter' : 'hunters'}`;
     if (this.props.subfetchesDisabled) {
       return <span>{text}</span>;
     }
 
-    const tooltip = (
-      <Tooltip id="view-count-tooltip">
-        Click to see who is viewing this puzzle
-      </Tooltip>
-    );
-
     return (
-      <span>
+      <span className="puzzle-metadata-viewers-button">
         <ViewersModal ref={this.modalRef} name={this.props.name} />
-        <OverlayTrigger placement="top" overlay={tooltip}>
-          <span className="view-count" onClick={this.showModal}>{text}</span>
-        </OverlayTrigger>
+        <Button className="btn-info" onClick={this.showModal}>{text}</Button>
       </span>
     );
   }
 }
 
-const ViewCountDisplayContainer = withTracker((_params: {count: number, name: string}) => {
+const ViewCountDisplayContainer = withTracker((_params: ViewCountDisplayParams) => {
   return { subfetchesDisabled: Flags.active('disable.subfetches') };
 })(ViewCountDisplay);
 
@@ -688,7 +683,7 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
     ) : null;
     const hideViewCount = this.props.subcountersDisabled;
     const numGuesses = this.props.guesses.length;
-    const guessesString = `${numGuesses || 'no'} ${numGuesses === 1 ? 'guess' : 'guesses'}`;
+
     return (
       <div className="puzzle-metadata">
         <PuzzleModalForm
@@ -704,13 +699,6 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
             {this.editButton()}
             {' '}
             <span className="puzzle-metadata-title">{this.props.puzzle.title}</span>
-            {' '}
-            {!hideViewCount && (
-              <ViewCountDisplayContainer
-                count={this.props.viewCount}
-                name={`puzzle:${this.props.puzzle._id}`}
-              />
-            )}
           </div>
           {this.props.puzzle.answer && answerComponent}
         </div>
@@ -733,8 +721,10 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
               target="_blank"
               rel="noreferrer noopener"
             >
-              Puzzle
-              {' '}
+              <span className="linkLabel">
+                Puzzle
+                {' '}
+              </span>
               <FontAwesomeIcon fixedWidth icon={faExternalLinkAlt} />
             </a>
           )}
@@ -743,9 +733,15 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
               <DocumentDisplay document={this.props.document} displayMode="link" />
             </span>
           )}
+          {!hideViewCount && (
+            <ViewCountDisplayContainer
+              count={this.props.viewCount}
+              name={`puzzle:${this.props.puzzle._id}`}
+            />
+          )}
           {!isAdministrivia && (
-            <Button className="puzzle-metadata-guess-button" onClick={this.showGuessModal}>
-              {this.props.puzzle.answer ? `View ${guessesString}` : `Submit answer (${guessesString})`}
+            <Button className="puzzle-metadata-guess-button btn-primary" onClick={this.showGuessModal}>
+              { this.props.puzzle.answer ? `See ${numGuesses} ${numGuesses === 1 ? 'guess' : 'guesses'}` : `Guess (${numGuesses} so far)` }
             </Button>
           )}
         </div>

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -253,7 +253,7 @@ class ViewCountDisplay extends React.Component<ViewCountDisplayProps> {
   };
 
   render() {
-    const text = `See ${this.props.count} ${this.props.count === 1 ? 'hunter' : 'hunters'}`;
+    const text = `See ${this.props.count} ${this.props.count === 1 ? 'viewer' : 'viewers'}`;
     if (this.props.subfetchesDisabled) {
       return <span>{text}</span>;
     }


### PR DESCRIPTION
Despite doing the same thing (opening a modal), the viewers and guess button have different presentations. The former is an unstyled link with a popover and the latter is a button. Since the action isn't navigation, standardize on button. Also move the viewers button to the bottom row, as it doesn't make a lot of sense inline with the title and contributes to needless line breaks there.

Change the text for both buttons to be more concise (and invoke a verb). The viewers button now reads "See \<n\> hunter(s)" while the guess button reads either "Guess (\<n\> so far)" or "See \<n\> guess(es)" depending on the solve status.

Change the labels for document links to reflect Google's naming convention (which conveniently shortens them) and use different icons for sheets and docs.

With those changes, everything fits on one line on most modern phones (using iPhone 8 as a guide). Below 375px (e.g. iPhone SE at 320px), the link labels are hidden. The link labels are hidden with css media queries, which is sufficient as long as the desktop view isn't allowed to reduce the width below 375px.