### PR TITLE
Reinstitute celebrations and support close on esc press

### DIFF
--- a/imports/client/components/Celebration.tsx
+++ b/imports/client/components/Celebration.tsx
@@ -14,10 +14,12 @@ class Celebration extends React.Component<CelebrationProps> {
 
   componentDidMount() {
     this.timer = window.setTimeout(() => { this.onClose(); }, 7000);
+    document.addEventListener('keydown', this.onKeyDown);
   }
 
   componentWillUnmount() {
     window.clearTimeout(this.timer);
+    document.removeEventListener('keydown', this.onKeyDown);
   }
 
   onClose = () => {
@@ -25,6 +27,13 @@ class Celebration extends React.Component<CelebrationProps> {
       this.props.onClose();
     }
   };
+
+  onKeyDown = (e: KeyboardEvent) => {
+    // Dismiss the celebration on esc
+    if (e.keyCode === 27) {
+      this.onClose();
+    }
+  }
 
   maybeClose = (e: React.MouseEvent) => {
     // Dismiss the celebration if you click on the overlay div (outside the content)

--- a/imports/client/components/CelebrationCenter.tsx
+++ b/imports/client/components/CelebrationCenter.tsx
@@ -52,14 +52,11 @@ class CelebrationCenter extends React.Component<CelebrationCenterProps, Celebrat
     }
   }
 
-  onPuzzleSolved = (_puzzle: PuzzleType) => {
+  onPuzzleSolved = (puzzle: PuzzleType, answer: string) => {
     // Only celebrate if:
     // 1) we're not on mobile, and
     // 2) the feature flag is not disabled, and
     // 3) TODO: the user has not disabled it in their profile settings
-    // Hack: disabled celebrations because I don't want to think about it right now
-    /*
-    const answer = puzzle.answer;
     if ((window.orientation === undefined) && !this.props.disabled && answer) {
       this.setState((prevState) => {
         const newQueue = prevState.playbackQueue.concat([{
@@ -68,11 +65,9 @@ class CelebrationCenter extends React.Component<CelebrationCenterProps, Celebrat
           answer,
           title: puzzle.title,
         }]);
-
         return { playbackQueue: newQueue };
       });
     }
-    */
   };
 
   resetComputation = () => {
@@ -83,9 +78,12 @@ class CelebrationCenter extends React.Component<CelebrationCenterProps, Celebrat
     this.computation = Tracker.autorun(() => {
       Puzzles.find().observe({
         changed: (newDoc, oldDoc) => {
-          if (oldDoc.answers.length < newDoc.answers.length) {
-            this.onPuzzleSolved(newDoc);
-          }
+          const oldAnswers = new Set(oldDoc.answers);
+          newDoc.answers.forEach((answer: string) => {
+            if (!oldAnswers.has(answer)) {
+              this.onPuzzleSolved(newDoc, answer);
+            }
+          });
         },
       });
     });


### PR DESCRIPTION
Reinstitutes celebrations (removed as part of multiple answer support). A celebration occurs if the answers field contains an answer that was not previously present. Multiple celebrations are queued if necessary.

Also addresses #233, closing the celebration when esc is pressed.