### PR TITLE
Polish chat controls

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -1,3 +1,6 @@
+@import "../../node_modules/bootstrap/scss/functions";
+@import "../../node_modules/bootstrap/scss/variables";
+
 // Puzzle components helper styles
 // Puzzle lists/tables
 .puzzle-group {
@@ -286,8 +289,23 @@ table.puzzle-list {
   flex-direction: row;
   align-items: stretch;
   justify-content: space-between;
+  border-top: $input-border-width solid $input-border-color;
+  overflow: hidden;
+  &:focus-within {
+    border-color: $input-focus-border-color;
+    box-shadow: $input-focus-box-shadow;
+  }
+  
   textarea {
     flex: 1 1 auto;
+    border: none;
+    &:focus {
+        box-shadow: none;
+    }
+  }
+  
+  button {
+    border-radius: 0;
   }
 }
 

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { withTracker } from 'meteor/react-meteor-data';
 import { _ } from 'meteor/underscore';
-import { faEdit, faPuzzlePiece } from '@fortawesome/free-solid-svg-icons';
+import { faEdit, faPuzzlePiece, faPaperPlane } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 import DOMPurify from 'dompurify';
@@ -427,8 +427,11 @@ interface ChatInputState {
 }
 
 class ChatInput extends React.PureComponent<ChatInputProps, ChatInputState> {
+  textAreaRef: React.RefObject<HTMLTextAreaElement>
+
   constructor(props: ChatInputProps) {
     super(props);
+    this.textAreaRef = React.createRef();
     this.state = {
       text: '',
     };
@@ -441,6 +444,9 @@ class ChatInput extends React.PureComponent<ChatInputProps, ChatInputState> {
   };
 
   sendMessageIfHasText = () => {
+    if (this.textAreaRef.current) {
+      this.textAreaRef.current.focus();
+    }
     if (this.state.text) {
       Meteor.call('sendChatMessage', this.props.puzzleId, this.state.text);
       this.setState({
@@ -469,6 +475,8 @@ class ChatInput extends React.PureComponent<ChatInputProps, ChatInputState> {
     return (
       <div className="chat-input-row">
         <TextareaAutosize
+          ref={this.textAreaRef}
+          className="form-control"
           style={chatInputStyles.textarea}
           maxLength={4000}
           minRows={1}
@@ -479,8 +487,14 @@ class ChatInput extends React.PureComponent<ChatInputProps, ChatInputState> {
           onHeightChange={this.onHeightChange}
           placeholder="Chat"
         />
-        <Button variant="light" onClick={this.sendMessageIfHasText}>
-          Send
+        <Button
+          variant="light"
+          onClick={this.sendMessageIfHasText}
+          onMouseDown={(e) => e.preventDefault()}
+          disabled={this.state.text.length === 0}
+          tabIndex={-1}
+        >
+          <FontAwesomeIcon icon={faPaperPlane} />
         </Button>
       </div>
     );


### PR DESCRIPTION
Minor changes to chat controls:
* Style tweaks, including improved control consistency
* Text area always gets focus after submit (previously never)
* Send button disabled when no text entered
* Textarea and button behave as one control, with shared focus and tab-index

Before:
![before-no-focus](https://user-images.githubusercontent.com/2136874/100247773-b225d600-2f08-11eb-8277-b9f93620d0e8.png)
After:
![after-no-focus](https://user-images.githubusercontent.com/2136874/100247797-ba7e1100-2f08-11eb-9c00-3b68083a2a4a.png)

Before with content and focus:
![before-focus](https://user-images.githubusercontent.com/2136874/100247852-c7026980-2f08-11eb-8539-09082d04c5f6.png)
After with content and focus:
![after-focus](https://user-images.githubusercontent.com/2136874/100247867-cbc71d80-2f08-11eb-9651-baeeab963638.png)
