### PR TITLE
Replace lots of underscore with native equivalents

### DIFF
--- a/imports/client/components/DeepLink.tsx
+++ b/imports/client/components/DeepLink.tsx
@@ -1,5 +1,4 @@
 import { Meteor } from 'meteor/meteor';
-import { _ } from 'meteor/underscore';
 import React from 'react';
 
 interface DeepLinkProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -59,11 +58,13 @@ class DeepLink extends React.Component<DeepLinkProps, DeepLinkState> {
   };
 
   render() {
-    const rest = _.omit(this.props, 'children', 'nativeUrl', 'browserUrl');
+    const {
+      children, nativeUrl, browserUrl, ...rest
+    } = this.props;
     return (
       <div onClick={this.onClick} {...rest}>
         {this.state.state === 'attemptingNative' && this.nativeIframe()}
-        {this.props.children}
+        {children}
       </div>
     );
   }

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -1,7 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { withTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import { faCopy, faSkullCrossbones, faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
@@ -361,7 +360,7 @@ class NotificationCenter extends React.Component<NotificationCenterProps, Notifi
       messages.push(<SlackMessage key="slack" onDismiss={this.hideSlackSetupMessage} />);
     }
 
-    _.forEach(this.props.guesses, (g) => {
+    this.props.guesses.forEach((g) => {
       if (this.state.dismissedGuesses[g.guess._id]) return;
       messages.push(<GuessMessage
         key={g.guess._id}
@@ -373,7 +372,7 @@ class NotificationCenter extends React.Component<NotificationCenterProps, Notifi
       />);
     });
 
-    _.forEach(this.props.announcements, (a) => {
+    this.props.announcements.forEach((a) => {
       messages.push(
         <AnnouncementMessage
           key={a.pa._id}

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -1,4 +1,3 @@
-import { _ } from 'meteor/underscore';
 import React from 'react';
 import Alert from 'react-bootstrap/lib/Alert';
 import Button from 'react-bootstrap/lib/Button';
@@ -39,10 +38,7 @@ class ProfileList extends React.Component<ProfileListProps, ProfileListState> {
 
   compileMatcher = () => {
     const searchKeys = this.state.searchString.split(' ');
-    const toMatch = _.chain(searchKeys)
-      .filter((s) => !!s)
-      .map((s) => s.toLowerCase())
-      .value();
+    const toMatch = searchKeys.filter(Boolean).map((s) => s.toLowerCase());
     const isInteresting = (profile: ProfileType) => {
       for (let i = 0; i < toMatch.length; i++) {
         const searchKey = toMatch[i];
@@ -94,7 +90,7 @@ class ProfileList extends React.Component<ProfileListProps, ProfileListState> {
   };
 
   render() {
-    const profiles = _.filter(this.props.profiles, this.compileMatcher());
+    const profiles = this.props.profiles.filter(this.compileMatcher());
     return (
       <div>
         <h1>List of hunters</h1>

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -77,8 +77,8 @@ class Puzzle extends React.PureComponent<PuzzleProps, PuzzleState> {
     const linkTarget = `/hunts/${this.props.puzzle.hunt}/puzzles/${this.props.puzzle._id}`;
     const tagIndex = _.indexBy(this.props.allTags, '_id');
     const shownTags = _.difference(this.props.puzzle.tags, this.props.suppressTags || []);
-    const ownTags = _.compact(shownTags.map((tagId) => { return tagIndex[tagId]; }));
-    const isAdministrivia = _.find(this.props.puzzle.tags, (t) => { return tagIndex[t] && tagIndex[t].name === 'administrivia'; });
+    const ownTags = shownTags.map((tagId) => { return tagIndex[tagId]; }).filter(Boolean);
+    const isAdministrivia = this.props.puzzle.tags.find((t) => { return tagIndex[t] && tagIndex[t].name === 'administrivia'; });
 
     const puzzleClasses = classnames('puzzle',
       this.props.puzzle.answers.length === this.props.puzzle.expectedAnswerCount ? 'solved' : 'unsolved',

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -124,15 +124,17 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
       // No search query, so no need to do fancy search computation
       interestingPuzzles = puzzles;
     } else {
-      const searchKeysWithEmptyKeysRemoved = _.filter(searchKeys, (key) => { return key.length > 0; });
+      const searchKeysWithEmptyKeysRemoved = searchKeys.filter((key) => { return key.length > 0; });
       const isInteresting = this.compileMatcher(searchKeysWithEmptyKeysRemoved);
-      interestingPuzzles = _.filter(puzzles, isInteresting);
+      interestingPuzzles = puzzles.filter(isInteresting);
     }
 
     if (this.state.showSolved) {
       return interestingPuzzles;
     } else {
-      return _.filter(interestingPuzzles, (puzzle) => { return !(puzzle.answers.length === puzzle.expectedAnswerCount); });
+      return interestingPuzzles.filter((puzzle) => {
+        return (puzzle.answers.length < puzzle.expectedAnswerCount);
+      });
     }
   };
 
@@ -185,7 +187,7 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
     }
 
     // Collect groups into a list.
-    const groups: PuzzleGroup[] = _.map(_.keys(groupsMap), (key) => {
+    const groups: PuzzleGroup[] = Object.keys(groupsMap).map((key) => {
       const val = groupsMap[key];
       return {
         sharedTag: tagsByIndex[key],

--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -1,4 +1,3 @@
-import { _ } from 'meteor/underscore';
 import React from 'react';
 import Alert from 'react-bootstrap/lib/Alert';
 import ControlLabel from 'react-bootstrap/lib/ControlLabel';
@@ -165,7 +164,7 @@ class PuzzleModalForm extends React.Component<PuzzleModalFormProps, PuzzleModalF
 
   tagNamesForIds = (tagIds: string[]) => {
     const tagNames: Record<string, string> = {};
-    _.each(this.props.tags, (t) => { tagNames[t._id] = t.name; });
+    this.props.tags.forEach((t) => { tagNames[t._id] = t.name; });
     return tagIds.map((t) => tagNames[t]);
   };
 
@@ -219,14 +218,11 @@ class PuzzleModalForm extends React.Component<PuzzleModalFormProps, PuzzleModalF
   render() {
     const disableForm = this.state.submitState === PuzzleModalFormSubmitState.SUBMITTING;
 
-    const selectOptions = _.chain(this.props.tags)
-      .map((t) => t.name)
-      .union(this.state.tags)
-      .compact()
+    const selectOptions = [...this.props.tags.map((t) => t.name), ...this.state.tags]
+      .filter(Boolean)
       .map((t) => {
         return { value: t, label: t };
-      })
-      .value();
+      });
 
     const docTypeSelector = !this.props.puzzle && this.state.docType ? (
       <FormGroup>

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -678,8 +678,8 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
 
   render() {
     const tagsById = _.indexBy(this.props.allTags, '_id');
-    const tags = _.compact(this.props.puzzle.tags.map((tagId) => { return tagsById[tagId]; }));
-    const isAdministrivia = _.findWhere(tags, { name: 'administrivia' });
+    const tags = this.props.puzzle.tags.map((tagId) => { return tagsById[tagId]; }).filter(Boolean);
+    const isAdministrivia = tags.find((t) => t.name === 'administrivia');
     const answerComponent = this.props.puzzle.answers.length > 0 ? (
       <span className="puzzle-metadata-answer">
         <span className="answer">{this.props.puzzle.answers.join(',')}</span>
@@ -827,7 +827,7 @@ class PuzzleGuessModal extends React.Component<PuzzleGuessModalProps, PuzzleGues
   };
 
   onSubmitGuess = () => {
-    const repeatGuess = _.find(this.props.guesses, (g) => { return g.guess === this.state.guessInput; });
+    const repeatGuess = this.props.guesses.find((g) => { return g.guess === this.state.guessInput; });
     const alreadySolved = this.props.puzzle.answers.length === this.props.puzzle.expectedAnswerCount;
     if ((repeatGuess || alreadySolved) && !this.state.confirmingSubmit) {
       const repeatGuessStr = repeatGuess ? 'This answer has already been submitted. ' : '';

--- a/imports/client/components/RelatedPuzzleGroups.tsx
+++ b/imports/client/components/RelatedPuzzleGroups.tsx
@@ -21,7 +21,7 @@ class RelatedPuzzleGroups extends React.Component<RelatedPuzzleGroupsProps> {
     layout: 'grid',
   };
 
-  relatedPuzzlesTagInterestingness = (tag: TagType, metaForTagIfKnown: TagType | null) => {
+  relatedPuzzlesTagInterestingness = (tag: TagType, metaForTagIfKnown: TagType | null | undefined) => {
     // Maps a tag into an interestingness class.  Smaller numbers are more interesting.
     // group: tags go at the beginning of the list, because you're
     // most interested in the other puzzles from this meta/round.
@@ -48,7 +48,7 @@ class RelatedPuzzleGroups extends React.Component<RelatedPuzzleGroupsProps> {
     const tagList = tags.slice(0);
 
     // Look for a tag that starts with 'meta-for:'.
-    const metaForTag = _.filter(tags, (tag) => { return tag.name.lastIndexOf('meta-for:', 0) === 0; })[0];
+    const metaForTag = tags.find((tag) => { return tag.name.lastIndexOf('meta-for:', 0) === 0; });
 
     tagList.sort((a, b) => {
       const ia = this.relatedPuzzlesTagInterestingness(a, metaForTag);
@@ -65,7 +65,7 @@ class RelatedPuzzleGroups extends React.Component<RelatedPuzzleGroupsProps> {
   };
 
   puzzlesWithTagIdExcept = (puzzles: PuzzleType[], tagId: string, puzzleId: string) => {
-    return _.filter(puzzles, (p) => {
+    return puzzles.filter((p) => {
       return p._id !== puzzleId && p.tags.indexOf(tagId) !== -1;
     });
   };
@@ -77,9 +77,9 @@ class RelatedPuzzleGroups extends React.Component<RelatedPuzzleGroupsProps> {
 
     // TODO: sort the tag groups by tag interestingness, which should probably be related to meta
     // presence/absence, tag group size, and number of solved/unsolved?
-    const activePuzzleTags = this.sortedTagsForRelatedPuzzles(_.compact(_.map(this.props.activePuzzle.tags, (tagId) => {
+    const activePuzzleTags = this.sortedTagsForRelatedPuzzles(this.props.activePuzzle.tags.map((tagId) => {
       return tagIndex[tagId];
-    })));
+    }).filter(Boolean));
 
     for (let tagi = 0; tagi < activePuzzleTags.length; tagi++) {
       const tag = activePuzzleTags[tagi];

--- a/imports/client/components/TagEditor.tsx
+++ b/imports/client/components/TagEditor.tsx
@@ -1,5 +1,4 @@
 import { withTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import React from 'react';
 import Creatable from 'react-select/lib/Creatable';
 import Tags from '../../lib/models/tags';
@@ -24,13 +23,12 @@ class TagEditor extends React.Component<TagEditorProps> {
   };
 
   render() {
-    const options = _.chain(this.props.allTags)
+    const options = this.props.allTags
       .map((t) => t.name)
-      .compact()
+      .filter(Boolean)
       .map((t) => {
         return { value: t, label: t };
-      })
-      .value();
+      });
 
     return (
       <span style={{ display: 'inline-block', minWidth: '200px' }}>

--- a/imports/lib/models/base.ts
+++ b/imports/lib/models/base.ts
@@ -71,17 +71,13 @@ class Base<T extends BaseType> extends Mongo.Collection<T> {
 
   [formatOptions]<Opts extends FindOneOptions>(opts: Opts): Opts {
     if (opts.fields) {
-      return _.extend(
-        {},
-        opts,
-        {
-          fields: _.extend(
-            {},
-            opts.fields,
-            { deleted: 1 },
-          ),
+      return {
+        ...opts,
+        fields: {
+          ...opts.fields,
+          deleted: 1,
         },
-      );
+      };
     }
 
     return opts;

--- a/imports/lib/models/hunts.ts
+++ b/imports/lib/models/hunts.ts
@@ -1,6 +1,5 @@
 import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
-import { _ } from 'meteor/underscore';
 import HuntsSchema, { HuntType } from '../schemas/hunts';
 import Base from './base';
 
@@ -15,7 +14,17 @@ Hunts.publish();
 // already and if the hunt allows open signups.
 // It's possible we should always allow operators to add someone to a hunt?
 Roles.loggedInRole.allow('hunt.join', (huntId) => {
-  if (!_.include(Meteor.user()!.hunts, huntId)) {
+  const user = Meteor.user();
+  if (!user) {
+    return false;
+  }
+
+  const joinedHunts = user.hunts;
+  if (!joinedHunts) {
+    return false;
+  }
+
+  if (!joinedHunts.includes(huntId)) {
     return false;
   }
 

--- a/imports/lib/models/pending_announcements.ts
+++ b/imports/lib/models/pending_announcements.ts
@@ -1,5 +1,4 @@
 import { Roles } from 'meteor/nicolaslopezj:roles';
-import { _ } from 'meteor/underscore';
 import PendingAnnouncementsSchema, { PendingAnnouncementType } from '../schemas/pending_announcements';
 import Base from './base';
 
@@ -8,7 +7,7 @@ PendingAnnouncements.attachSchema(PendingAnnouncementsSchema);
 PendingAnnouncements.publish(function (q) {
   // It's sufficient to use the user property for filtering here; we
   // don't need to pay attention to the hunt ID
-  return _.extend({}, q, { user: this.userId });
+  return { ...q, user: this.userId };
 });
 
 // Users can delete their own notifications

--- a/imports/lib/models/puzzles.ts
+++ b/imports/lib/models/puzzles.ts
@@ -1,4 +1,3 @@
-import { _ } from 'meteor/underscore';
 import { huntsMatchingCurrentUser } from '../../model-helpers';
 import ActiveOperatorRole from '../active-operator-role';
 import PuzzlesSchema, { PuzzleType } from '../schemas/puzzles';
@@ -6,7 +5,7 @@ import Base from './base';
 
 const Puzzles = new Base<PuzzleType>('puzzles', {
   transform(doc: PuzzleType): PuzzleType {
-    return _.extend({}, doc, { tags: _.uniq(doc.tags) });
+    return { ...doc, tags: [...new Set(doc.tags)] };
   },
 });
 Puzzles.attachSchema(PuzzlesSchema);

--- a/imports/model-helpers.ts
+++ b/imports/model-helpers.ts
@@ -30,7 +30,7 @@ const huntsMatchingCurrentUser = function <T extends HuntModel> (
   if (!u) {
     throw new Meteor.Error(401, 'Unauthenticated');
   }
-  const q = _.clone(origQuery);
+  const q = { ...origQuery };
   let huntList: T['hunt'][];
 
   if (q.hunt) {

--- a/imports/server/gdrive.ts
+++ b/imports/server/gdrive.ts
@@ -1,5 +1,4 @@
 import { Meteor } from 'meteor/meteor';
-import { _ } from 'meteor/underscore';
 import Ansible from '../ansible';
 import Flags from '../flags';
 import Documents from '../lib/models/documents';
@@ -23,7 +22,7 @@ function checkClientOk() {
 }
 
 function createDocument(name: string, type: keyof typeof MimeTypes): string {
-  if (!_.has(MimeTypes, type)) {
+  if (!Object.prototype.hasOwnProperty.call(MimeTypes, type)) {
     throw new Meteor.Error(400, `Invalid document type ${type}`);
   }
   checkClientOk();

--- a/imports/server/hunts.ts
+++ b/imports/server/hunts.ts
@@ -3,7 +3,6 @@ import { check } from 'meteor/check';
 import { Email } from 'meteor/email';
 import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
-import { _ } from 'meteor/underscore';
 import Ansible from '../ansible';
 import Hunts from '../lib/models/hunts';
 import Profiles from '../lib/models/profiles';
@@ -74,9 +73,9 @@ Meteor.methods({
     Meteor.users.update(joineeUser._id, { $addToSet: { hunts: { $each: [huntId] } } });
     const joineeEmails = (joineeUser.emails || []).map((e) => e.address);
 
-    _.each(hunt.mailingLists, (listName) => {
+    hunt.mailingLists.forEach((listName) => {
       const list = new List(listName);
-      _.each(joineeEmails, (joineeEmail) => {
+      joineeEmails.forEach((joineeEmail) => {
         if (!list.add(joineeEmail)) {
           Ansible.log('Unable to add user to list', { joineeEmail, list: listName });
         }

--- a/imports/server/puzzle.ts
+++ b/imports/server/puzzle.ts
@@ -2,7 +2,6 @@ import { Match, check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { Random } from 'meteor/random';
-import { _ } from 'meteor/underscore';
 import Ansible from '../ansible';
 import Flags from '../flags';
 import DocumentPermissions from '../lib/models/document_permissions';
@@ -61,7 +60,7 @@ Meteor.methods({
     const fullPuzzle = {
       ...puzzle,
       _id: Random.id(),
-      tags: _.uniq(tagIds),
+      tags: [...new Set(tagIds)],
       answers: [],
     };
 
@@ -118,12 +117,12 @@ Meteor.methods({
     });
     Puzzles.update(
       puzzleId,
-      { $set: { ...puzzle, tags: _.uniq(tagIds) } },
+      { $set: { ...puzzle, tags: [...new Set(tagIds)] } },
     );
 
     if (oldPuzzle.title !== puzzle.title) {
       Meteor.defer(Meteor.bindEnvironment(() => {
-        const doc = ensureDocument(_.extend({ _id: puzzleId }, puzzle));
+        const doc = ensureDocument({ _id: puzzleId, ...puzzle });
         renameDocument(doc.value.id, `${puzzle.title}: Death and Mayhem`);
       }));
     }
@@ -199,7 +198,7 @@ Meteor.methods({
 
     const user = Meteor.users.findOne(this.userId)!;
     const puzzle = Puzzles.findOne(puzzleId);
-    if (!puzzle || !_.contains(user.hunts, puzzle.hunt)) {
+    if (!puzzle || !user.hunts.includes(puzzle.hunt)) {
       throw new Meteor.Error(404, 'Unknown puzzle');
     }
 

--- a/imports/server/subscribers.ts
+++ b/imports/server/subscribers.ts
@@ -9,7 +9,6 @@
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
-import { _ } from 'meteor/underscore';
 import moment from 'moment';
 import Flags from '../flags';
 import Servers from './models/servers';
@@ -95,7 +94,7 @@ Meteor.publish('subscribers.counts', function (q: Record<string, any>) {
   const handle = cursor.observe({
     added: (doc) => {
       const { name, user } = doc;
-      if (!_.has(counters, name)) {
+      if (!Object.prototype.hasOwnProperty.call(counters, name)) {
         counters[name] = {};
 
         if (initialized) {
@@ -103,13 +102,13 @@ Meteor.publish('subscribers.counts', function (q: Record<string, any>) {
         }
       }
 
-      if (!_.has(counters[name], user)) {
+      if (!Object.prototype.hasOwnProperty.call(counters[name], user)) {
         counters[name][user] = 0;
       }
 
       counters[name][user] += 1;
       if (initialized) {
-        this.changed('subscribers.counts', name, { value: _.keys(counters[name]).length });
+        this.changed('subscribers.counts', name, { value: Object.keys(counters[name]).length });
       }
     },
 
@@ -122,14 +121,14 @@ Meteor.publish('subscribers.counts', function (q: Record<string, any>) {
       }
 
       if (initialized) {
-        this.changed('subscribers.counts', name, { value: _.keys(counters[name]).length });
+        this.changed('subscribers.counts', name, { value: Object.keys(counters[name]).length });
       }
     },
   });
   this.onStop(() => handle.stop());
 
-  _.each(counters, (val, key) => {
-    this.added('subscribers.counts', key, { value: _.keys(val).length });
+  Object.entries(counters).forEach(([key, val]) => {
+    this.added('subscribers.counts', key, { value: Object.keys(val).length });
   });
   initialized = true;
   this.ready();
@@ -155,7 +154,7 @@ Meteor.publish('subscribers.fetch', function (name) {
     added: (doc) => {
       const { user } = doc;
 
-      if (!_.has(users, user)) {
+      if (!Object.prototype.hasOwnProperty.call(users, user)) {
         users[user] = 0;
         this.added('subscribers', `${name}:${user}`, { name, user });
       }


### PR DESCRIPTION
Mostly a lift of #279 with a couple merge fixes and guarding against null `Meteor.user().hunts`
in the `hunt.join` allow rule (which is why we had to revert #279).