### PR TITLE
Fix autovalue stuff in puzzles around arrays

### DIFF
--- a/imports/lib/schemas/puzzles.ts
+++ b/imports/lib/schemas/puzzles.ts
@@ -28,7 +28,10 @@ const PuzzleFieldsOverrides: Overrides<t.TypeOf<typeof PuzzleFields>> = {
   answers: {
     autoValue() {
       if (this.isSet && this.value) {
-        return answerify(this.value);
+        if (typeof this.value === 'string') {
+          return answerify(this.value);
+        }
+        return this.value.map((x) => answerify(x));
       }
 
       return undefined;

--- a/imports/lib/schemas/typedSchemas.ts
+++ b/imports/lib/schemas/typedSchemas.ts
@@ -45,7 +45,7 @@ interface FieldInfo {
 type AutoValueFlatten<T> = T extends any[] ? T[0] : T;
 interface AutoValueThis<T> {
   key: string;
-  value: AutoValueFlatten<T>;
+  value: T | AutoValueFlatten<T>;
   closestSubschemaFieldName: string | null;
   isSet: boolean;
   unset: () => void;
@@ -63,7 +63,7 @@ interface AutoValueThis<T> {
   docId?: string;
 }
 
-type AutoValueReturn<T> = undefined | AutoValueFlatten<T> | (T extends any[] ? never :
+type AutoValueReturn<T> = undefined | T | AutoValueFlatten<T> | (T extends any[] ? never :
                                                              {$setOnInsert: T})
 
 type SharedOverrides<T> = {

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -47,7 +47,7 @@ function transitionGuess(guess: GuessType, newState: GuessType['state']) {
       _id: guess.puzzle,
     }, {
       $pull: {
-        answer: guess.guess,
+        answers: guess.guess,
       },
     });
     GlobalHooks.runPuzzleNoLongerSolvedHooks(guess.puzzle);


### PR DESCRIPTION
`autoValue` is confusing and sometimes gets the whole array (on document
creation?) and sometimes gets just the element that changed (a string, in this
case).  Loosen the types and do some runtime type-checking to deal with it.

Fix a typo in guesses where we wouldn't pull the guess from `answers` when
transitioning from correct to any other state.