### PR TITLE
Get rid of desiredLayout hack

### DIFF
--- a/client/stylesheets/app.scss
+++ b/client/stylesheets/app.scss
@@ -1,21 +1,11 @@
-.app-content-fullscreen {
-  position: fixed;
-  top: 50px;
-  bottom: 0px;
-  left: 0px;
-  right: 0px;
-}
-
-.connection-status-fullscreen {
+.connection-status {
   position: fixed;
   top: 50px;
   left: 0px;
   right: 0px;
-  z-index: 1;
-}
-
-.app-content-scrollable {
-  padding-top: 70px;
+  // This z-index is chosen to be higher than any z-index used by Bootstrap
+  // (which are all in the 1000-1100 range)
+  z-index: 10000;
 }
 
 /* Prevent mobile safari zoom */

--- a/client/stylesheets/index.css
+++ b/client/stylesheets/index.css
@@ -1,3 +1,10 @@
+.jolly-roger {
+    /* This value is taken from the Bootstrap documentation to support
+    navbar-fixed-top:
+    https://getbootstrap.com/docs/3.4/components/#navbar-fixed-top */
+    padding-top: 70px;
+}
+
 .jolly-roger .navbar-brand {
     padding: 0;
     float: none;

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -192,8 +192,8 @@ table.puzzle-list {
 ////////////
 // Puzzle page styles
 .puzzle-page {
-  position: absolute;
-  top: 0px;
+  position: fixed;
+  top: 50px;
   bottom: 0px;
   left: 0px;
   right: 0px;

--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -98,34 +98,21 @@ const AppNavbarContainer = withTracker(() => {
   };
 })(AppNavbar);
 
-interface RouteComponent {
-  desiredLayout?: string;
-}
-
 interface AppProps {
-  routes: {component: RouteComponent}[];
   children: React.ReactNode;
 }
 
 class App extends React.Component<AppProps> {
   render() {
-    // Hack: see if the leaf route wants the fullscreen layout.
-    const { routes, children } = this.props;
-    const leafRoute = routes[routes.length - 1];
-    const layout = leafRoute.component.desiredLayout;
-
     return (
       <div>
         <NotificationCenter />
         <AppNavbarContainer />
-        {layout === 'fullscreen' && (
-          <div className="connection-status-fullscreen">
-            <ConnectionStatus />
-          </div>
-        )}
-        <div className={layout === 'fullscreen' ? 'app-content-fullscreen' : 'container-fluid app-content-scrollable'}>
-          {layout !== 'fullscreen' && <ConnectionStatus />}
-          {children}
+        <div className="connection-status">
+          <ConnectionStatus />
+        </div>
+        <div className="container-fluid">
+          {this.props.children}
         </div>
       </div>
     );

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -1309,7 +1309,5 @@ const tracker = withTracker(({ params }: PuzzlePageParams) => {
 });
 
 const PuzzlePageContainer = tracker(crumb(PuzzlePage));
-// Mark this page as needing fixed, fullscreen layout.
-(PuzzlePageContainer as any).desiredLayout = 'fullscreen';
 
 export default PuzzlePageContainer;


### PR DESCRIPTION
If we're a bit more clever with our CSS (and accept one very minor UI change - namely that the disconnect alert is always at a fixed non-scrolling position), then we can have fixed markup for the app framework and only need custom markup and styling for the actual puzzle page.

This gets rid of the fairly awkward hack where the App component was going digging through the resolved routes under it (which will make the react-router v5 upgrade easier).