### PR TITLE
Remove circuit-breakers for subscription counters/watchers

### DIFF
--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -13,7 +13,6 @@ import ToggleButton from 'react-bootstrap/ToggleButton';
 import ToggleButtonGroup from 'react-bootstrap/ToggleButtonGroup';
 import { RouteComponentProps } from 'react-router';
 import { Link } from 'react-router-dom';
-import Flags from '../../flags';
 import Puzzles from '../../lib/models/puzzles';
 import Tags from '../../lib/models/tags';
 import { PuzzleType } from '../../lib/schemas/puzzles';
@@ -452,10 +451,8 @@ const PuzzleListPageContainer = withTracker(({ match }: PuzzleListPageWithRouter
   const puzzlesHandle = Meteor.subscribe('mongo.puzzles', { hunt: match.params.huntId });
   const tagsHandle = Meteor.subscribe('mongo.tags', { hunt: match.params.huntId });
 
-  if (!Flags.active('disable.subcounters')) {
-    // Don't bother including this in ready - it's ok if it trickles in
-    Meteor.subscribe('subscribers.counts', { hunt: match.params.huntId });
-  }
+  // Don't bother including this in ready - it's ok if it trickles in
+  Meteor.subscribe('subscribers.counts', { hunt: match.params.huntId });
 
   const ready = puzzlesHandle.ready() && tagsHandle.ready();
   if (!ready) {

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -29,7 +29,6 @@ import DocumentTitle from 'react-document-title';
 import { RouteComponentProps } from 'react-router';
 import TextareaAutosize from 'react-textarea-autosize';
 import Ansible from '../../ansible';
-import Flags from '../../flags';
 import ChatMessages from '../../lib/models/chats';
 import Documents from '../../lib/models/documents';
 import Guesses from '../../lib/models/guess';
@@ -610,7 +609,6 @@ interface PuzzlePageMetadataParams {
 }
 
 interface PuzzlePageMetadataProps extends PuzzlePageMetadataParams {
-  subcountersDisabled: boolean;
   viewCount: number;
   canUpdate: boolean;
 }
@@ -679,7 +677,6 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
         <span className="answer">{this.props.puzzle.answers.join(',')}</span>
       </span>
     ) : null;
-    const hideViewCount = this.props.subcountersDisabled;
     const numGuesses = this.props.guesses.length;
 
     return (
@@ -731,12 +728,10 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
               <DocumentDisplay document={this.props.document} displayMode="link" />
             </span>
           )}
-          {!hideViewCount && (
-            <ViewCountDisplay
-              count={this.props.viewCount}
-              name={`puzzle:${this.props.puzzle._id}`}
-            />
-          )}
+          <ViewCountDisplay
+            count={this.props.viewCount}
+            name={`puzzle:${this.props.puzzle._id}`}
+          />
           {!isAdministrivia && (
             <Button variant="primary" className="puzzle-metadata-guess-button" onClick={this.showGuessModal}>
               { this.props.puzzle.answers.length === this.props.puzzle.expectedAnswerCount ? `See ${numGuesses} ${numGuesses === 1 ? 'guess' : 'guesses'}` : `Guess (${numGuesses} so far)` }
@@ -758,7 +753,6 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
 const PuzzlePageMetadataContainer = withTracker(({ puzzle }: PuzzlePageMetadataParams) => {
   const count = SubscriberCounters.findOne(`puzzle:${puzzle._id}`);
   return {
-    subcountersDisabled: Flags.active('disable.subcounters'),
     viewCount: count ? count.value : 0,
     canUpdate: Roles.userHasPermission(Meteor.userId(), 'mongo.puzzles.update'),
   };
@@ -1256,14 +1250,12 @@ const tracker = withTracker(({ match }: PuzzlePageWithRouterParams) => {
   // * Related puzzles probably only needs puzzles and tags, but right now it just gets the same
   //   data that the puzzle metadata gets, so it blocks maybe-unnecessarily.
 
-  if (!Flags.active('disable.subcounters')) {
-    // Keep a count of how many people are viewing a puzzle. Don't use
-    // the subs manager - we don't want this cached
-    Meteor.subscribe('subscribers.inc', `puzzle:${params.puzzleId}`, {
-      puzzle: params.puzzleId,
-      hunt: params.huntId,
-    });
-  }
+  // Add the current user to the collection of people viewing this puzzle.
+  // Don't use the subs manager - we don't want this cached.
+  Meteor.subscribe('subscribers.inc', `puzzle:${params.puzzleId}`, {
+    puzzle: params.puzzleId,
+    hunt: params.huntId,
+  });
 
   const displayNamesHandle = Profiles.subscribeDisplayNames();
   let displayNames = {};
@@ -1276,9 +1268,8 @@ const tracker = withTracker(({ match }: PuzzlePageWithRouterParams) => {
   const guessesHandle = Meteor.subscribe('mongo.guesses', { puzzle: params.puzzleId });
   const documentsHandle = Meteor.subscribe('mongo.documents', { puzzle: params.puzzleId });
 
-  if (!Flags.active('disable.subcounters')) {
-    Meteor.subscribe('subscribers.counts', { hunt: params.huntId });
-  }
+  // Track the tally of people viewing this puzzle.
+  Meteor.subscribe('subscribers.counts', { hunt: params.huntId });
 
   const puzzlesReady = puzzlesHandle.ready() && tagsHandle.ready() && guessesHandle.ready() && documentsHandle.ready() && displayNamesHandle.ready();
 

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -234,13 +234,9 @@ class ViewersModal extends React.Component<ViewersModalProps, ViewersModalState>
   }
 }
 
-interface ViewCountDisplayParams {
+interface ViewCountDisplayProps {
   count: number;
   name: string;
-}
-
-interface ViewCountDisplayProps extends ViewCountDisplayParams {
-  subfetchesDisabled: boolean;
 }
 
 class ViewCountDisplay extends React.Component<ViewCountDisplayProps> {
@@ -257,10 +253,6 @@ class ViewCountDisplay extends React.Component<ViewCountDisplayProps> {
 
   render() {
     const text = `See ${this.props.count} ${this.props.count === 1 ? 'viewer' : 'viewers'}`;
-    if (this.props.subfetchesDisabled) {
-      return <span>{text}</span>;
-    }
-
     return (
       <span className="puzzle-metadata-viewers-button">
         <ViewersModal ref={this.modalRef} name={this.props.name} />
@@ -269,10 +261,6 @@ class ViewCountDisplay extends React.Component<ViewCountDisplayProps> {
     );
   }
 }
-
-const ViewCountDisplayContainer = withTracker((_params: ViewCountDisplayParams) => {
-  return { subfetchesDisabled: Flags.active('disable.subfetches') };
-})(ViewCountDisplay);
 
 interface RelatedPuzzleSectionProps {
   activePuzzle: PuzzleType;
@@ -744,7 +732,7 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
             </span>
           )}
           {!hideViewCount && (
-            <ViewCountDisplayContainer
+            <ViewCountDisplay
               count={this.props.viewCount}
               name={`puzzle:${this.props.puzzle._id}`}
             />

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -1009,7 +1009,6 @@ class CircuitBreakerControl extends React.Component<CircuitBreakerControlProps> 
 
 interface CircuitBreakerSectionProps {
   flagDisableGdrivePermissions: boolean;
-  flagDisableSubcounters: boolean;
   flagDisableApplause: boolean;
 }
 
@@ -1062,27 +1061,6 @@ class CircuitBreakerSection extends React.Component<CircuitBreakerSectionProps> 
           </p>
         </CircuitBreakerControl>
         <CircuitBreakerControl
-          title="Viewer counts"
-          featureDisabled={this.props.flagDisableSubcounters}
-          onChange={(newValue) => this.setFlagValue('disable.subcounters', newValue)}
-        >
-          <p>
-            To allow people to get a sense of how many people are looking at any given puzzle at a time,
-            we track which users have which puzzle open, and send these aggregate counts to all viewers.
-            This is expensive, because it fans out at O(tabs open to the site) per user navigation, which
-            grows quickly.
-          </p>
-          <p>
-            If you&apos;re seeing Jolly Roger getting slow under load, consider
-            disabling this feature to reduce the total amount of work the server
-            has to do.
-          </p>
-          <p>
-            Disabling this feature means that Jolly Roger will no longer show
-            viewer counts for puzzles.
-          </p>
-        </CircuitBreakerControl>
-        <CircuitBreakerControl
           title="Celebrations"
           featureDisabled={this.props.flagDisableApplause}
           onChange={(newValue) => this.setFlagValue('disable.applause', newValue)}
@@ -1124,7 +1102,6 @@ interface SetupPageRewriteProps {
 
   flagDisableGoogleIntegration: boolean;
   flagDisableGdrivePermissions: boolean;
-  flagDisableSubcounters: boolean;
   flagDisableApplause: boolean;
 }
 
@@ -1167,7 +1144,6 @@ class SetupPageRewrite extends React.Component<SetupPageRewriteProps> {
         />
         <CircuitBreakerSection
           flagDisableGdrivePermissions={this.props.flagDisableGdrivePermissions}
-          flagDisableSubcounters={this.props.flagDisableSubcounters}
           flagDisableApplause={this.props.flagDisableApplause}
         />
       </div>
@@ -1203,7 +1179,6 @@ const tracker = withTracker((): SetupPageRewriteProps => {
   // Circuit breakers
   const flagDisableGoogleIntegration = Flags.active('disable.google');
   const flagDisableGdrivePermissions = Flags.active('disable.gdrive_permissions');
-  const flagDisableSubcounters = Flags.active('disable.subcounters');
   const flagDisableApplause = Flags.active('disable.applause');
 
   return {
@@ -1223,7 +1198,6 @@ const tracker = withTracker((): SetupPageRewriteProps => {
 
     flagDisableGoogleIntegration,
     flagDisableGdrivePermissions,
-    flagDisableSubcounters,
     flagDisableApplause,
   };
 });

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -1010,7 +1010,6 @@ class CircuitBreakerControl extends React.Component<CircuitBreakerControlProps> 
 interface CircuitBreakerSectionProps {
   flagDisableGdrivePermissions: boolean;
   flagDisableSubcounters: boolean;
-  flagDisableViewerLists: boolean;
   flagDisableApplause: boolean;
 }
 
@@ -1084,21 +1083,6 @@ class CircuitBreakerSection extends React.Component<CircuitBreakerSectionProps> 
           </p>
         </CircuitBreakerControl>
         <CircuitBreakerControl
-          title="Viewer details"
-          featureDisabled={this.props.flagDisableViewerLists}
-          onChange={(newValue) => this.setFlagValue('disable.subfetches', newValue)}
-        >
-          <p>
-            The Viewer counts feature also allows viewing which specific users are currently active
-            on a puzzle.  This can cause additional server load.
-          </p>
-          <p>
-            Disabling this feature means that Jolly Roger will no longer allow
-            clicking on the viewer count on a puzzle page to bring up a list of
-            which specific users are included in a particular view count.
-          </p>
-        </CircuitBreakerControl>
-        <CircuitBreakerControl
           title="Celebrations"
           featureDisabled={this.props.flagDisableApplause}
           onChange={(newValue) => this.setFlagValue('disable.applause', newValue)}
@@ -1141,7 +1125,6 @@ interface SetupPageRewriteProps {
   flagDisableGoogleIntegration: boolean;
   flagDisableGdrivePermissions: boolean;
   flagDisableSubcounters: boolean;
-  flagDisableViewerLists: boolean;
   flagDisableApplause: boolean;
 }
 
@@ -1185,7 +1168,6 @@ class SetupPageRewrite extends React.Component<SetupPageRewriteProps> {
         <CircuitBreakerSection
           flagDisableGdrivePermissions={this.props.flagDisableGdrivePermissions}
           flagDisableSubcounters={this.props.flagDisableSubcounters}
-          flagDisableViewerLists={this.props.flagDisableViewerLists}
           flagDisableApplause={this.props.flagDisableApplause}
         />
       </div>
@@ -1222,7 +1204,6 @@ const tracker = withTracker((): SetupPageRewriteProps => {
   const flagDisableGoogleIntegration = Flags.active('disable.google');
   const flagDisableGdrivePermissions = Flags.active('disable.gdrive_permissions');
   const flagDisableSubcounters = Flags.active('disable.subcounters');
-  const flagDisableViewerLists = Flags.active('disable.subfetches');
   const flagDisableApplause = Flags.active('disable.applause');
 
   return {
@@ -1243,7 +1224,6 @@ const tracker = withTracker((): SetupPageRewriteProps => {
     flagDisableGoogleIntegration,
     flagDisableGdrivePermissions,
     flagDisableSubcounters,
-    flagDisableViewerLists,
     flagDisableApplause,
   };
 });

--- a/imports/client/components/SubscriberCount.tsx
+++ b/imports/client/components/SubscriberCount.tsx
@@ -2,12 +2,10 @@ import { withTracker } from 'meteor/react-meteor-data';
 import React from 'react';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
-import Flags from '../../flags';
 import { SubscriberCounters } from '../subscribers';
 
 interface SubscriberCountProps {
   puzzleId: string;
-  disabled: boolean;
   viewCount: number;
 }
 
@@ -15,10 +13,6 @@ class SubscriberCount extends React.Component<SubscriberCountProps> {
   static displayName = 'SubscriberCount';
 
   render() {
-    if (this.props.disabled) {
-      return <div />;
-    }
-
     const countTooltip = (
       <Tooltip id={`count-description-${this.props.puzzleId}`}>
         users currently viewing this puzzle
@@ -37,10 +31,8 @@ class SubscriberCount extends React.Component<SubscriberCountProps> {
 }
 
 const SubscriberCountContainer = withTracker(({ puzzleId }: { puzzleId: string }) => {
-  const disabled = Flags.active('disable.subcounters');
   const count = SubscriberCounters.findOne(`puzzle:${puzzleId}`);
   return {
-    disabled,
     viewCount: count ? count.value : 0,
   };
 })(SubscriberCount);

--- a/imports/server/migrations/26-remove-subcounter-feature-flags.ts
+++ b/imports/server/migrations/26-remove-subcounter-feature-flags.ts
@@ -1,0 +1,11 @@
+import { Migrations } from 'meteor/percolate:migrations';
+import FeatureFlags from '../../lib/models/feature_flags';
+
+Migrations.add({
+  version: 26,
+  name: 'Remove subscription counter/watchers circuit breaker',
+  up() {
+    FeatureFlags.remove({ name: 'disable.subcounters' });
+    FeatureFlags.remove({ name: 'disable.subfetches' });
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -24,3 +24,4 @@ import './22-unset-slack-handles';
 import './23-serviceconfigurations-remove-slack';
 import './24-hunts-remove-slack-fields';
 import './25-remove-slack-featureflag';
+import './26-remove-subcounter-feature-flags';

--- a/imports/server/subscribers.ts
+++ b/imports/server/subscribers.ts
@@ -10,7 +10,6 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
 import moment from 'moment';
-import Flags from '../flags';
 import Servers from './models/servers';
 import Subscribers from './models/subscribers';
 
@@ -39,9 +38,7 @@ const periodic = function () {
   // Attempt to refresh our server record every 30 seconds (with
   // jitter). We should have 4 periods before we get GC'd mistakenly.
   Meteor.setTimeout(periodic, 15000 + (15000 * Random.fraction()));
-  if (!Flags.active('disable.subcounters')) {
-    cleanup();
-  }
+  cleanup();
 };
 
 Meteor.publish('subscribers.inc', function (name, context) {


### PR DESCRIPTION
These have been operating stably for years now, and I want to take a hard dep on subscription watching to track presence, so I can show who is in a group audio call and who is just in the text chat.