### PR TITLE
Suggestion: Use external link icon for external puzzle links

### DIFF
--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { _ } from 'meteor/underscore';
-import { faEdit, faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
+import { faEdit, faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 import React from 'react';
@@ -124,7 +124,7 @@ class Puzzle extends React.PureComponent<PuzzleProps, PuzzleState> {
             {this.props.puzzle.url ? (
               <span>
                 <a href={this.props.puzzle.url} target="_blank" rel="noopener noreferrer" title="Open the puzzle">
-                  <FontAwesomeIcon icon={faPuzzlePiece} />
+                  <FontAwesomeIcon icon={faExternalLinkAlt} />
                 </a>
               </span>
             ) : null}


### PR DESCRIPTION
Use external link icon for puzzle links in listings, consistent with the use of this icon on the puzzle page. This is consistent with #275 and, if that is adopted, this probably should be as well.

I really have no strong opinions about what icon gets used for what, but it'd be nice to be consistent. Puzzle-piece for JR link and external-link for puzzle link seems a reasonable convention, but I'm very open to suggestions. (I vaguely recall supporting puzzle-piece for links years ago...)