### PR TITLE
Replace external link icon with puzzle piece

### DIFF
--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { withTracker } from 'meteor/react-meteor-data';
 import { _ } from 'meteor/underscore';
-import { faEdit, faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
+import { faEdit, faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 import DOMPurify from 'dompurify';
@@ -728,7 +728,7 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
                 Puzzle
                 {' '}
               </span>
-              <FontAwesomeIcon fixedWidth icon={faExternalLinkAlt} />
+              <FontAwesomeIcon fixedWidth icon={faPuzzlePiece} />
             </a>
           )}
           {this.props.document && (


### PR DESCRIPTION
Per conversation with @ebroder, we're going with puzzle-piece for puzzle links. Replaces #276.