### PR TITLE
Don't prefer emoji over sans-serif for most content

### DIFF
--- a/client/stylesheets/index.css
+++ b/client/stylesheets/index.css
@@ -8,7 +8,7 @@
 }
 
 .jolly-roger {
-    font-family: "Helvetica Neue", "Helvetica,Arial", "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
+    font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
 }
 
 .chat-section p, .chat-section ul, .chat-section blockquote, .chat-section pre {


### PR DESCRIPTION
Before this patch, buttons like the "See 2 guesses" button would get the emoji
block number for digits.