### PR TITLE
Rewrite README and split out other documentation by purpose

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,54 @@
+# Jolly Roger development
+
+Jolly Roger is written in TypeScript using the Meteor web framework.  To run
+Jolly Roger locally, you'll need to first
+[install Meteor](https://www.meteor.com/install).
+
+## Run the server
+
+Obtain the source code:
+
+```bash
+git clone https://github.com/deathandmayhem/jolly-roger
+cd jolly-roger
+```
+
+Install dependencies from `npm`:
+
+```bash
+meteor npm install
+```
+
+Run Meteor:
+
+```bash
+meteor
+```
+
+This will start up a server on [http://localhost:3000](http://localhost:3000),
+which you can navigate to with your web browser of choice.
+
+However, you can't do much until you create an account.
+
+## Create admin account
+
+While `meteor` is running in the first terminal, open a second terminal,
+navigate to your jolly-roger clone, spawn a Meteor interactive shell, create a
+user, and make it an admin:
+
+```js
+meteor shell
+> Accounts.createUser({email: 'broder@mit.edu', password: 'password'})
+'WaoEku3wBrWLLc7pK'
+> Roles.addUserToRoles('WaoEku3wBrWLLc7pK', 'admin')
+```
+
+Now, you should be able to log in at
+[http://localhost:3000](http://localhost:3000) with the email and password you
+created from the shell.
+
+## Additional server setup
+
+Users with the `admin` role can configure other server options from the setup
+page at [http://localhost:3000/setup](http://localhost:3000/setup).  This is
+where you'd go to configure various Google integration configuration options.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -52,3 +52,20 @@ created from the shell.
 Users with the `admin` role can configure other server options from the setup
 page at [http://localhost:3000/setup](http://localhost:3000/setup).  This is
 where you'd go to configure various Google integration configuration options.
+
+
+## Example hunt data
+
+Jolly Roger ships with a fixture representing data from the 2015 MIT Mystery
+Hunt, to get a sense of what a fully-populated UI might look like.
+
+To create the fixture hunt on your instance, log in as an admin in a browser
+window, then open the **browser** javascript console (not the Meteor shell we
+were using above) and run the following:
+
+```js
+Meteor.call("createFixtureHunt")
+```
+
+Upon success, you should see a hunt named 2015 in the list at
+[http://localhost:3000/hunts/](http://localhost:3000/hunts/).

--- a/OPERATION.md
+++ b/OPERATION.md
@@ -1,0 +1,20 @@
+# Jolly Roger deployment
+
+(This document is a work in progress, and is currently incomplete.)
+
+This document describes how to deploy and operate a production-grade Jolly Roger instance.
+
+You will need:
+
+* A MongoDB instance.
+* Compute nodes on which to run the Meteor node.js backend.
+* A reverse proxy to do HTTPS termination and forward traffic to the Meteor backend.
+* A domain name which resolves to the IP address of the reverse proxy.
+* A way to send automated email, for onboarding and password reset flows.
+* A Google account and OAuth application, for automated document creation and sharing.
+
+You may optionally add:
+
+* A Kerberos keytab for mailinglist integration.
+
+TODO: finish writing about what's needed for a production build/deployment

--- a/README.md
+++ b/README.md
@@ -1,135 +1,106 @@
-Jolly Roger
-===========
+# Jolly Roger
 
 ![Jolly Roger](public/images/hero.png)
 
-The next generation Virtual HQ for Death and Mayhem, written in
-Meteor. It uses [react-router][react-router] for navigation and
-[Collection2][collection2] for schema support.
+Jolly Roger is a coordination tool for collaboratively solving puzzlehunts like the [MIT Mystery Hunt][http://web.mit.edu/puzzle/www/].
+The team Death and Mayhem created Jolly Roger in 2015 for the 2016 MIT
+Mystery Hunt, and it is still actively maintained and in production service.
 
-Getting Started
----------------
+At its core, it allows tracking puzzles and guesses in an ever-evolving hunt
+structure, and provides a chat room and a Google spreadsheet for each
+puzzle.
 
-Jolly Roger uses support in Meteor for [ECMAScript 6][es6] (which is
-compiled by [Babel][babeljs] down to ES 5) and [React][React]. You
-need at least version 1.2 for this support. Once you've [installed
-Meteor][meteor install], you can start the server by just running:
 
-```bash
-meteor
-```
+## Features
 
-Right now, there's no onboarding flow for the first user, so you'll
-have to manually create a user:
+### Automated spreadsheet creation/sharing
 
-```js
-meteor shell
-> Accounts.createUser({email: 'broder@mit.edu', password: 'password'})
-'WaoEku3wBrWLLc7pK'
-```
+Like many Hunt collaboration tools, Jolly Roger automatically creates a
+Google Sheet for each puzzle entered into a hunt.  If a user has linked
+their Google account to Jolly Roger, Jolly Roger will additionally share the
+sheet with that user on first load, which will cause the user's cursor to
+show their name, rather than "Anonymous Animal".
 
-You'll probably also want to make yourself an admin:
+Users who do not link a Google account (or don't have or use one) can still
+participate in the sheet anonymously.
 
-```js
-> Roles.addUserToRoles('WaoEku3wBrWLLc7pK', 'admin')
-```
+### Per-puzzle chat rooms
 
-Organization
-------------
+Jolly Roger provides its own persistent chat with each puzzle.  No need to
+constantly jump between the spreadsheet and a third-party chat service.  No
+losing relevant discussion to 10000-message retention limits in the middle
+of the Hunt.  Supports Markdown formatting.
 
-Jolly Roger is primarily structured as a client-side app. The server
-primarily performs authentication (and authorization, for writes), but
-otherwise largely exposes Meteor's MongoDB interfaces for direct
-consumption by the client. The server performs no authorization for
-accessing data - any authenticated user can query any app model.
+We intentionally keep the chat pane always visible on each puzzle page, so
+remote hunters desperately trying to get your attention are hard to
+accidentally ignore.
 
-Style
------
+### Tag-based structure
 
-This project uses [Airbnb's JavaScript style
-guide][airbnb-javascript]. It's not perfect, but it's one of the more
-modern presets, and if nothing else it forces some
-consistency. There's an included [ESLint][] config file.  You can
-(and should) lint your code by running:
+In many hunts, it's not always clear from the beginning what puzzles will be
+related or may contribute to which metapuzzles.  Jolly Roger solves this by
+eschewing a top-down hierarchical round structure and instead allowing
+multiple tags to be applied to each puzzle to construct dynamic groupings as
+you gain more information about the hunt structure over time.
 
-```bash
-meteor npm run lint
-```
+We've found this approach able to be capable of modeling every hunt
+structure we've thrown at it.
 
-Models
-------
+Once a metapuzzle is solved, the puzzles in that group are usually less
+interesting from a hunt-progress perspective, so we automatically reorder
+things on the puzzle list page, sending the whole group to the bottom of the
+list when you solve the meta for the group.
 
-All Jolly Roger database models have defined schemas to try and
-protect our sanity. Each model should use SimpleSchema's support for
-[chaining][simple-schema-chaining] to include the `Schemas.Base`
-schema, which adds standardized fields like `createdAt` and
-`updatedAt`.
+### Viewer tracking
 
-The collection objects (under `Models`) should all be instances of
-`Models.Base` (or a subclass). The base model automatically sets up a
-role-based system for modifications.
+Sometimes you want to find a puzzle that doesn't have much attention on it
+right now, or you want to find something where people are already looking at
+the puzzle.  Viewer counts in the puzzle list make it easy to find what
+you're looking for.
 
-However, `Models.Base` instances are not automatically published. You
-can call `model.publish()` to do that. You can optionally pass a
-function which modifies the query to add additional restrictions,
-c.f. `Models.Puzzles` which restricts the `hunt` query term to hunts
-that the user is a member of.
+### Instant filter search
 
-Roles
------
+Find puzzles in the growing list by searching for any piece of the title,
+answer, or tag.
 
-Jolly Roger pulls in [nicolaslopezj's roles package][roles] package
-for managing permissions. Roles are automatically added to models to
-control modifications. Templates and other code should be written to
-take roles into account, but in practice we'll likely use the admin
-role for controlling virtually all permissioning.
+### Operator guess queue
 
-Google Integration
-------------------
+Avoid irritating Hunt HQ with your team's excessive ill-fated backsolving
+attempts by staffing an operator queue that can tell people "I'm not calling
+this in until you convince me you're not just submitting every possible
+combination of three letters."
 
-Jolly Roger uses Google Spreadsheets for the per-puzzle collaboration
-document, and it automatically provisions them when puzzles are
-created. (This helps with, e.g., permissions issues with manually
-created documents).
+Or just make sure your team is ready to receive callbacks before calling
+things in.
 
-In order to access the Google APIs, you first need to enable support
-for the Google Drive APIs from
-the [Google Developer Console][google-developer-drive] (click the
-"Enable" button near the top). Then you'll need to create a Google
-OAuth client ID. From
-the
-[Google Developer Credentials Console][google-developer-credentials],
-create a new OAuth Client ID. If you're developing locally (via
-localhost), choose "Other"; otherwise, choose "Web application". Once
-you have the client ID, store it in the Meteor shell by running:
+### Multiple answer support
 
-```js
-> ServiceConfiguration.configurations.upsert({service: 'google'}, {
-    $set: {
-      clientId: 'CLIENT ID',
-      secret: 'SECRET',
-      loginStyle: 'popup',
-    },
-  })
-```
+Some hunts have puzzles with multiple answers, which present a challenge for
+many systems: how do you track a correct answer while still indicating that
+there's more to be figured out?  If you make a separate puzzle for each
+answer, you lose the context of the discussion/spreadsheet; if you just
+comma-separate answers, it's hard to tell which puzzles are finished vs.
+ones that are only partially completed.
 
-Once that's done, manually navigate to `/setup`
-(e.g. http://localhost:3000/setup). From there, you'll be able to link
-an account to the OAuth application, giving Jolly Roger permissions to
-create documents on behalf of that account.
+Jolly Roger has first-class support for puzzles with more than one answer,
+and it Just Works™ with all the smart sorting too.
 
-(In production, we have a dedicated Google account that owns both the
-OAuth application and the Drive credentials)
+### Announcements
 
-[airbnb-javascript]: https://github.com/airbnb/javascript
-[babeljs]: http://babeljs.io
-[collection2]: https://atmospherejs.com/aldeed/collection2
-[es6]: https://github.com/lukehoban/es6features
-[google-developer-credentials]: https://console.developers.google.com/apis/credentials
-[google-developer-drive]: https://console.developers.google.com/apis/api/drive.googleapis.com/overview
-[ESLint]: http://eslint.org/
-[meteor install]: https://www.meteor.com/install
-[React]: https://facebook.github.io/react/
-[react-router]: https://github.com/rackt/react-router
-[roles]: https://atmospherejs.com/nicolaslopezj/roles
-[simple-schema-chaining]: https://github.com/aldeed/meteor-simple-schema#combining-simpleschemas
+Make sure everyone on the team sees teamwide announcements, whether they've
+been actively hunting the whole time or are dropping in and out and just
+need to get up to speed.
+
+### Realtime updates
+
+You never need to refresh the page.  Everything tracked in Jolly Roger
+updates in realtime.  It's delightful.
+
+
+## Setting up a Jolly Roger instance
+
+Interested in developing or testing Jolly Roger locally?  See
+[DEVELOPMENT.md](DEVELOPMENT.md).
+
+Interested in operating a production-grade instance of Jolly Roger?  See
+[OPERATION.md](OPERATION.md).

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ participate in the sheet anonymously.
 Jolly Roger provides its own persistent chat with each puzzle.  No need to
 constantly jump between the spreadsheet and a third-party chat service.  No
 losing relevant discussion to 10000-message retention limits in the middle
-of the Hunt.  Supports Markdown formatting.
+of the Hunt.  Supports basic formatting -- bulleted lists, \_italics\_,
+\*bold\*, \`monospace\`, and \`\`\`code blocks\`\`\`.
 
 We intentionally keep the chat pane always visible on each puzzle page, so
 remote hunters desperately trying to get your attention are hard to


### PR DESCRIPTION
`README.md` now explains what Jolly Roger is and why you'd want to use it.
`DEVELOPING.md` explains how to set up your own instance for development.
`OPERATION.md` is a stub, but in time should help explain what else you'll need
to bring to run Jolly Roger in anger.

We should probably come up with a new place to write about internals.