### PR TITLE
Add Discord server configuration, OAuth flow, and automate guild invitations

### DIFF
--- a/client/stylesheets/setup.scss
+++ b/client/stylesheets/setup.scss
@@ -4,14 +4,14 @@
   }
 }
 
-.gdrive-subsection {
+.setup-subsection {
   &:not(:last-child) {
     border-bottom: 1px solid #ccc;
     padding-bottom: 16px;
     margin-bottom: 16px;
   }
 }
-.gdrive-subsection-header {
+.setup-subsection-header {
   font-size: 16px;
   font-weight: bold;
   //background-color: #f0f0f0

--- a/imports/client/discord.ts
+++ b/imports/client/discord.ts
@@ -1,4 +1,9 @@
+import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
+import { OAuth } from 'meteor/oauth';
+import { Random } from 'meteor/random';
+import { ServiceConfiguration } from 'meteor/service-configuration';
+import { API_BASE, DiscordOAuthScopes } from '../lib/discord';
 
 // Psuedo-collection used by setup for selecting guild
 export type DiscordGuildType = {
@@ -6,3 +11,40 @@ export type DiscordGuildType = {
   name: string;
 }
 export const DiscordGuilds = new Mongo.Collection<DiscordGuildType>('discord.guilds');
+
+function requestDiscordCredential(credentialRequestCompleteCallback: any) {
+  const options = {};
+  const config = ServiceConfiguration.configurations.findOne({ service: 'discord' });
+  if (!config) {
+    if (credentialRequestCompleteCallback) {
+      credentialRequestCompleteCallback(new Meteor.Error(400, 'Discord service not configured'));
+    }
+    return;
+  }
+
+  const credentialToken = Random.secret();
+  // eslint-disable-next-line no-underscore-dangle
+  const loginStyle = OAuth._loginStyle('discord', config, options || {});
+  const loginUrlParameters = {
+    response_type: 'code',
+    client_id: config.appId,
+    scope: DiscordOAuthScopes.join(' '),
+    redirect_uri: OAuth._redirectUri('discord', config),
+    // eslint-disable-next-line no-underscore-dangle
+    state: OAuth._stateParam(loginStyle, credentialToken, undefined),
+  };
+  const loginUrlParamString = Object.keys(loginUrlParameters).map((param) => {
+    return `${encodeURIComponent(param)}=${encodeURIComponent((<any> loginUrlParameters)[param])}`;
+  }).join('&');
+  const loginUrl = `${API_BASE}/oauth2/authorize?${loginUrlParamString}`;
+
+  OAuth.launchLogin({
+    loginService: 'discord',
+    loginStyle,
+    loginUrl,
+    credentialRequestCompleteCallback,
+    credentialToken,
+  });
+}
+
+export { requestDiscordCredential };

--- a/imports/client/discord.ts
+++ b/imports/client/discord.ts
@@ -1,0 +1,8 @@
+import { Mongo } from 'meteor/mongo';
+
+// Psuedo-collection used by setup for selecting guild
+export type DiscordGuildType = {
+  _id: string;
+  name: string;
+}
+export const DiscordGuilds = new Mongo.Collection<DiscordGuildType>('discord.guilds');

--- a/imports/lib/discord.ts
+++ b/imports/lib/discord.ts
@@ -1,0 +1,4 @@
+const DiscordOAuthScopes = ['identify', 'guilds.join'];
+const API_BASE = 'https://discord.com/api/v8';
+
+export { API_BASE, DiscordOAuthScopes };

--- a/imports/lib/roles.ts
+++ b/imports/lib/roles.ts
@@ -3,6 +3,8 @@ import { Roles } from 'meteor/nicolaslopezj:roles';
 Roles.registerAction('gdrive.credential', true);
 Roles.registerAction('google.configureOAuth', true);
 Roles.registerAction('hunt.join', true);
+Roles.registerAction('discord.configureOAuth', true);
+Roles.registerAction('discord.configureBot', true);
 Roles.registerAction('users.makeOperator', true);
 
 const InactiveOperatorRole = new Roles.Role('inactiveOperator');

--- a/imports/lib/schemas/discord_account.ts
+++ b/imports/lib/schemas/discord_account.ts
@@ -1,0 +1,10 @@
+import * as t from 'io-ts';
+
+const DiscordAccountType = t.type({
+  id: t.string,
+  username: t.string,
+  discriminator: t.string,
+  avatar: t.union([t.string, t.undefined]),
+});
+
+export default DiscordAccountType;

--- a/imports/lib/schemas/profiles.ts
+++ b/imports/lib/schemas/profiles.ts
@@ -1,11 +1,13 @@
 import * as t from 'io-ts';
 import { BaseCodec, BaseOverrides } from './base';
+import DiscordAccountType from './discord_account';
 import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
 
 const ProfileFieldsType = t.type({
   // Autopopulated with the first of the user's email addresses?
   primaryEmail: t.string,
   googleAccount: t.union([t.string, t.undefined]),
+  discordAccount: t.union([DiscordAccountType, t.undefined]),
   // Initial value: ""
   displayName: t.string,
   phoneNumber: t.union([t.string, t.undefined]),

--- a/imports/lib/schemas/settings.ts
+++ b/imports/lib/schemas/settings.ts
@@ -4,6 +4,10 @@ import { inheritSchema, buildSchema } from './typedSchemas';
 
 // We can't represent tagged unions in SimpleSchema, so we use different types
 // for the actual type vs. the type used to derive the schema.
+const GuildType = t.type({
+  _id: t.string,
+  name: t.string,
+});
 export const SettingCodec = t.intersection([
   BaseCodec,
   t.taggedUnion('name', [
@@ -21,6 +25,18 @@ export const SettingCodec = t.intersection([
     t.type({
       name: t.literal('gdrive.template.spreadsheet'),
       value: t.type({ id: t.string }),
+    }),
+    t.type({
+      name: t.literal('discord.bot'),
+      value: t.type({
+        token: t.string,
+      }),
+    }),
+    t.type({
+      name: t.literal('discord.guild'),
+      value: t.type({
+        guild: GuildType,
+      }),
     }),
   ]),
 ]);

--- a/imports/server/discord.ts
+++ b/imports/server/discord.ts
@@ -1,0 +1,143 @@
+import { HTTP } from 'meteor/http';
+import { Meteor } from 'meteor/meteor';
+import { OAuth } from 'meteor/oauth';
+import { ServiceConfiguration } from 'meteor/service-configuration';
+// import Flags from '../flags'; // TODO: allow disabling via featureflag
+import { API_BASE, DiscordOAuthScopes } from '../lib/discord';
+
+class DiscordAPIClient {
+  private accessToken: string;
+
+  constructor(accessToken: string) {
+    this.accessToken = accessToken;
+  }
+
+  retrieveUserInfo = () => {
+    let response;
+    try {
+      response = HTTP.get(`${API_BASE}/users/@me`, {
+        headers: {
+          Authorization: `Bearer ${this.accessToken}`,
+        },
+      });
+    } catch (err) {
+      throw Object.assign(
+        new Meteor.Error(`Failed to retrieve user data from Discord. ${err.message}`),
+        { response: err.response }
+      );
+    }
+
+    return {
+      id: response.data.id,
+      username: response.data.username,
+      discriminator: response.data.discriminator,
+      avatar: response.data.avatar,
+    };
+  };
+}
+
+class DiscordBot {
+  private botToken: string;
+
+  constructor(botToken: string) {
+    this.botToken = botToken;
+  }
+
+  authHeaders = () => {
+    return {
+      headers: {
+        Authorization: `Bot ${this.botToken}`,
+      },
+    };
+  };
+
+  listGuilds = () => {
+    const response = HTTP.get(`${API_BASE}/users/@me/guilds`, {
+      ...this.authHeaders(),
+    });
+
+    return response.data;
+  };
+
+  getUserInGuild = (discordUserId: string, guildId: string) => {
+    let response;
+    try {
+      response = HTTP.get(`${API_BASE}/guilds/${guildId}/members/${discordUserId}`, {
+        ...this.authHeaders(),
+      });
+    } catch (err) {
+      if (err.response && err.response.statusCode === 404) {
+        // No such user.
+        return undefined;
+      }
+
+      throw Object.assign(
+        new Meteor.Error(`Failed to retrieve guild ${guildId} member with discord user id ${discordUserId}. ${err.message}`),
+        { response: err.response }
+      );
+    }
+
+    return response.data;
+  };
+
+  addUserToGuild = (discordUserId: string, discordUserToken: string, guildId: string) => {
+    try {
+      const opts = {
+        ...this.authHeaders(),
+        data: {
+          access_token: discordUserToken,
+        },
+      };
+      HTTP.put(`${API_BASE}/guilds/${guildId}/members/${discordUserId}`, opts);
+    } catch (err) {
+      throw Object.assign(
+        new Meteor.Error(`Failed to add discord user ${discordUserId} to guild ${guildId}. ${err.message}`),
+        { response: err.response }
+      );
+    }
+  };
+}
+
+const handleOauthRequest = (query: any) => {
+  const config = ServiceConfiguration.configurations.findOne({ service: 'discord' });
+  if (!config) {
+    throw new Meteor.Error('Missing service configuration for discord');
+  }
+
+  let response;
+  try {
+    response = HTTP.post(`${API_BASE}/oauth2/token`, {
+      params: {
+        client_id: config.appId,
+        client_secret: OAuth.openSecret(config.secret),
+        grant_type: 'authorization_code',
+        code: query.code,
+        redirect_uri: OAuth._redirectUri('discord', config),
+        scope: DiscordOAuthScopes.join(' '),
+      },
+    });
+  } catch (err) {
+    throw Object.assign(
+      new Meteor.Error(`Failed to complete OAuth handshake with Discord. ${err.message}`),
+      { response: err.response }
+    );
+  }
+
+  return {
+    serviceData: {
+      accessToken: response.data.access_token,
+      tokenType: response.data.token_type,
+      refreshToken: response.data.refresh_token,
+      receivedAt: new Date(),
+      // `expiresIn` is the number of seconds since `receivedAt` at which this
+      // access token expires.  The refresh token is presumably good
+      // indefinitely.
+      expiresIn: response.data.expires_in,
+      scope: response.data.scope,
+    },
+  };
+};
+
+OAuth.registerService('discord', 2, null, handleOauthRequest);
+
+export { DiscordAPIClient, DiscordBot };

--- a/imports/server/profile.ts
+++ b/imports/server/profile.ts
@@ -1,8 +1,11 @@
 import { check } from 'meteor/check';
 import { Google } from 'meteor/google-oauth';
 import { Meteor } from 'meteor/meteor';
+import { OAuth } from 'meteor/oauth';
 import Ansible from '../ansible';
 import Profiles from '../lib/models/profiles';
+import Settings from '../lib/models/settings';
+import { DiscordAPIClient, DiscordBot } from './discord';
 
 Meteor.methods({
   saveProfile(newProfile: unknown) {
@@ -54,5 +57,78 @@ Meteor.methods({
   unlinkUserGoogleAccount() {
     check(this.userId, String);
     Profiles.update(this.userId, { $unset: { googleAccount: 1 } });
+  },
+
+  linkUserDiscordAccount(key: unknown, secret: unknown) {
+    check(this.userId, String);
+    check(key, String);
+    check(secret, String);
+
+    // Retrieve the OAuth token from the OAuth subsystem.
+    const credential = OAuth.retrieveCredential(key, secret);
+    Ansible.log('Linking user to Discord account', {
+      user: this.userId,
+    });
+
+    // Save the user's credentials to their User object, under services.discord.
+    Meteor.users.update(this.userId, {
+      $set: {
+        'services.discord': credential.serviceData,
+      },
+    });
+
+    // Use OAuth token to retrieve user's identifier
+    const { accessToken } = credential.serviceData;
+    const apiClient = new DiscordAPIClient(accessToken);
+    const userInfo = apiClient.retrieveUserInfo();
+
+    // Save user's id, identifier, and avatar to their profile.
+    Profiles.update(this.userId, {
+      $set: {
+        discordAccount: userInfo,
+      },
+    });
+
+    // Invite the user to the guild, if one is configured.
+    const discordGuildDoc = Settings.findOne({ name: 'discord.guild' });
+    const guild = discordGuildDoc && discordGuildDoc.name === 'discord.guild' && discordGuildDoc.value.guild;
+
+    const discordBotTokenDoc = Settings.findOne({ name: 'discord.bot' });
+    const botToken = discordBotTokenDoc && discordBotTokenDoc.name === 'discord.bot' && discordBotTokenDoc.value.token;
+
+    if (guild && botToken) {
+      // Invitations to the guild must be performed by the bot user.
+      const bot = new DiscordBot(botToken);
+      // If the user is already in the guild, no need to add them again.
+      const guildMember = bot.getUserInGuild(userInfo.id, guild._id);
+      if (!guildMember) {
+        Ansible.log('Adding user to guild', {
+          user: this.userId,
+          discordUser: userInfo.id,
+          guild: guild._id,
+        });
+        bot.addUserToGuild(userInfo.id, accessToken, guild._id);
+      } else {
+        Ansible.log('User is already a member of guild', {
+          user: this.userId,
+          discordUser: userInfo.id,
+          guild: guild._id,
+        });
+      }
+    }
+  },
+
+  unlinkUserDiscordAccount() {
+    check(this.userId, String);
+
+    // TODO: tell Discord to revoke the token?
+
+    // Remove token (secret) from the user object in the database.
+    Meteor.users.update(this.userId, {
+      $unset: { 'services.discord': '' },
+    });
+
+    // Remove display name from user's profile object.
+    Profiles.update(this.userId, { $unset: { discordAccount: 1 } });
   },
 });

--- a/imports/server/setup.ts
+++ b/imports/server/setup.ts
@@ -1,5 +1,6 @@
 import { Match, check } from 'meteor/check';
 import { Google } from 'meteor/google-oauth';
+import { HTTP } from 'meteor/http';
 import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { ServiceConfiguration } from 'meteor/service-configuration';
@@ -75,4 +76,127 @@ Meteor.methods({
       Settings.remove({ name: 'gdrive.template.document' });
     }
   },
+
+  setupDiscordOAuthClient(clientId: unknown, clientSecret: unknown) {
+    check(this.userId, String);
+    check(clientId, String);
+    check(clientSecret, String);
+    Roles.checkPermission(this.userId, 'discord.configureOAuth');
+
+    if (!clientId && !clientSecret) {
+      Ansible.log('Disabling discord oauth client', {
+        user: this.userId,
+      });
+      ServiceConfiguration.configurations.remove({ service: 'discord' });
+      return;
+    }
+
+    Ansible.log('Configuring discord oauth client', {
+      clientId,
+      user: this.userId,
+    });
+
+    // Test the client id/secret.
+    const postData = 'grant_type=client_credentials&scope=identify+connections';
+    const headers = {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    };
+    const authString = `${clientId}:${clientSecret}`;
+    const resp = HTTP.post('https://discord.com/api/v8/oauth2/token', {
+      content: postData,
+      headers,
+      auth: authString,
+    });
+
+    if (resp.statusCode === 200) {
+      ServiceConfiguration.configurations.upsert({ service: 'discord' }, {
+        $set: {
+          appId: clientId,
+          secret: clientSecret,
+          loginStyle: 'popup',
+        },
+      });
+    } else {
+      throw new Meteor.Error('Discord credential test failed');
+    }
+  },
+
+  setupDiscordBotToken(token: unknown) {
+    check(this.userId, String);
+    check(token, String);
+    Roles.checkPermission(this.userId, 'discord.configureBot');
+
+    if (token) {
+      Ansible.log('Configuring discord bot token (token redacted)', {
+        user: this.userId,
+      });
+      Settings.upsert({ name: 'discord.bot' },
+        { $set: { 'value.token': token } });
+    } else {
+      Ansible.log('Discarding discord bot token', {
+        user: this.userId,
+      });
+      Settings.remove({ name: 'discord.bot' });
+    }
+  },
+
+  setupDiscordBotGuild(guild: unknown) {
+    check(this.userId, String);
+    Roles.checkPermission(this.userId, 'discord.configureBot');
+    check(guild, Match.Maybe({
+      _id: String,
+      name: String,
+    }));
+
+    if (guild) {
+      Ansible.log('Configuring discord bot guild', {
+        user: this.userId,
+        ...guild,
+      });
+      Settings.upsert({ name: 'discord.guild' }, {
+        $set: { 'value.guild': guild },
+      });
+    } else {
+      Settings.remove({ name: 'discord.guild' });
+    }
+  },
+});
+
+Meteor.publish('discord.guilds', function () {
+  // Only allow admins to list guilds
+  if (!this.userId || !Roles.userHasPermission(this.userId, 'discord.configureBot')) {
+    Ansible.log('Sub to discord.guilds not logged in as admin');
+    return [];
+  }
+
+  const botSettings = Settings.findOne({ name: 'discord.bot' });
+  if (!botSettings || botSettings.name !== 'discord.bot') {
+    Ansible.log('Sub to discord.guilds: no bot settings');
+    return [];
+  }
+
+  const token = botSettings.value && botSettings.value.token;
+  if (!token) {
+    Ansible.log('Sub to discord.guilds: no bot token');
+    return [];
+  }
+
+  // Make HTTP request to discord API.
+  const resp = HTTP.get('https://discord.com/api/v8/users/@me/guilds', {
+    headers: {
+      Authorization: `Bot ${token}`,
+    },
+  });
+
+  if (resp.statusCode !== 200) {
+    Ansible.log('Sub to discord.guilds: discord remote error', { resp });
+    return [];
+  }
+
+  resp.data.forEach((guild: any) => {
+    this.added('discord.guilds', guild.id, { name: guild.name });
+  });
+  this.ready();
+  // eslint-disable-next-line
+  return;
 });

--- a/server/main.ts
+++ b/server/main.ts
@@ -14,6 +14,7 @@ import '../imports/server/ansible';
 import '../imports/server/api-init';
 import '../imports/server/api_keys';
 import '../imports/server/chat';
+import '../imports/server/discord';
 import '../imports/server/feature_flags';
 import '../imports/server/fixture';
 import '../imports/server/git_revision';

--- a/types/oauth/index.d.ts
+++ b/types/oauth/index.d.ts
@@ -1,6 +1,12 @@
 declare module 'meteor/oauth' {
   export module OAuth {
+    function _loginStyle(service: string, config: any, options: any): string;
     function _redirectUri(service: string, config: any): string;
     function _retrieveCredentialSecret(token: string): string;
+    function _stateParam(loginStyle: string, credentialToken: string, redirectUrl: string): string;
+    function launchLogin(options: any): void;
+    function openSecret(serviceData: string, userId?: string): string;
+    function registerService(name: string, version: number, urls: string[] | null,
+                             handleOauthRequest: Function): void;
   }
 }

--- a/types/oauth/index.d.ts
+++ b/types/oauth/index.d.ts
@@ -3,10 +3,11 @@ declare module 'meteor/oauth' {
     function _loginStyle(service: string, config: any, options: any): string;
     function _redirectUri(service: string, config: any): string;
     function _retrieveCredentialSecret(token: string): string;
-    function _stateParam(loginStyle: string, credentialToken: string, redirectUrl: string): string;
+    function _stateParam(loginStyle: string, credentialToken: string, redirectUrl?: string): string;
     function launchLogin(options: any): void;
     function openSecret(serviceData: string, userId?: string): string;
     function registerService(name: string, version: number, urls: string[] | null,
                              handleOauthRequest: Function): void;
+    function retrieveCredential(key: string, secret: string): any;
   }
 }


### PR DESCRIPTION
This is a rather-large patchset that implements a baseline Discord integration capable of automating guild invitations.

The first commit adds server configuration at `/setup`.  We introduce a new `ServiceConfiguration` with `{ name: 'discord' }` to hold the OAuth client ID and client secret, following the same general scheme as other OAuth integrations.  We add two new `Settings` keys, `discord.bot` and `discord.guild` to keep track of the bot client token and the guild we intend to this server to help manage.

The second commit implements OAuth2 login, account linking, and guild invitation.  The flow starts on ProfilePage.tsx, traverses the usual Meteor OAuth machinery, and then once a token has been obtained, bottoms out in the Meteor methods in `imports/server/profile.ts`.

Fixes #320.