### PR TITLE
Add `Send` button to chat input area

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -280,6 +280,16 @@ table.puzzle-list {
   }
 }
 
+.chat-input-row {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  justify-content: space-between;
+  textarea {
+    flex: 1 1 auto;
+  }
+}
+
 .chat-history {
   flex: 1 1 auto;
   overflow-y: auto;

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -411,9 +411,7 @@ const chatInputStyles = {
     // The default Chrome stylesheet has line-height set to a plain number.
     // We work around the Chrome bug by setting an explicit sized line-height for the textarea.
     lineHeight: '20px',
-    flex: 'none',
     padding: '9px 4px',
-    borderWidth: '1px 0 0 0',
     resize: 'none' as 'none',
   },
 };
@@ -442,18 +440,22 @@ class ChatInput extends React.PureComponent<ChatInputProps, ChatInputState> {
     });
   };
 
+  sendMessageIfHasText = () => {
+    if (this.state.text) {
+      Meteor.call('sendChatMessage', this.props.puzzleId, this.state.text);
+      this.setState({
+        text: '',
+      });
+      if (this.props.onMessageSent) {
+        this.props.onMessageSent();
+      }
+    }
+  };
+
   onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      if (this.state.text) {
-        Meteor.call('sendChatMessage', this.props.puzzleId, this.state.text);
-        this.setState({
-          text: '',
-        });
-        if (this.props.onMessageSent) {
-          this.props.onMessageSent();
-        }
-      }
+      this.sendMessageIfHasText();
     }
   };
 
@@ -465,17 +467,22 @@ class ChatInput extends React.PureComponent<ChatInputProps, ChatInputState> {
 
   render() {
     return (
-      <TextareaAutosize
-        style={chatInputStyles.textarea}
-        maxLength={4000}
-        minRows={1}
-        maxRows={12}
-        value={this.state.text}
-        onChange={this.onInputChanged}
-        onKeyDown={this.onKeyDown}
-        onHeightChange={this.onHeightChange}
-        placeholder="Chat"
-      />
+      <div className="chat-input-row">
+        <TextareaAutosize
+          style={chatInputStyles.textarea}
+          maxLength={4000}
+          minRows={1}
+          maxRows={12}
+          value={this.state.text}
+          onChange={this.onInputChanged}
+          onKeyDown={this.onKeyDown}
+          onHeightChange={this.onHeightChange}
+          placeholder="Chat"
+        />
+        <Button variant="light" onClick={this.sendMessageIfHasText}>
+          Send
+        </Button>
+      </div>
     );
   }
 }


### PR DESCRIPTION
On mobile devices the keyboards often don't have an Enter key, so a separate
"Send" button is needed.

Fixes #287

![button idle](https://user-images.githubusercontent.com/307325/99772359-754c8000-2abf-11eb-8148-f31f373d4b66.png)

![resized to content on desktop](https://user-images.githubusercontent.com/307325/99772452-aa58d280-2abf-11eb-92d2-d0de71e6cf80.png)

![mobile size](https://user-images.githubusercontent.com/307325/99772403-91e8b800-2abf-11eb-88b3-527d68ba3153.png)

![mobile size with content](https://user-images.githubusercontent.com/307325/99772495-c2c8ed00-2abf-11eb-9951-433fbcff03ab.png)