### PR TITLE
Add WebRTC calls on each puzzle page

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -405,23 +405,33 @@ table.puzzle-list {
     }
 
     .muted {
-      /* TODO: make this more intelligible with an icon */
       position: absolute;
       top: 0;
       right: 0;
-      width: 3px;
+      font-size: 12px;
+      width: 16px;
+      text-align: center;
+      color: #ff0000;
       height: 50%;
-      background-color: #ff0000;
     }
 
     .deafened {
-      /* TODO: make this more intelligible with an icon */
       position: absolute;
-      bottom: 0;
+      bottom: 2px;
       right: 0;
-      width: 3px;
+      font-size: 12px;
+      width: 16px;
+      text-align: center;
+      color: #ff0000;
       height: 50%;
-      background-color: #ff0000;
+    }
+
+    .spectrogram {
+      position: absolute;
+      top: 0;
+      right: 0;
+      left: 0;
+      bottom: 0;
     }
   }
 

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -318,6 +318,22 @@ table.puzzle-list {
   background-color: #ebd0e3;
   font-size: 12px;
   line-height: 12px;
+  border-bottom: 1px solid #000;
+
+  .av-actions {
+    display: flex;
+    flex-direction: row;
+    //margin-top: 6px;
+
+    .btn {
+      flex: 1;
+      padding: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 0;
+    }
+  }
 }
 
 .chatter-subsection {
@@ -335,6 +351,7 @@ table.puzzle-list {
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-end;
+    min-height: 12px; // So that when there's no people it doesn't collapse entirely
   }
 
   .people-item {
@@ -395,21 +412,6 @@ table.puzzle-list {
     height: 100%;
     width: 100%;
     fill: #3d98fa;
-  }
-
-  .av-actions {
-    display: flex;
-    margin-top: 6px;
-
-    .btn {
-      flex: 1;
-      padding: 0 auto;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      height: 40px;
-      border-radius: 0;
-    }
   }
 }
 

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -313,6 +313,106 @@ table.puzzle-list {
   }
 }
 
+.chatter-section {
+  flex: 0;
+  background-color: #ebd0e3;
+  font-size: 12px;
+  line-height: 12px;
+}
+
+.chatter-subsection {
+  position: relative;
+  padding-top: 6px;
+
+  header {
+    position: absolute;
+    top: 6px;
+    left: 2px;
+    z-index: 20;
+  }
+
+  .people-list {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .people-item {
+    flex: 0 0 auto;
+    width: 40px;
+    height: 40px;
+    background: #f9f9f9dc;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-transform: uppercase;
+    font-weight: bold;
+    font-size: 24px;
+    color: black;
+    line-height: 24px;
+    margin-left: 4px;
+    position: relative;
+
+    .initial {
+      z-index: 10
+    }
+
+    .connection {
+      position: absolute;
+      bottom: 0;
+      left: 0;
+      width: 100%;
+      height: 3px;
+      background-color: #cccccc;
+
+      &.connecting {
+        background-color: #bbdcff;
+      }
+
+      &.connected {
+        background-color: #3d98fa;
+      }
+
+      &.disconnected {
+        background-color: red;
+      }
+
+      &.failed {
+        background-color: maroon;
+      }
+
+      &.closed {
+        background-color: black;
+      }
+    }
+  }
+
+  .speaker-volume {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    fill: #3d98fa;
+  }
+
+  .av-actions {
+    display: flex;
+    margin-top: 6px;
+
+    .btn {
+      flex: 1;
+      padding: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 40px;
+      border-radius: 0;
+    }
+  }
+}
+
 .chat-history {
   flex: 1 1 auto;
   overflow-y: auto;

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -445,6 +445,16 @@ table.puzzle-list {
   }
 }
 
+.chatter-tooltip {
+  // Force chatter tooltip overlay to get larger than the default
+  // react-bootstrap stylesheet permits.  We can only apply classes to the root
+  // tooltip <div>; the .tooltip-inner className is controlled by
+  // react-bootstrap/popper.
+  .tooltip-inner {
+    max-width: 300px;
+  }
+}
+
 .chat-history {
   flex: 1 1 auto;
   overflow-y: auto;

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -411,7 +411,7 @@ table.puzzle-list {
       z-index: 10;
     }
 
-    &.active .initial {
+    &.live .initial {
       // white border around initial
       // aids readability if the spectrum graph is high
       text-shadow: -1px 1px 0 white,

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -383,11 +383,11 @@ table.puzzle-list {
       height: 3px;
       background-color: #cccccc;
 
-      &.connecting {
+      &.checking {
         background-color: #bbdcff;
       }
 
-      &.connected {
+      &.connected, &.completed {
         background-color: #3d98fa;
       }
 

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -403,6 +403,26 @@ table.puzzle-list {
         background-color: black;
       }
     }
+
+    .muted {
+      /* TODO: make this more intelligible with an icon */
+      position: absolute;
+      top: 0;
+      right: 0;
+      width: 3px;
+      height: 50%;
+      background-color: #ff0000;
+    }
+
+    .deafened {
+      /* TODO: make this more intelligible with an icon */
+      position: absolute;
+      bottom: 0;
+      right: 0;
+      width: 3px;
+      height: 50%;
+      background-color: #ff0000;
+    }
   }
 
   .speaker-volume {

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -358,7 +358,7 @@ table.puzzle-list {
     flex: 0 0 auto;
     width: 40px;
     height: 40px;
-    background: #f9f9f9dc;
+    background: white;
 
     display: flex;
     align-items: center;
@@ -371,8 +371,53 @@ table.puzzle-list {
     margin-left: 4px;
     position: relative;
 
+    .icon {
+      font-size: 12px;
+      width: 16px;
+      text-align: center;
+      color: $danger;
+      height: 50%;
+    }
+
+    $mutedTop: -4px;
+    $mutedRight: -2px;
+    $deafenDiff: 2px;
+
+    &.muted .muted-icon {
+      position: absolute;
+      top: $mutedTop;
+      right: $mutedRight;
+    }
+
+    &.deafened {
+      color: $secondary;
+      background: #ffffff88;
+      border: $deafenDiff solid white;
+
+      .muted-icon {
+        position: absolute;
+        top: $mutedTop - $deafenDiff;
+        right: $mutedRight - $deafenDiff;
+      }
+
+      .deafened-icon {
+        position: absolute;
+        bottom: 1px;
+        right: $mutedRight - $deafenDiff;
+      }
+    }
+
     .initial {
-      z-index: 10
+      z-index: 10;
+    }
+
+    &.active .initial {
+      // white border around initial
+      // aids readability if the spectrum graph is high
+      text-shadow: -1px 1px 0 white,
+				  1px 1px 0 white,
+				 1px -1px 0 white,
+				-1px -1px 0 white;
     }
 
     .connection {
@@ -404,26 +449,11 @@ table.puzzle-list {
       }
     }
 
-    .muted {
-      position: absolute;
-      top: 0;
-      right: 0;
-      font-size: 12px;
-      width: 16px;
-      text-align: center;
-      color: #ff0000;
-      height: 50%;
-    }
-
-    .deafened {
-      position: absolute;
-      bottom: 2px;
-      right: 0;
-      font-size: 12px;
-      width: 16px;
-      text-align: center;
-      color: #ff0000;
-      height: 50%;
+    &.deafened .connection {
+      bottom: -$deafenDiff;
+      left: -$deafenDiff;
+      right: -$deafenDiff;
+      width: auto;
     }
 
     .spectrogram {
@@ -433,15 +463,6 @@ table.puzzle-list {
       left: 0;
       bottom: 0;
     }
-  }
-
-  .speaker-volume {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    height: 100%;
-    width: 100%;
-    fill: #3d98fa;
   }
 }
 

--- a/imports/client/components/AuthenticatedRoute.tsx
+++ b/imports/client/components/AuthenticatedRoute.tsx
@@ -29,7 +29,7 @@ interface AuthWrapperState {
   loading: boolean;
 }
 
-class AuthWrapper extends React.Component<AuthWrapperProps, AuthWrapperState> {
+class AuthWrapper extends React.PureComponent<AuthWrapperProps, AuthWrapperState> {
   constructor(props: AuthWrapperProps) {
     super(props);
     this.state = { loading: true };
@@ -88,7 +88,7 @@ const AuthWrapperContainer = withTracker((_props: AuthWrapperContainerProps) => 
   };
 })(AuthWrapper);
 
-class AuthenticatedRoute extends React.Component<AuthenticatedRouteProps> {
+class AuthenticatedRoute extends React.PureComponent<AuthenticatedRouteProps> {
   render() {
     // Pull off the component, which we'll pass to AuthWrapperContainer.
     // The rest of the props are from RouteProps, to which we'll add our

--- a/imports/client/components/CallLinkBox.tsx
+++ b/imports/client/components/CallLinkBox.tsx
@@ -1,0 +1,361 @@
+import { Meteor } from 'meteor/meteor';
+import { withTracker } from 'meteor/react-meteor-data';
+import React from 'react';
+import CallSignals from '../../lib/models/call_signals';
+import Profiles from '../../lib/models/profiles';
+import { CallParticipantType } from '../../lib/schemas/call_participants';
+import { CallSignalType, CallSignalMessageType } from '../../lib/schemas/call_signals';
+import { ProfileType } from '../../lib/schemas/profiles';
+
+/*
+enum WebRTCConnectionState {
+  New = 'new',
+  Connecting = 'connecting',
+  Connected = 'connected',
+  Disconnected = 'disconnected',
+  Failed = 'failed',
+  Closed ='closed',
+}
+*/
+
+// TODO: maybe make this configurable from the server via Settings?
+// I'm reasonably happy to run an open STUN server for everyone, but once we
+// get into TURN we have to have some sort of auth, and that's going to be a
+// mess
+const rtcConfig = {
+  iceServers: [
+    // TODO: implement TURN relaying if necessary.
+    // For what it's worth: all the setups I've tried so far have worked
+    // without a TURN setup, but it's probably still worth investing in making
+    // it work for the long tail of network configurations.
+    // { urls: "turn:turn.zarvox.org:3478?transport=udp" },
+    { urls: ['stun:turn.zarvox.org'] },
+  ],
+};
+
+interface CallLinkBoxState {
+  localCandidates: RTCIceCandidate[];
+  // TODO: track this but use the browser type
+  // connectionState: WebRTCConnectionState;
+}
+
+interface CallLinkBoxParams {
+  selfParticipant: CallParticipantType;
+  peerParticipant: CallParticipantType;
+  localStream: MediaStream;
+  audioContext: AudioContext;
+  deafened: boolean;
+}
+
+interface CallLinkBoxProps extends CallLinkBoxParams {
+  signal: CallSignalType | undefined;
+  peerProfile: ProfileType | undefined;
+}
+
+class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
+  private audioRef: React.RefObject<HTMLVideoElement>;
+
+  private remoteStream: MediaStream;
+
+  private pc: RTCPeerConnection;
+
+  private isInitiator: boolean;
+
+  private wrapperStreamSource: MediaStreamAudioSourceNode | undefined;
+
+  private wrapperStreamDestination: MediaStreamAudioDestinationNode;
+
+  private gainNode: GainNode;
+
+  constructor(props: CallLinkBoxProps) {
+    super(props);
+
+    this.state = {
+      localCandidates: [],
+    };
+
+    // Create a ref so we can get at the audio element on the page to set its
+    // srcObject.
+    this.audioRef = React.createRef();
+
+    // Create a stream object to populate tracks into as we receive them from
+    // our peer.
+    this.remoteStream = new MediaStream();
+    this.gainNode = this.props.audioContext.createGain();
+    this.wrapperStreamDestination = this.props.audioContext.createMediaStreamDestination();
+
+    this.pc = new RTCPeerConnection(rtcConfig);
+    this.pc.addEventListener('icecandidate', this.onNewLocalCandidate);
+    this.pc.addEventListener('iceconnectionstatechange', this.onIceConnectionStateChange);
+    this.pc.addEventListener('connectionstatechange', this.onConnectionStateChange);
+    this.pc.addEventListener('track', this.onNewRemoteTrack);
+    this.pc.addEventListener('negotiationneeded', this.onNegotiationNeeded);
+
+    // Add stream to RTCPeerConnection for self.
+    const tracks = props.localStream.getTracks();
+    for (let i = 0; i < tracks.length; i++) {
+      const track = tracks[i];
+      this.log(track, props.localStream);
+      this.pc.addTrack(track);
+    }
+
+    // If we're the initiator, get the ball rolling.  Create an
+    // offer, so we'll:
+    // 1) generate an SDP descriptor and
+    // 2) start doing STUN to collect our ICE candidates.
+    //
+    // We must make the offer *after* we have a user media stream;
+    // browsers won't bother if the peer doesn't have a stream worth
+    // sharing, because SDP requires knowing what the stream format
+    // is.  (This is fine; we already have the stream by the time we
+    // construct a CallLink.)
+    this.isInitiator = props.selfParticipant._id < props.peerParticipant._id;
+    if (this.isInitiator) {
+      this.pc.createOffer().then(this.onLocalOfferCreated);
+    }
+
+    if (props.signal) {
+      this.log(`signals: processing ${props.signal.messages.length} initial signals`);
+      this.processSignalMessages(props.signal.messages, 0);
+    }
+  }
+
+  componentDidUpdate(prevProps: CallLinkBoxProps, _prevState: CallLinkBoxState,
+    _snapshot: any) {
+    // Process any new signal messages in the updated props.
+    if (this.props.signal) {
+      const newLength = this.props.signal.messages.length;
+      const oldLength = prevProps.signal ? prevProps.signal.messages.length : 0;
+      this.log(`signals: old ${oldLength} new ${newLength}`);
+      this.processSignalMessages(this.props.signal.messages, oldLength);
+    }
+
+    // Update gain if deafened changed.
+    if (this.props.deafened !== prevProps.deafened) {
+      const newGain = this.props.deafened ? 0.0 : 1.0;
+      this.gainNode.gain.setValueAtTime(newGain, this.props.audioContext.currentTime);
+    }
+  }
+
+  componentWillUnmount() {
+    // Tear down the connections and all active streams on them.
+    this.pc.close();
+
+    // TODO: tear down animation periodic handle
+  }
+
+  log = (...args: any) => {
+    // eslint-disable-next-line no-console
+    console.log(this.props.peerParticipant._id, ...args);
+  }
+
+  onLocalOfferCreated = (offer: RTCSessionDescriptionInit) => {
+    this.log('onLocalOfferCreated');
+    this.log(offer);
+    this.pc.setLocalDescription(offer);
+    const offerObj = {
+      type: offer.type,
+      sdp: offer.sdp,
+    };
+    Meteor.call('signalPeer', this.props.selfParticipant._id, this.props.peerParticipant._id, { type: 'sdp', content: JSON.stringify(offerObj) });
+  };
+
+  processSignalMessages = (messages: CallSignalMessageType[], previouslyProcessed: number) => {
+    const len = messages.length;
+    for (let i = previouslyProcessed; i < len; i++) {
+      // this.log(`signal ${i}: ${JSON.stringify(this.props.signal.messages[i])}`);
+      this.handleSignal(messages[i]);
+    }
+  };
+
+  handleSignal = (message: CallSignalMessageType) => {
+    if (message.type === 'sdp') {
+      this.log('handle sdp');
+      // Create an RTCSessionDescription using the received SDP offer.
+      // Set it.  In the callback, create an answer, then set that as
+      // the local description, then signal the initiator.
+      const sdpDesc = JSON.parse(message.content);
+      this.pc.setRemoteDescription(sdpDesc)
+        .then(this.onRemoteDescriptionSet)
+        .catch(this.onRemoteDescriptionSetFailure);
+    } else if (message.type === 'iceCandidate') {
+      this.log('handle ice', message.content);
+      const iceDesc = JSON.parse(message.content);
+      if (iceDesc) {
+        const remoteCandidate = new RTCIceCandidate(iceDesc);
+        // TODO: error handling
+        this.pc.addIceCandidate(remoteCandidate);
+      } else {
+        this.log('all candidates received');
+      }
+    } else {
+      this.log('dunno what this message is:', message);
+    }
+  };
+
+  onAnswerCreated = (answer: RTCSessionDescriptionInit) => {
+    this.log('onAnswerCreated', answer);
+    this.pc.setLocalDescription(answer);
+    const answerObj = {
+      type: answer.type,
+      sdp: answer.sdp,
+    };
+    Meteor.call('signalPeer', this.props.selfParticipant._id, this.props.peerParticipant._id, { type: 'sdp', content: JSON.stringify(answerObj) });
+  };
+
+  onAnswerCreatedFailure = (err: DOMException) => {
+    this.log('onAnswerCreatedFailure', err);
+  }
+
+  onRemoteDescriptionSet = () => {
+    this.log('remoteDescriptionSet');
+    if (!this.isInitiator) {
+      this.pc.createAnswer().then(this.onAnswerCreated);
+    }
+  };
+
+  onRemoteDescriptionSetFailure = (err: Error) => {
+    this.log('remoteDescriptionSetFailure', err);
+  };
+
+  onNewLocalCandidate = (e: RTCPeerConnectionIceEvent) => {
+    //    this.log("new local candidate:");
+    //    this.log(e);
+    const iceCandidate = e.candidate;
+    if (iceCandidate) {
+      this.setState((prevState) => {
+        return { localCandidates: [...prevState.localCandidates, iceCandidate] };
+      });
+    } else {
+      this.log('local candidate list complete');
+    }
+
+    Meteor.call('signalPeer',
+      this.props.selfParticipant._id,
+      this.props.peerParticipant._id,
+      { type: 'iceCandidate', content: JSON.stringify(iceCandidate) });
+  };
+
+  onNewRemoteTrack = (e: RTCTrackEvent) => {
+    this.log('newRemoteTrack', e);
+    if (e.track.kind === 'audio') {
+      // Wire in the gain node, through the audio context.
+      const stubStream = new MediaStream();
+      stubStream.addTrack(e.track);
+
+      // This audio element is a workaround for
+      // https://bugs.chromium.org/p/chromium/issues/detail?id=933677 wherein
+      // audio tracks from a peer connection never deliver data into a WebAudio
+      // context unless they are first made the srcObject of some audio or
+      // video element.
+      const stubAudioElement = document.createElement('audio');
+      stubAudioElement.muted = true;
+      stubAudioElement.srcObject = stubStream;
+
+      this.wrapperStreamSource = this.props.audioContext.createMediaStreamSource(stubStream);
+
+      // Wire up the audio track to the gain node.
+      this.wrapperStreamSource.connect(this.gainNode);
+      // Then wire up the output of that gain node to our levels-adjusted track.
+      this.gainNode.connect(this.wrapperStreamDestination);
+      const innerTracks = this.wrapperStreamDestination.stream.getTracks();
+      this.log('innerTracks', innerTracks);
+      const leveledAudioTrack = innerTracks[0];
+
+      // Add that track to our post-level-adjustment stream.
+      this.remoteStream.addTrack(leveledAudioTrack);
+
+      /*
+      if (enableExpensiveFeatures) {
+        // Wire up the audio track to the analyser.
+        this.wrapperStreamSource.connect(this.analyserNode);
+
+        // Enable periodic updates of the frequency analyzer
+        this.periodicHandle = window.requestAnimationFrame(this.drawSpectrum);
+      }
+      */
+    } else {
+      // Ignore non-audio tracks.
+      // this.remoteStream.addTrack(e.track);
+    }
+
+    if (this.audioRef.current) {
+      this.audioRef.current.srcObject = this.remoteStream;
+    }
+  };
+
+  onNegotiationNeeded = (e: Event) => {
+    this.log('negotiationNeeded', e);
+  };
+
+  onIceConnectionStateChange = (e: Event) => {
+    this.log('new ice connection state change:');
+    this.log(e);
+    // Repaint.  TODO: make this setState instead
+    this.forceUpdate();
+  };
+
+  onConnectionStateChange = (e: Event) => {
+    this.log('new connection state change:');
+    this.log(e);
+    // Repaint.  TODO: make this setState instead
+    this.forceUpdate();
+  };
+
+  render() {
+    const name = (this.props.peerProfile && this.props.peerProfile.displayName) || 'no profile wat';
+    const titleText = 'uhh working on this';
+    return (
+      <div
+        key={`viewer-${this.props.peerParticipant._id}`}
+        title={titleText || name}
+        className="people-item"
+      >
+        <span className="initial">{name.slice(0, 1)}</span>
+        <div className="webrtc">
+
+          {/*  <span className={`connection ${connectionState}`} /> */}
+          {/*
+          <svg className="speaker-volume">
+            {
+              volumeBars.map((bar, i) => {
+                const width = 100 / volumeBars.length;
+                const buffer = 100 / (8 * volumeBars.length);
+                return (
+                  <rect
+                    key={`bar-${bar}-${i}`}
+                    x={`${width * i + buffer}%`}
+                    y={`${100 - bar}%`}
+                    width={`${width - 2 * buffer}%`}
+                    height={`${bar}%`}
+                  />
+                );
+              })
+            }
+          </svg>
+          */}
+        </div>
+        <audio ref={this.audioRef} className="audio-sink" autoPlay playsInline />
+      </div>
+    );
+  }
+}
+
+const tracker = withTracker((params: CallLinkBoxParams) => {
+  const signal = CallSignals.findOne({
+    sender: params.peerParticipant._id,
+    target: params.selfParticipant._id,
+  });
+
+  // TODO: Fetch our own profile maybe
+  const peerProfile = Profiles.findOne(params.peerParticipant.createdBy);
+
+  return {
+    signal,
+    peerProfile,
+  };
+});
+
+const CallLinkBoxContainer = tracker(CallLinkBox);
+
+export default CallLinkBoxContainer;

--- a/imports/client/components/CallLinkBox.tsx
+++ b/imports/client/components/CallLinkBox.tsx
@@ -2,6 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
 import { faMicrophone, faHeadphonesAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import classnames from 'classnames';
 import React from 'react';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
@@ -285,7 +286,11 @@ class CallLinkBox extends React.PureComponent<CallLinkBoxProps, CallLinkBoxState
       >
         <div
           key={`viewer-${this.props.peerParticipant._id}`}
-          className={`people-item ${this.props.peerParticipant.muted ? 'muted' : ''} ${this.props.peerParticipant.deafened ? 'deafened' : ''} ${this.props.peerParticipant.muted || this.props.peerParticipant.deafened ? '' : 'active'}`}
+          className={classnames('people-item', {
+            muted: this.props.peerParticipant.muted,
+            deafened: this.props.peerParticipant.deafened,
+            live: !this.props.peerParticipant.muted && !this.props.peerParticipant.deafened,
+          })}
         >
           <span className="initial">{name.slice(0, 1)}</span>
           <div className="webrtc">

--- a/imports/client/components/CallLinkBox.tsx
+++ b/imports/client/components/CallLinkBox.tsx
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
-import { faMicrophone, faHeadphonesAlt } from '@fortawesome/free-solid-svg-icons';
+import { faMicrophoneSlash, faVolumeMute } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 import React from 'react';
@@ -294,8 +294,8 @@ class CallLinkBox extends React.PureComponent<CallLinkBoxProps, CallLinkBoxState
         >
           <span className="initial">{name.slice(0, 1)}</span>
           <div className="webrtc">
-            {this.props.peerParticipant.muted && <span className="icon muted-icon"><FontAwesomeIcon icon={faMicrophone} /></span>}
-            {this.props.peerParticipant.deafened && <span className="icon deafened-icon"><FontAwesomeIcon icon={faHeadphonesAlt} /></span>}
+            {this.props.peerParticipant.muted && <span className="icon muted-icon"><FontAwesomeIcon icon={faMicrophoneSlash} /></span>}
+            {this.props.peerParticipant.deafened && <span className="icon deafened-icon"><FontAwesomeIcon icon={faVolumeMute} /></span>}
             {(!this.props.spectraDisabled &&
               !this.props.peerParticipant.muted) ? (
                 <Spectrum

--- a/imports/client/components/CallLinkBox.tsx
+++ b/imports/client/components/CallLinkBox.tsx
@@ -222,7 +222,7 @@ class CallLinkBox extends React.PureComponent<CallLinkBoxProps, CallLinkBoxState
     }
   };
 
-  onNegotiationNeeded = (e: Event) => {
+  onNegotiationNeeded = (_e: Event) => {
     // If we're the initiator, get the ball rolling.  Create an
     // offer, so we'll:
     // 1) generate an SDP descriptor and

--- a/imports/client/components/CallLinkBox.tsx
+++ b/imports/client/components/CallLinkBox.tsx
@@ -33,7 +33,7 @@ interface CallLinkBoxProps extends CallLinkBoxParams {
   spectraDisabled: boolean;
 }
 
-class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
+class CallLinkBox extends React.PureComponent<CallLinkBoxProps, CallLinkBoxState> {
   private audioRef: React.RefObject<HTMLVideoElement>;
 
   private spectrumRef: React.RefObject<Spectrum>;

--- a/imports/client/components/CallLinkBox.tsx
+++ b/imports/client/components/CallLinkBox.tsx
@@ -252,6 +252,10 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
               {' '}
               {this.state.iceConnectionState}
             </div>
+            {this.props.peerParticipant.muted &&
+              <div>Muted (no one can hear them)</div>}
+            {this.props.peerParticipant.deafened &&
+              <div>Deafened (they can&apos;t hear anyone)</div>}
           </Tooltip>
         )}
       >
@@ -262,6 +266,8 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
           <span className="initial">{name.slice(0, 1)}</span>
           <div className="webrtc">
             <span className={`connection ${this.state.iceConnectionState}`} />
+            {this.props.peerParticipant.muted && <span className="muted" />}
+            {this.props.peerParticipant.deafened && <span className="deafened" />}
             {/*
             <svg className="speaker-volume">
               {

--- a/imports/client/components/CallLinkBox.tsx
+++ b/imports/client/components/CallLinkBox.tsx
@@ -5,6 +5,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
+import Flags from '../../flags';
 import CallSignals from '../../lib/models/call_signals';
 import Profiles from '../../lib/models/profiles';
 import PublicSettings from '../../lib/models/public_settings';
@@ -30,6 +31,7 @@ interface CallLinkBoxProps extends CallLinkBoxParams {
   signal: CallSignalType | undefined;
   peerProfile: ProfileType | undefined;
   turnServerUrls: string[];
+  spectraDisabled: boolean;
 }
 
 class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
@@ -283,13 +285,15 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
             <span className={`connection ${this.state.iceConnectionState}`} />
             {this.props.peerParticipant.muted && <span className="muted"><FontAwesomeIcon icon={faMicrophone} /></span>}
             {this.props.peerParticipant.deafened && <span className="deafened"><FontAwesomeIcon icon={faHeadphonesAlt} /></span>}
-            <Spectrum
-              className="spectrogram"
-              width={40}
-              height={40}
-              audioContext={this.props.audioContext}
-              ref={this.spectrumRef}
-            />
+            {!this.props.spectraDisabled ? (
+              <Spectrum
+                className="spectrogram"
+                width={40}
+                height={40}
+                audioContext={this.props.audioContext}
+                ref={this.spectrumRef}
+              />
+            ) : null}
           </div>
           <audio ref={this.audioRef} className="audio-sink" autoPlay playsInline muted={this.props.deafened} />
         </div>
@@ -309,10 +313,13 @@ const tracker = withTracker((params: CallLinkBoxParams) => {
   const turnServerConfig = PublicSettings.findOne({ name: 'webrtc.turnserver' });
   const turnServerUrls = (turnServerConfig && turnServerConfig.name === 'webrtc.turnserver' && turnServerConfig.value.urls) || [];
 
+  const spectraDisabled = Flags.active('disable.spectra');
+
   return {
     signal,
     peerProfile,
     turnServerUrls,
+    spectraDisabled,
   };
 });
 

--- a/imports/client/components/CallLinkBox.tsx
+++ b/imports/client/components/CallLinkBox.tsx
@@ -255,7 +255,10 @@ class CallLinkBox extends React.PureComponent<CallLinkBoxProps, CallLinkBoxState
         key={`viewer-${this.props.peerParticipant._id}`}
         placement="right"
         overlay={(
-          <Tooltip id={`caller-${this.props.peerParticipant._id}`}>
+          <Tooltip
+            id={`caller-${this.props.peerParticipant._id}`}
+            className="chatter-tooltip"
+          >
             <div>{name}</div>
             <div>
               connection status:

--- a/imports/client/components/CallLinkBox.tsx
+++ b/imports/client/components/CallLinkBox.tsx
@@ -262,7 +262,6 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
         overlay={(
           <Tooltip id={`caller-${this.props.peerParticipant._id}`}>
             <div>{name}</div>
-            {/* TODO: add mute/deafened status here */}
             <div>
               connection status:
               {' '}
@@ -305,7 +304,6 @@ const tracker = withTracker((params: CallLinkBoxParams) => {
     target: params.selfParticipant._id,
   });
 
-  // TODO: Fetch our own profile maybe
   const peerProfile = Profiles.findOne(params.peerParticipant.createdBy);
 
   const turnServerConfig = PublicSettings.findOne({ name: 'webrtc.turnserver' });

--- a/imports/client/components/CallLinkBox.tsx
+++ b/imports/client/components/CallLinkBox.tsx
@@ -15,7 +15,6 @@ import { ProfileType } from '../../lib/schemas/profiles';
 import Spectrum from './Spectrum';
 
 interface CallLinkBoxState {
-  localCandidates: RTCIceCandidate[];
   iceConnectionState: RTCIceConnectionState;
 }
 
@@ -49,7 +48,6 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
     super(props);
 
     this.state = {
-      localCandidates: [],
       iceConnectionState: 'new',
     };
 
@@ -86,7 +84,7 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
     const tracks = props.localStream.getTracks();
     for (let i = 0; i < tracks.length; i++) {
       const track = tracks[i];
-      this.log(track, props.localStream);
+      // this.log(track, props.localStream);
       this.pc.addTrack(track);
     }
 
@@ -106,7 +104,7 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
     }
 
     if (props.signal) {
-      this.log(`signals: processing ${props.signal.messages.length} initial signals`);
+      // this.log(`signals: processing ${props.signal.messages.length} initial signals`);
       this.processSignalMessages(props.signal.messages, 0);
     }
   }
@@ -115,9 +113,9 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
     _snapshot: any) {
     // Process any new signal messages in the updated props.
     if (this.props.signal) {
-      const newLength = this.props.signal.messages.length;
+      // const newLength = this.props.signal.messages.length;
       const oldLength = prevProps.signal ? prevProps.signal.messages.length : 0;
-      this.log(`signals: old ${oldLength} new ${newLength}`);
+      // this.log(`signals: old ${oldLength} new ${newLength}`);
       this.processSignalMessages(this.props.signal.messages, oldLength);
     }
   }
@@ -133,8 +131,8 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
   }
 
   onLocalOfferCreated = (offer: RTCSessionDescriptionInit) => {
-    this.log('onLocalOfferCreated');
-    this.log(offer);
+    // this.log('onLocalOfferCreated');
+    // this.log(offer);
     this.pc.setLocalDescription(offer);
     const offerObj = {
       type: offer.type,
@@ -153,7 +151,7 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
 
   handleSignal = (message: CallSignalMessageType) => {
     if (message.type === 'sdp') {
-      this.log('handle sdp');
+      // this.log('handle sdp');
       // Create an RTCSessionDescription using the received SDP offer.
       // Set it.  In the callback, create an answer, then set that as
       // the local description, then signal the initiator.
@@ -162,7 +160,7 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
         .then(this.onRemoteDescriptionSet)
         .catch(this.onRemoteDescriptionSetFailure);
     } else if (message.type === 'iceCandidate') {
-      this.log('handle ice', message.content);
+      // this.log('handle ice', message.content);
       const iceDesc = JSON.parse(message.content);
       if (iceDesc) {
         const remoteCandidate = new RTCIceCandidate(iceDesc);
@@ -177,7 +175,7 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
   };
 
   onAnswerCreated = (answer: RTCSessionDescriptionInit) => {
-    this.log('onAnswerCreated', answer);
+    // this.log('onAnswerCreated', answer);
     this.pc.setLocalDescription(answer);
     const answerObj = {
       type: answer.type,
@@ -191,7 +189,7 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
   }
 
   onRemoteDescriptionSet = () => {
-    this.log('remoteDescriptionSet');
+    // this.log('remoteDescriptionSet');
     if (!this.isInitiator) {
       this.pc.createAnswer().then(this.onAnswerCreated);
     }
@@ -202,14 +200,8 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
   };
 
   onNewLocalCandidate = (e: RTCPeerConnectionIceEvent) => {
-    //    this.log("new local candidate:");
-    //    this.log(e);
     const iceCandidate = e.candidate;
-    if (iceCandidate) {
-      this.setState((prevState) => {
-        return { localCandidates: [...prevState.localCandidates, iceCandidate] };
-      });
-    } else {
+    if (!iceCandidate) {
       this.log('local candidate list complete');
     }
 
@@ -220,7 +212,7 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
   };
 
   onNewRemoteTrack = (e: RTCTrackEvent) => {
-    this.log('newRemoteTrack', e);
+    // this.log('newRemoteTrack', e);
     if (e.track.kind === 'audio') {
       // Wire the track directly to the audio element for playback with echo
       // cancellation.
@@ -247,9 +239,9 @@ class CallLinkBox extends React.Component<CallLinkBoxProps, CallLinkBoxState> {
     this.log('negotiationNeeded', e);
   };
 
-  onIceConnectionStateChange = (e: Event) => {
-    this.log('new ice connection state change:');
-    this.log(e);
+  onIceConnectionStateChange = (_e: Event) => {
+    // this.log('new ice connection state change:');
+    // this.log(e);
     this.setState({
       iceConnectionState: this.pc.iceConnectionState,
     });

--- a/imports/client/components/CallLinkBox.tsx
+++ b/imports/client/components/CallLinkBox.tsx
@@ -72,6 +72,8 @@ class CallLinkBox extends React.PureComponent<CallLinkBoxProps, CallLinkBoxState
       ],
     };
 
+    this.isInitiator = props.selfParticipant._id < props.peerParticipant._id;
+
     this.pc = new RTCPeerConnection(rtcConfig);
     this.pc.addEventListener('icecandidate', this.onNewLocalCandidate);
     // Firefox doesn't support connectionstatechange or connectionState yet, so
@@ -86,21 +88,6 @@ class CallLinkBox extends React.PureComponent<CallLinkBoxProps, CallLinkBoxState
       const track = tracks[i];
       // this.log(track, props.localStream);
       this.pc.addTrack(track);
-    }
-
-    // If we're the initiator, get the ball rolling.  Create an
-    // offer, so we'll:
-    // 1) generate an SDP descriptor and
-    // 2) start doing STUN to collect our ICE candidates.
-    //
-    // We must make the offer *after* we have a user media stream;
-    // browsers won't bother if the peer doesn't have a stream worth
-    // sharing, because SDP requires knowing what the stream format
-    // is.  (This is fine; we already have the stream by the time we
-    // construct a CallLink.)
-    this.isInitiator = props.selfParticipant._id < props.peerParticipant._id;
-    if (this.isInitiator) {
-      this.pc.createOffer().then(this.onLocalOfferCreated);
     }
 
     if (props.signal) {
@@ -236,7 +223,21 @@ class CallLinkBox extends React.PureComponent<CallLinkBoxProps, CallLinkBoxState
   };
 
   onNegotiationNeeded = (e: Event) => {
-    this.log('negotiationNeeded', e);
+    // If we're the initiator, get the ball rolling.  Create an
+    // offer, so we'll:
+    // 1) generate an SDP descriptor and
+    // 2) start doing STUN to collect our ICE candidates.
+    //
+    // We must make the offer *after* we have a user media stream;
+    // browsers won't bother if the peer doesn't have a stream worth
+    // sharing, because SDP requires knowing what the stream format
+    // is.  (This is fine; we already have the stream by the time we
+    // construct a CallLink.)
+    if (this.isInitiator) {
+      this.pc.createOffer().then(this.onLocalOfferCreated);
+    }
+
+    // this.log('negotiationNeeded', e);
   };
 
   onIceConnectionStateChange = (_e: Event) => {

--- a/imports/client/components/CallLinkBox.tsx
+++ b/imports/client/components/CallLinkBox.tsx
@@ -274,22 +274,24 @@ class CallLinkBox extends React.PureComponent<CallLinkBoxProps, CallLinkBoxState
       >
         <div
           key={`viewer-${this.props.peerParticipant._id}`}
-          className="people-item"
+          className={`people-item ${this.props.peerParticipant.muted ? 'muted' : ''} ${this.props.peerParticipant.deafened ? 'deafened' : ''} ${this.props.peerParticipant.muted || this.props.peerParticipant.deafened ? '' : 'active'}`}
         >
           <span className="initial">{name.slice(0, 1)}</span>
           <div className="webrtc">
+            {this.props.peerParticipant.muted && <span className="icon muted-icon"><FontAwesomeIcon icon={faMicrophone} /></span>}
+            {this.props.peerParticipant.deafened && <span className="icon deafened-icon"><FontAwesomeIcon icon={faHeadphonesAlt} /></span>}
+            {!this.props.spectraDisabled &&
+              !this.props.peerParticipant.muted &&
+              !this.props.peerParticipant.deafened ? (
+                <Spectrum
+                  className="spectrogram"
+                  width={40}
+                  height={40}
+                  audioContext={this.props.audioContext}
+                  ref={this.spectrumRef}
+                />
+              ) : null}
             <span className={`connection ${this.state.iceConnectionState}`} />
-            {this.props.peerParticipant.muted && <span className="muted"><FontAwesomeIcon icon={faMicrophone} /></span>}
-            {this.props.peerParticipant.deafened && <span className="deafened"><FontAwesomeIcon icon={faHeadphonesAlt} /></span>}
-            {!this.props.spectraDisabled ? (
-              <Spectrum
-                className="spectrogram"
-                width={40}
-                height={40}
-                audioContext={this.props.audioContext}
-                ref={this.spectrumRef}
-              />
-            ) : null}
           </div>
           <audio ref={this.audioRef} className="audio-sink" autoPlay playsInline muted={this.props.deafened} />
         </div>

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -1,0 +1,147 @@
+import { Meteor } from 'meteor/meteor';
+import { Random } from 'meteor/random';
+import { withTracker } from 'meteor/react-meteor-data';
+import React from 'react';
+import Button from 'react-bootstrap/Button';
+import CallParticipants from '../../lib/models/call_participants';
+import { CallParticipantType } from '../../lib/schemas/call_participants';
+import CallLinkBox from './CallLinkBox';
+
+const tabId = Random.id();
+
+interface RTCCallSectionParams {
+  huntId: string;
+  puzzleId: string;
+  onLeaveCall(): void;
+  onToggleMute(): void;
+  muted: boolean;
+  audioContext: AudioContext;
+  localStream: MediaStream;
+}
+
+interface RTCCallSectionProps extends RTCCallSectionParams {
+  participantsReady: boolean;
+  participants: CallParticipantType[];
+  selfParticipant: CallParticipantType | undefined;
+  signalsReady: boolean;
+  selfUserId: string | undefined;
+}
+
+interface RTCCallSectionState {
+  deafened: boolean;
+}
+
+class RTCCallSection extends React.Component<RTCCallSectionProps, RTCCallSectionState> {
+  constructor(props: RTCCallSectionProps) {
+    super(props);
+
+    this.state = {
+      deafened: false,
+    };
+  }
+
+  nonSelfParticipants = () => {
+    return this.props.participants.filter((p) => {
+      return (p.createdBy !== this.props.selfUserId) || (p.tab !== tabId);
+    });
+  }
+
+  toggleMuted = () => {
+    this.props.onToggleMute();
+  };
+
+  toggleDeafened = () => {
+    this.setState((prevState) => ({
+      deafened: !prevState.deafened,
+    }));
+  };
+
+  leaveCall = () => {
+    this.props.onLeaveCall();
+  };
+
+  render() {
+    if (!this.props.participantsReady || !this.props.signalsReady) {
+      return <div />;
+    }
+
+    const callerCount = this.props.participants.length;
+    const others = this.nonSelfParticipants();
+
+    return (
+      <div className="chatter-subsection av-chatters">
+        <header>
+          {`${callerCount} caller${callerCount !== 1 ? 's' : ''}`}
+        </header>
+        <div className="people-list">
+          <div
+            key="self"
+            className="people-item"
+          >
+            <span className="initial">Me</span>
+          </div>
+          {this.props.signalsReady && this.props.selfParticipant && others.map((p) => {
+            return (
+              <CallLinkBox
+                key={p._id}
+                selfParticipant={this.props.selfParticipant!}
+                peerParticipant={p}
+                localStream={this.props.localStream}
+                audioContext={this.props.audioContext}
+                deafened={this.state.deafened}
+              />
+            );
+          })}
+        </div>
+        <div className="av-actions">
+          <Button
+            className={this.props.muted ? 'btn-secondary' : 'btn-light'}
+            onClick={this.toggleMuted}
+          >
+            {this.props.muted ? 'muted' : 'mute'}
+          </Button>
+          <Button
+            className={this.state.deafened ? 'btn-secondary' : 'btn-light'}
+            onClick={this.toggleDeafened}
+          >
+            {this.state.deafened ? 'deafened' : 'deafen'}
+          </Button>
+          <Button className="btn-danger" onClick={this.leaveCall}>leave audio call</Button>
+        </div>
+      </div>
+    );
+  }
+}
+
+// This exists just to apply React lifecycle treatment to this subscribe.
+const tracker = withTracker((params: RTCCallSectionParams) => {
+  const joinSub = Meteor.subscribe('call.join', params.huntId, params.puzzleId, tabId);
+  const participants = joinSub.ready() ? CallParticipants.find({
+    hunt: params.huntId,
+    call: params.puzzleId,
+  }).fetch() : [];
+
+  const selfUserId = Meteor.userId() || undefined;
+  const selfParticipant = participants.find((p) => {
+    return p.createdBy === selfUserId && p.tab === tabId;
+  });
+  let signalsReady;
+  if (selfParticipant) {
+    const signalsSub = Meteor.subscribe('call.signal', selfParticipant._id);
+    signalsReady = signalsSub.ready();
+  } else {
+    signalsReady = false;
+  }
+
+  return {
+    participantsReady: joinSub.ready(),
+    selfParticipant,
+    participants,
+    signalsReady,
+    selfUserId,
+  };
+});
+
+const RTCCallSectionContainer = tracker(RTCCallSection);
+
+export default RTCCallSectionContainer;

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -8,6 +8,7 @@ import Tooltip from 'react-bootstrap/Tooltip';
 import CallParticipants from '../../lib/models/call_participants';
 import { CallParticipantType } from '../../lib/schemas/call_participants';
 import CallLinkBox from './CallLinkBox';
+import Spectrum from './Spectrum';
 
 const tabId = Random.id();
 
@@ -96,6 +97,20 @@ class RTCCallSection extends React.Component<RTCCallSectionProps, RTCCallSection
           className="people-item"
         >
           <span className="initial">Me</span>
+          <div className="webrtc">
+            <Spectrum
+              className="spectrogram"
+              width={40}
+              height={40}
+              audioContext={this.props.audioContext}
+              ref={((spectrum) => {
+                if (spectrum) {
+                  spectrum.connect(this.props.localStream);
+                }
+              }
+              )}
+            />
+          </div>
         </div>
       </OverlayTrigger>
     );

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -2,6 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
 import { faMicrophone, faHeadphonesAlt } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import classnames from 'classnames';
 import React from 'react';
 import Button from 'react-bootstrap/Button';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
@@ -73,7 +74,11 @@ class RTCCallSection extends React.Component<RTCCallSectionProps> {
       >
         <div
           key="self"
-          className={`people-item ${this.props.muted ? 'muted' : ''} ${this.props.deafened ? 'deafened' : ''} ${this.props.muted || this.props.deafened ? '' : 'active'}`}
+          className={classnames('people-item', {
+            muted: this.props.muted,
+            deafened: this.props.deafened,
+            live: !this.props.muted && !this.props.deafened,
+          })}
         >
           <span className="initial">{initial}</span>
           <div className="webrtc">

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -8,7 +8,9 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
 import Flags from '../../flags';
 import CallParticipants from '../../lib/models/call_participants';
+import Profiles from '../../lib/models/profiles';
 import { CallParticipantType } from '../../lib/schemas/call_participants';
+import { ProfileType } from '../../lib/schemas/profiles';
 import CallLinkBox from './CallLinkBox';
 import Spectrum from './Spectrum';
 
@@ -31,6 +33,7 @@ interface RTCCallSectionProps extends RTCCallSectionParams {
   selfParticipant: CallParticipantType | undefined;
   signalsReady: boolean;
   selfUserId: string | undefined;
+  selfProfile: ProfileType | undefined;
   spectraDisabled: boolean;
 }
 
@@ -54,6 +57,8 @@ class RTCCallSection extends React.Component<RTCCallSectionProps> {
   };
 
   renderSelfBox = () => {
+    const selfProfile = this.props.selfProfile;
+    const initial = selfProfile ? selfProfile.displayName.slice(0, 1) : 'U'; // get it?  it's you
     return (
       <OverlayTrigger
         key="self"
@@ -70,7 +75,7 @@ class RTCCallSection extends React.Component<RTCCallSectionProps> {
           key="self"
           className="people-item"
         >
-          <span className="initial">Me</span>
+          <span className="initial">{initial}</span>
           <div className="webrtc">
             {this.props.muted && <span className="muted"><FontAwesomeIcon icon={faMicrophone} /></span>}
             {this.props.deafened && <span className="deafened"><FontAwesomeIcon icon={faHeadphonesAlt} /></span>}
@@ -155,6 +160,7 @@ const tracker = withTracker((params: RTCCallSectionParams) => {
   }).fetch() : [];
 
   const selfUserId = Meteor.userId() || undefined;
+  const selfProfile = selfUserId ? Profiles.findOne(selfUserId) : undefined;
   const selfParticipant = participants.find((p) => {
     return p.createdBy === selfUserId && p.tab === params.tabId;
   });
@@ -171,6 +177,7 @@ const tracker = withTracker((params: RTCCallSectionParams) => {
   return {
     participantsReady: joinSub.ready(),
     selfParticipant,
+    selfProfile,
     participants,
     signalsReady,
     selfUserId,

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -3,6 +3,8 @@ import { Random } from 'meteor/random';
 import { withTracker } from 'meteor/react-meteor-data';
 import React from 'react';
 import Button from 'react-bootstrap/Button';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
 import CallParticipants from '../../lib/models/call_participants';
 import { CallParticipantType } from '../../lib/schemas/call_participants';
 import CallLinkBox from './CallLinkBox';
@@ -60,6 +62,29 @@ class RTCCallSection extends React.Component<RTCCallSectionProps, RTCCallSection
     this.props.onLeaveCall();
   };
 
+  renderSelfBox = () => {
+    return (
+      <OverlayTrigger
+        key="self"
+        placement="right"
+        overlay={(
+          <Tooltip id="caller-self">
+            <div>You are in the call.</div>
+            {this.props.muted && <div>You are currently muted and will transmit no audio.</div>}
+            {this.state.deafened && <div>You are currently deafened and will hear no audio.</div>}
+          </Tooltip>
+        )}
+      >
+        <div
+          key="self"
+          className="people-item"
+        >
+          <span className="initial">Me</span>
+        </div>
+      </OverlayTrigger>
+    );
+  };
+
   render() {
     if (!this.props.participantsReady || !this.props.signalsReady) {
       return <div />;
@@ -92,12 +117,7 @@ class RTCCallSection extends React.Component<RTCCallSectionProps, RTCCallSection
             {`${callerCount} caller${callerCount !== 1 ? 's' : ''}`}
           </header>
           <div className="people-list">
-            <div
-              key="self"
-              className="people-item"
-            >
-              <span className="initial">Me</span>
-            </div>
+            {this.renderSelfBox()}
             {this.props.signalsReady && this.props.selfParticipant && others.map((p) => {
               return (
                 <CallLinkBox

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -49,10 +49,26 @@ class RTCCallSection extends React.Component<RTCCallSectionProps, RTCCallSection
   }
 
   toggleMuted = () => {
+    if (this.props.selfParticipant) {
+      Meteor.call('setMuted', this.props.selfParticipant._id, !this.props.muted,
+        (err: Meteor.Error | undefined) => {
+          if (err) {
+            // Ignore.  Not much we can do here; the server failed to accept our change.
+          }
+        });
+    }
     this.props.onToggleMute();
   };
 
   toggleDeafened = () => {
+    if (this.props.selfParticipant) {
+      Meteor.call('setDeafened', this.props.selfParticipant._id, !this.state.deafened,
+        (err: Meteor.Error | undefined) => {
+          if (err) {
+            // Ignore.  Not much we can do here; the server failed to accept our change.
+          }
+        });
+    }
     this.setState((prevState) => ({
       deafened: !prevState.deafened,
     }));
@@ -101,14 +117,14 @@ class RTCCallSection extends React.Component<RTCCallSectionProps, RTCCallSection
             size="sm"
             onClick={this.toggleMuted}
           >
-            {this.props.muted ? 'muted' : 'mute'}
+            {this.props.muted ? 'unmute' : 'mute self'}
           </Button>
           <Button
             variant={this.state.deafened ? 'secondary' : 'light'}
             size="sm"
             onClick={this.toggleDeafened}
           >
-            {this.state.deafened ? 'deafened' : 'deafen'}
+            {this.state.deafened ? 'undeafen' : 'deafen self'}
           </Button>
           <Button variant="danger" size="sm" onClick={this.leaveCall}>leave call</Button>
         </div>

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -1,6 +1,8 @@
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
 import { withTracker } from 'meteor/react-meteor-data';
+import { faMicrophone, faHeadphonesAlt } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import Button from 'react-bootstrap/Button';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
@@ -98,6 +100,8 @@ class RTCCallSection extends React.Component<RTCCallSectionProps, RTCCallSection
         >
           <span className="initial">Me</span>
           <div className="webrtc">
+            {this.props.muted && <span className="muted"><FontAwesomeIcon icon={faMicrophone} /></span>}
+            {this.state.deafened && <span className="deafened"><FontAwesomeIcon icon={faHeadphonesAlt} /></span>}
             <Spectrum
               className="spectrogram"
               width={40}

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
-import { faMicrophone, faHeadphonesAlt } from '@fortawesome/free-solid-svg-icons';
+import { faMicrophoneSlash, faVolumeMute } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 import React from 'react';
@@ -82,8 +82,8 @@ class RTCCallSection extends React.Component<RTCCallSectionProps> {
         >
           <span className="initial">{initial}</span>
           <div className="webrtc">
-            {this.props.muted && <span className="icon muted-icon"><FontAwesomeIcon icon={faMicrophone} /></span>}
-            {this.props.deafened && <span className="icon deafened-icon"><FontAwesomeIcon icon={faHeadphonesAlt} /></span>}
+            {this.props.muted && <span className="icon muted-icon"><FontAwesomeIcon icon={faMicrophoneSlash} /></span>}
+            {this.props.deafened && <span className="icon deafened-icon"><FontAwesomeIcon icon={faVolumeMute} /></span>}
             {!this.props.spectraDisabled && !this.props.muted && !this.props.deafened ? (
               <Spectrum
                 className="spectrogram"

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -69,46 +69,50 @@ class RTCCallSection extends React.Component<RTCCallSectionProps, RTCCallSection
     const others = this.nonSelfParticipants();
 
     return (
-      <div className="chatter-subsection av-chatters">
-        <header>
-          {`${callerCount} caller${callerCount !== 1 ? 's' : ''}`}
-        </header>
-        <div className="people-list">
-          <div
-            key="self"
-            className="people-item"
-          >
-            <span className="initial">Me</span>
-          </div>
-          {this.props.signalsReady && this.props.selfParticipant && others.map((p) => {
-            return (
-              <CallLinkBox
-                key={p._id}
-                selfParticipant={this.props.selfParticipant!}
-                peerParticipant={p}
-                localStream={this.props.localStream}
-                audioContext={this.props.audioContext}
-                deafened={this.state.deafened}
-              />
-            );
-          })}
-        </div>
+      <>
         <div className="av-actions">
           <Button
-            className={this.props.muted ? 'btn-secondary' : 'btn-light'}
+            variant={this.props.muted ? 'secondary' : 'light'}
+            size="sm"
             onClick={this.toggleMuted}
           >
             {this.props.muted ? 'muted' : 'mute'}
           </Button>
           <Button
-            className={this.state.deafened ? 'btn-secondary' : 'btn-light'}
+            variant={this.state.deafened ? 'secondary' : 'light'}
+            size="sm"
             onClick={this.toggleDeafened}
           >
             {this.state.deafened ? 'deafened' : 'deafen'}
           </Button>
-          <Button className="btn-danger" onClick={this.leaveCall}>leave audio call</Button>
+          <Button variant="danger" size="sm" onClick={this.leaveCall}>leave call</Button>
         </div>
-      </div>
+        <div className="chatter-subsection av-chatters">
+          <header>
+            {`${callerCount} caller${callerCount !== 1 ? 's' : ''}`}
+          </header>
+          <div className="people-list">
+            <div
+              key="self"
+              className="people-item"
+            >
+              <span className="initial">Me</span>
+            </div>
+            {this.props.signalsReady && this.props.selfParticipant && others.map((p) => {
+              return (
+                <CallLinkBox
+                  key={p._id}
+                  selfParticipant={this.props.selfParticipant!}
+                  peerParticipant={p}
+                  localStream={this.props.localStream}
+                  audioContext={this.props.audioContext}
+                  deafened={this.state.deafened}
+                />
+              );
+            })}
+          </div>
+        </div>
+      </>
     );
   }
 }

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import Button from 'react-bootstrap/Button';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
+import Flags from '../../flags';
 import CallParticipants from '../../lib/models/call_participants';
 import { CallParticipantType } from '../../lib/schemas/call_participants';
 import CallLinkBox from './CallLinkBox';
@@ -30,6 +31,7 @@ interface RTCCallSectionProps extends RTCCallSectionParams {
   selfParticipant: CallParticipantType | undefined;
   signalsReady: boolean;
   selfUserId: string | undefined;
+  spectraDisabled: boolean;
 }
 
 class RTCCallSection extends React.Component<RTCCallSectionProps> {
@@ -72,18 +74,20 @@ class RTCCallSection extends React.Component<RTCCallSectionProps> {
           <div className="webrtc">
             {this.props.muted && <span className="muted"><FontAwesomeIcon icon={faMicrophone} /></span>}
             {this.props.deafened && <span className="deafened"><FontAwesomeIcon icon={faHeadphonesAlt} /></span>}
-            <Spectrum
-              className="spectrogram"
-              width={40}
-              height={40}
-              audioContext={this.props.audioContext}
-              ref={((spectrum) => {
-                if (spectrum) {
-                  spectrum.connect(this.props.localStream);
+            {!this.props.spectraDisabled ? (
+              <Spectrum
+                className="spectrogram"
+                width={40}
+                height={40}
+                audioContext={this.props.audioContext}
+                ref={((spectrum) => {
+                  if (spectrum) {
+                    spectrum.connect(this.props.localStream);
+                  }
                 }
-              }
-              )}
-            />
+                )}
+              />
+            ) : null}
           </div>
         </div>
       </OverlayTrigger>
@@ -162,12 +166,15 @@ const tracker = withTracker((params: RTCCallSectionParams) => {
     signalsReady = false;
   }
 
+  const spectraDisabled = Flags.active('disable.spectra');
+
   return {
     participantsReady: joinSub.ready(),
     selfParticipant,
     participants,
     signalsReady,
     selfUserId,
+    spectraDisabled,
   };
 });
 

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -73,13 +73,13 @@ class RTCCallSection extends React.Component<RTCCallSectionProps> {
       >
         <div
           key="self"
-          className="people-item"
+          className={`people-item ${this.props.muted ? 'muted' : ''} ${this.props.deafened ? 'deafened' : ''} ${this.props.muted || this.props.deafened ? '' : 'active'}`}
         >
           <span className="initial">{initial}</span>
           <div className="webrtc">
-            {this.props.muted && <span className="muted"><FontAwesomeIcon icon={faMicrophone} /></span>}
-            {this.props.deafened && <span className="deafened"><FontAwesomeIcon icon={faHeadphonesAlt} /></span>}
-            {!this.props.spectraDisabled ? (
+            {this.props.muted && <span className="icon muted-icon"><FontAwesomeIcon icon={faMicrophone} /></span>}
+            {this.props.deafened && <span className="icon deafened-icon"><FontAwesomeIcon icon={faHeadphonesAlt} /></span>}
+            {!this.props.spectraDisabled && !this.props.muted && !this.props.deafened ? (
               <Spectrum
                 className="spectrogram"
                 width={40}

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -136,6 +136,8 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
   };
 
   gotLocalMediaStream = (mediaStream: MediaStream) => {
+    // @ts-ignore ts doesn't know about the possible existence of webkitAudioContext
+    const AudioContext = window.AudioContext || window.webkitAudioContext;
     const audioContext = new AudioContext();
     const wrapperStreamDestination = audioContext.createMediaStreamDestination();
     const gainNode = audioContext.createGain();

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -214,44 +214,28 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
     });
   };
 
-  renderCallControls = () => {
-    const joinLabel = this.props.rtcViewers.length > 0 ? 'join audio call' : 'start audio call';
-    return (
-      <div className="av-actions">
-        {this.state.state === 'call' ? (
-          <>
-            <Button
-              className={this.state.muted ? 'btn-secondary' : 'btn-light'}
-              onClick={this.toggleMuted}
-            >
-              mute
-              {this.state.muted && 'd'}
-            </Button>
-            <Button className="btn-danger" onClick={this.leaveCall}>leave audio call</Button>
-          </>
-        ) : (
-          <Button className="btn-primary" onClick={this.joinCall}>{joinLabel}</Button>
-        )}
-      </div>
-    );
-  };
-
   renderCallersSubsection = () => {
     const { rtcViewers, huntId, puzzleId } = this.props;
     switch (this.state.state) {
       case 'chatonly':
-      case 'requestingstream':
+      case 'requestingstream': {
+        const joinLabel = rtcViewers.length > 0 ? 'join audio call' : 'start audio call';
         return (
-          <div className="chatter-subsection av-chatters">
-            <header>
-              {`${rtcViewers.length} caller${rtcViewers.length !== 1 ? 's' : ''}`}
-            </header>
-            <div className="people-list">
-              {rtcViewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}`} {...viewer} />)}
+          <>
+            <div className="av-actions">
+              <Button variant="primary" size="sm" block onClick={this.joinCall}>{joinLabel}</Button>
             </div>
-            {this.renderCallControls()}
-          </div>
+            <div className="chatter-subsection av-chatters">
+              <header>
+                {`${rtcViewers.length} caller${rtcViewers.length !== 1 ? 's' : ''}`}
+              </header>
+              <div className="people-list">
+                {rtcViewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}`} {...viewer} />)}
+              </div>
+            </div>
+          </>
         );
+      }
       case 'call':
         return (
           <CallSection

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -2,6 +2,8 @@ import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
 import React, { ReactChild } from 'react';
 import Button from 'react-bootstrap/Button';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
 import Flags from '../../flags';
 import CallParticipants from '../../lib/models/call_participants';
 import Profiles from '../../lib/models/profiles';
@@ -25,10 +27,20 @@ interface PersonBoxProps {
 const ViewerPersonBox = ({
   user, name, titleText, children,
 }: PersonBoxProps) => (
-  <div key={`viewer-${user}`} title={titleText || name} className="people-item">
-    <span className="initial">{name.slice(0, 1)}</span>
-    { children }
-  </div>
+  <OverlayTrigger
+    key={`viewer-${user}`}
+    placement="right"
+    overlay={(
+      <Tooltip id={`viewer-${user}`}>
+        {name}
+      </Tooltip>
+    )}
+  >
+    <div key={`viewer-${user}`} title={titleText || name} className="people-item">
+      <span className="initial">{name.slice(0, 1)}</span>
+      { children }
+    </div>
+  </OverlayTrigger>
 );
 
 interface ChatPeopleParams {

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -364,8 +364,6 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
     const totalViewers = viewers.length + unknown;
     return (
       <section className="chatter-section">
-        {/* TODO: mark this <audio> as muted before going to prod, lest people
-            get self-feedback.  It's easier to test locally for now though. */}
         <audio ref={this.htmlNodeRef} autoPlay playsInline muted />
         {!rtcDisabled && this.renderCallersSubsection()}
         <div className="chatter-subsection non-av-viewers">

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -81,9 +81,7 @@ interface ChatPeopleState {
 
   audioContext: AudioContext | undefined;
   rawMediaSource: MediaStream | undefined;
-  // wrapperStreamSource: MediaStreamAudioSourceNode | undefined;
   gainNode: GainNode | undefined;
-  // wrapperStreamDestination: MediaStreamAudioDestinationNode | undefined;
   leveledStreamSource: MediaStream | undefined;
 }
 
@@ -120,9 +118,7 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
 
       audioContext: undefined,
       rawMediaSource: undefined,
-      // wrapperStreamSource: undefined,
       gainNode: undefined,
-      // wrapperStreamDestination: undefined,
       leveledStreamSource: undefined,
     };
 
@@ -199,7 +195,6 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
 
   joinCall = () => {
     if (navigator.mediaDevices) {
-      // TODO: get user media, set the state in the callback.
       this.setState({
         state: 'requestingstream',
       });
@@ -234,8 +229,6 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
     const gainValue = this.state.muted ? 0.0 : 1.0;
     gainNode.gain.setValueAtTime(gainValue, audioContext.currentTime);
 
-    let wrapperStreamSource;
-
     const leveledStreamSource = new MediaStream();
     const rawTracks = mediaStream.getTracks();
     for (let i = 0; i < rawTracks.length; i++) {
@@ -245,7 +238,7 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
         // track in another stream.
         const stubStream = new MediaStream();
         stubStream.addTrack(rawTrack);
-        wrapperStreamSource = audioContext.createMediaStreamSource(stubStream);
+        const wrapperStreamSource = audioContext.createMediaStreamSource(stubStream);
 
         // Wire up the audio track to the gain node.
         wrapperStreamSource.connect(gainNode);
@@ -272,9 +265,7 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
       state: 'call',
       audioContext,
       rawMediaSource: mediaStream,
-      // wrapperStreamSource,
       gainNode,
-      // wrapperStreamDestination,
       leveledStreamSource,
     });
   };
@@ -298,9 +289,7 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
       deafened: false,
       audioContext: undefined,
       rawMediaSource: undefined,
-      // wrapperStreamSource: undefined,
       gainNode: undefined,
-      // wrapperStreamDestination: undefined,
       leveledStreamSource: undefined,
     });
   };

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -204,6 +204,7 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
 
     this.setState({
       state: 'chatonly',
+      muted: false,
       audioContext: undefined,
       rawMediaSource: undefined,
       // wrapperStreamSource: undefined,

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -343,6 +343,9 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
             {`ERROR GETTING MIC: ${this.state.error}`}
           </div>
         );
+      default:
+        // Unreachable.  TypeScript knows this, but eslint doesn't.
+        return <div />;
     }
   };
 

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -418,11 +418,8 @@ const ChatPeopleContainer = withTracker(({ huntId, puzzleId }: ChatPeopleParams)
   }).fetch();
   let selfParticipant;
   rtcParticipants.forEach((p) => {
-    if (p.createdBy === Meteor.userId()) {
-      if (p.tab === tabId) {
-        selfParticipant = p;
-      }
-      return;
+    if (p.createdBy === Meteor.userId() && p.tab === tabId) {
+      selfParticipant = p;
     }
 
     const user = p.createdBy;
@@ -435,10 +432,8 @@ const ChatPeopleContainer = withTracker(({ huntId, puzzleId }: ChatPeopleParams)
     // If the same user is joined twice in CallParticipants (from two different
     // tabs), dedupe in the viewer listing.
     // (We include both in rtcParticipants still.)
-    if (!rtcViewerIndex[user]) {
-      rtcViewers.push({ user, name: profile.displayName });
-      rtcViewerIndex[user] = true;
-    }
+    rtcViewers.push({ user, name: profile.displayName });
+    rtcViewerIndex[user] = true;
   });
 
   // eslint-disable-next-line no-restricted-globals

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -1,0 +1,394 @@
+import { Meteor } from 'meteor/meteor';
+import { withTracker } from 'meteor/react-meteor-data';
+import React, { ReactChild } from 'react';
+import Button from 'react-bootstrap/Button';
+import Flags from '../../flags';
+import CallParticipants from '../../lib/models/call_participants';
+import Profiles from '../../lib/models/profiles';
+import { CallParticipantType } from '../../lib/schemas/call_participants';
+import { Subscribers } from '../subscribers';
+import CallSection from './CallSection';
+
+interface ViewerSubscriber {
+  user: string;
+  name: string;
+}
+
+interface PersonBoxProps {
+  user: string;
+  name: string;
+  titleText?: string;
+  tabId?: string;
+  children?: ReactChild;
+}
+
+const ViewerPersonBox = ({
+  user, name, titleText, children,
+}: PersonBoxProps) => (
+  <div key={`viewer-${user}`} title={titleText || name} className="people-item">
+    <span className="initial">{name.slice(0, 1)}</span>
+    { children }
+  </div>
+);
+
+interface ChatPeopleParams {
+  huntId: string;
+  puzzleId: string;
+}
+
+interface ChatPeopleProps extends ChatPeopleParams {
+  ready: boolean;
+  viewers: ViewerSubscriber[];
+  rtcViewers: ViewerSubscriber[];
+  unknown: number;
+  rtcParticipants: CallParticipantType[];
+  rtcDisabled: boolean;
+}
+
+interface ChatPeopleState {
+  // TODO: make this an enum of 'chatonly', 'requestingstream', 'streamerror', 'call',
+  state: string;
+  error: string;
+  muted: boolean;
+  // TOOD: media stream
+
+  audioContext: AudioContext | undefined;
+  rawMediaSource: MediaStream | undefined;
+  // wrapperStreamSource: MediaStreamAudioSourceNode | undefined;
+  gainNode: GainNode | undefined;
+  // wrapperStreamDestination: MediaStreamAudioDestinationNode | undefined;
+  leveledStreamSource: MediaStream | undefined;
+}
+
+// Helper to tear down tracks of streams
+function stopTracks(stream: MediaStream | null | undefined) {
+  if (stream) {
+    const tracks = stream.getTracks();
+    tracks.forEach((track) => {
+      track.stop();
+    });
+  }
+}
+
+class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
+  private htmlNodeRef: React.RefObject<HTMLAudioElement>;
+
+  constructor(props: ChatPeopleProps) {
+    super(props);
+    this.state = {
+      state: 'chatonly',
+      error: '',
+      muted: false,
+
+      audioContext: undefined,
+      rawMediaSource: undefined,
+      // wrapperStreamSource: undefined,
+      gainNode: undefined,
+      // wrapperStreamDestination: undefined,
+      leveledStreamSource: undefined,
+    };
+
+    this.htmlNodeRef = React.createRef();
+  }
+
+  componentWillUnmount() {
+    // Stop any tracks that might be running.
+    stopTracks(this.state.rawMediaSource);
+  }
+
+  toggleMuted = () => {
+    const newGain = this.state.muted ? 1.0 : 0.0;
+    if (this.state.gainNode && this.state.audioContext) {
+      this.state.gainNode.gain.setValueAtTime(newGain, this.state.audioContext.currentTime);
+    }
+
+    this.setState((prevState) => ({
+      muted: !prevState.muted,
+    }));
+  };
+
+  joinCall = () => {
+    // TODO: get user media, set the state in the callback.
+    this.setState({
+      state: 'requestingstream',
+    });
+
+    // Get the user media stream.
+    const mediaStreamConstraints = {
+      audio: {
+        echoCancellation: { ideal: true },
+        autoGainControl: { ideal: true },
+        noiseSuppression: { ideal: true },
+      },
+      // TODO: conditionally allow video if enabled by feature flag?
+    };
+
+    navigator.mediaDevices.getUserMedia(mediaStreamConstraints)
+      .then(this.gotLocalMediaStream)
+      .catch(this.handleLocalMediaStreamError);
+  };
+
+  gotLocalMediaStream = (mediaStream: MediaStream) => {
+    const audioContext = new AudioContext();
+    const wrapperStreamDestination = audioContext.createMediaStreamDestination();
+    const gainNode = audioContext.createGain();
+    const gainValue = this.state.muted ? 0.0 : 1.0;
+    gainNode.gain.setValueAtTime(gainValue, audioContext.currentTime);
+
+    let wrapperStreamSource;
+
+    const leveledStreamSource = new MediaStream();
+    const rawTracks = mediaStream.getTracks();
+    for (let i = 0; i < rawTracks.length; i++) {
+      const rawTrack = rawTracks[i];
+      if (rawTrack.kind === 'audio') {
+        // Chrome doesn't support createMediaStreamTrackSource, so stuff the
+        // track in another stream.
+        const stubStream = new MediaStream();
+        stubStream.addTrack(rawTrack);
+        wrapperStreamSource = audioContext.createMediaStreamSource(stubStream);
+
+        // Wire up the audio track to the gain node.
+        wrapperStreamSource.connect(gainNode);
+
+        // Then wire up the output of that gain node to our levels-adjusted track.
+        gainNode.connect(wrapperStreamDestination);
+        const innerTracks = wrapperStreamDestination.stream.getTracks();
+        const leveledAudioTrack = innerTracks[0];
+
+        // Add that track to our post-level-adjustment stream.
+        leveledStreamSource.addTrack(leveledAudioTrack);
+      }
+      if (rawTrack.kind === 'video') {
+        leveledStreamSource.addTrack(rawTrack);
+      }
+    }
+
+    const htmlNode = this.htmlNodeRef.current;
+    if (htmlNode) {
+      htmlNode.srcObject = leveledStreamSource;
+    }
+
+    this.setState({
+      state: 'call',
+      audioContext,
+      rawMediaSource: mediaStream,
+      // wrapperStreamSource,
+      gainNode,
+      // wrapperStreamDestination,
+      leveledStreamSource,
+    });
+  };
+
+  handleLocalMediaStreamError = (e: MediaStreamError) => {
+    this.setState({
+      state: 'streamerror',
+      error: `Couldn't get local microphone: ${e.message}`,
+    });
+  };
+
+  leaveCall = () => {
+    stopTracks(this.state.rawMediaSource);
+    if (this.htmlNodeRef.current) {
+      this.htmlNodeRef.current.srcObject = null;
+    }
+
+    this.setState({
+      state: 'chatonly',
+      audioContext: undefined,
+      rawMediaSource: undefined,
+      // wrapperStreamSource: undefined,
+      gainNode: undefined,
+      // wrapperStreamDestination: undefined,
+      leveledStreamSource: undefined,
+    });
+  };
+
+  renderCallControls = () => {
+    const joinLabel = this.props.rtcViewers.length > 0 ? 'join audio call' : 'start audio call';
+    return (
+      <div className="av-actions">
+        {this.state.state === 'call' ? (
+          <>
+            <Button
+              className={this.state.muted ? 'btn-secondary' : 'btn-light'}
+              onClick={this.toggleMuted}
+            >
+              mute
+              {this.state.muted && 'd'}
+            </Button>
+            <Button className="btn-danger" onClick={this.leaveCall}>leave audio call</Button>
+          </>
+        ) : (
+          <Button className="btn-primary" onClick={this.joinCall}>{joinLabel}</Button>
+        )}
+      </div>
+    );
+  };
+
+  renderCallersSubsection = () => {
+    const { rtcViewers, huntId, puzzleId } = this.props;
+    switch (this.state.state) {
+      case 'chatonly':
+      case 'requestingstream':
+        return (
+          <div className="chatter-subsection av-chatters">
+            <header>
+              {`${rtcViewers.length} caller${rtcViewers.length !== 1 ? 's' : ''}`}
+            </header>
+            <div className="people-list">
+              {rtcViewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}`} {...viewer} />)}
+            </div>
+            {this.renderCallControls()}
+          </div>
+        );
+      case 'call':
+        return (
+          <CallSection
+            huntId={huntId}
+            puzzleId={puzzleId}
+            onLeaveCall={this.leaveCall}
+            onToggleMute={this.toggleMuted}
+            muted={this.state.muted}
+            audioContext={this.state.audioContext!}
+            localStream={this.state.leveledStreamSource!}
+          />
+        );
+      case 'streamerror':
+        return (
+          <div>
+            {`ERROR GETTING MIC: ${this.state.error}`}
+          </div>
+        );
+      default:
+        // Should be unreachable.  TODO: make typescript know it
+        return <div />;
+    }
+  };
+
+  render() {
+    const {
+      ready,
+      viewers,
+      unknown,
+      rtcDisabled,
+    } = this.props;
+
+    if (!ready) {
+      return null;
+    }
+
+    const totalViewers = viewers.length + unknown;
+    return (
+      <section className="chatter-section">
+        {/* TODO: mark this <audio> as muted before going to prod, lest people
+            get self-feedback.  It's easier to test locally for now though. */}
+        <audio ref={this.htmlNodeRef} autoPlay playsInline muted />
+        {!rtcDisabled && this.renderCallersSubsection()}
+        <div className="chatter-subsection non-av-viewers">
+          <header>
+            {`${totalViewers} other viewer${totalViewers !== 1 ? 's' : ''}`}
+          </header>
+          <div className="people-list">
+            {viewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}`} {...viewer} />)}
+          </div>
+        </div>
+      </section>
+    );
+  }
+}
+
+// ChatPeopleContainer is the component that deals with all user presence and
+// WebRTC call subscriptions, state, and visualization.
+const ChatPeopleContainer = withTracker(({ huntId, puzzleId }: ChatPeopleParams) => {
+  // A note on this feature flag: we still do the subs for call *metadata* for
+  // simplicity even when webrtc is flagged off; we simply avoid rendering
+  // anything in the UI (which prevents clients from subbing to 'call.join' or
+  // doing signalling).
+  const rtcDisabled = Flags.active('disable.webrtc');
+
+  const subscriberTopic = `puzzle:${puzzleId}`;
+  const subscribersHandle = Meteor.subscribe('subscribers.fetch', subscriberTopic);
+  const callMembersHandle = Meteor.subscribe('call.metadata', huntId, puzzleId);
+  const profilesHandle = Profiles.subscribeDisplayNames();
+
+  const ready = subscribersHandle.ready() && callMembersHandle.ready() && profilesHandle.ready();
+  if (!ready) {
+    return {
+      ready: false,
+      unknown: 0,
+      viewers: [] as ViewerSubscriber[],
+      rtcViewers: [] as ViewerSubscriber[],
+      rtcParticipants: [] as CallParticipantType[],
+      rtcDisabled,
+    };
+  }
+
+  let unknown = 0;
+  const viewers: ViewerSubscriber[] = [];
+
+  const rtcViewers: ViewerSubscriber[] = [];
+  const rtcViewerIndex: any = {};
+
+  const rtcParticipants = CallParticipants.find({
+    hunt: huntId,
+    call: puzzleId,
+  }).fetch();
+  rtcParticipants.forEach((p) => {
+    if (p.createdBy === Meteor.userId()) {
+      return;
+    }
+
+    const user = p.createdBy;
+    const profile = Profiles.findOne(user);
+    if (!profile || !profile.displayName) {
+      unknown += 1;
+      return;
+    }
+
+    // If the same user is joined twice in CallParticipants (from two different
+    // tabs), dedupe in the viewer listing.
+    // (We include both in rtcParticipants still.)
+    if (!rtcViewerIndex[user]) {
+      rtcViewers.push({ user, name: profile.displayName });
+      rtcViewerIndex[user] = true;
+    }
+  });
+
+  // eslint-disable-next-line no-restricted-globals
+  Subscribers.find({ name: subscriberTopic }).forEach((s) => {
+    if (!s.user) {
+      unknown += 1;
+      return;
+    }
+
+    if (rtcViewerIndex[s.user]) {
+      // already counted among rtcViewers, don't duplicate
+      return;
+    }
+
+    if (s.user === Meteor.userId()) {
+      // no need to show self among viewers
+      return;
+    }
+
+    const profile = Profiles.findOne(s.user);
+    if (!profile || !profile.displayName) {
+      unknown += 1;
+      return;
+    }
+
+    viewers.push({ user: s.user, name: profile.displayName });
+  });
+
+  return {
+    ready,
+    unknown,
+    viewers,
+    rtcViewers,
+    rtcParticipants,
+    rtcDisabled,
+  };
+})(ChatPeople);
+
+export default ChatPeopleContainer;

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -108,24 +108,31 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
   };
 
   joinCall = () => {
-    // TODO: get user media, set the state in the callback.
-    this.setState({
-      state: 'requestingstream',
-    });
+    if (navigator.mediaDevices) {
+      // TODO: get user media, set the state in the callback.
+      this.setState({
+        state: 'requestingstream',
+      });
 
-    // Get the user media stream.
-    const mediaStreamConstraints = {
-      audio: {
-        echoCancellation: { ideal: true },
-        autoGainControl: { ideal: true },
-        noiseSuppression: { ideal: true },
-      },
-      // TODO: conditionally allow video if enabled by feature flag?
-    };
+      // Get the user media stream.
+      const mediaStreamConstraints = {
+        audio: {
+          echoCancellation: { ideal: true },
+          autoGainControl: { ideal: true },
+          noiseSuppression: { ideal: true },
+        },
+        // TODO: conditionally allow video if enabled by feature flag?
+      };
 
-    navigator.mediaDevices.getUserMedia(mediaStreamConstraints)
-      .then(this.gotLocalMediaStream)
-      .catch(this.handleLocalMediaStreamError);
+      navigator.mediaDevices.getUserMedia(mediaStreamConstraints)
+        .then(this.gotLocalMediaStream)
+        .catch(this.handleLocalMediaStreamError);
+    } else {
+      this.setState({
+        state: 'streamerror',
+        error: 'Couldn\'t get local microphone: browser denies access on non-HTTPS origins',
+      });
+    }
   };
 
   gotLocalMediaStream = (mediaStream: MediaStream) => {

--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -131,7 +131,7 @@ interface HuntAppProps extends HuntAppWithRouterParams {
   canJoin: boolean;
 }
 
-class HuntApp extends React.Component<HuntAppProps> {
+class HuntApp extends React.PureComponent<HuntAppProps> {
   renderBody = () => {
     if (!this.props.ready) {
       return <span>loading...</span>;

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -1108,7 +1108,7 @@ interface PuzzlePageState {
   defaultsAppliedForPuzzle: string;
 }
 
-class PuzzlePage extends React.Component<PuzzlePageProps, PuzzlePageState> {
+class PuzzlePage extends React.PureComponent<PuzzlePageProps, PuzzlePageState> {
   private puzzlePageEl: HTMLElement | null;
 
   constructor(props: PuzzlePageProps) {

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -16,7 +16,6 @@ import FormControl, { FormControlProps } from 'react-bootstrap/FormControl';
 import FormGroup from 'react-bootstrap/FormGroup';
 import FormLabel from 'react-bootstrap/FormLabel';
 import FormText from 'react-bootstrap/FormText';
-import Modal from 'react-bootstrap/Modal';
 import Nav from 'react-bootstrap/Nav';
 import NavItem from 'react-bootstrap/NavItem';
 import NavLink from 'react-bootstrap/NavLink';
@@ -41,7 +40,7 @@ import { DocumentType } from '../../lib/schemas/documents';
 import { GuessType } from '../../lib/schemas/guess';
 import { PuzzleType } from '../../lib/schemas/puzzles';
 import { TagType } from '../../lib/schemas/tags';
-import { Subscribers, SubscriberCounters } from '../subscribers';
+import ChatPeople from './ChatPeople';
 import DocumentDisplay from './Documents';
 import ModalForm from './ModalForm';
 import PuzzleModalForm, { PuzzleModalFormSubmitPayload } from './PuzzleModalForm';
@@ -134,133 +133,6 @@ const DefaultChatHeightFraction = 0.6;
 //   |    b/a    |
 //   |           |
 //   |___________|
-
-interface ViewerSubscriber {
-  user: string;
-  name: string;
-}
-
-interface ViewersListProps {
-  name: string;
-  ready: boolean;
-  subscribers: ViewerSubscriber[];
-  unknown: number;
-}
-
-class ViewersList extends React.Component<ViewersListProps> {
-  render() {
-    if (!this.props.ready) {
-      return <span>loading...</span>;
-    }
-
-    return (
-      <div>
-        <ul>
-          {this.props.subscribers.map((s) => <li key={s.user}>{s.name}</li>)}
-        </ul>
-        {this.props.unknown !== 0 && `(Plus ${this.props.unknown} hunters with no name set)`}
-      </div>
-    );
-  }
-}
-
-const ViewersListContainer = withTracker(({ name }: { name: string }) => {
-  // Don't want this subscription persisting longer than necessary
-  const subscribersHandle = Meteor.subscribe('subscribers.fetch', name);
-  const profilesHandle = Profiles.subscribeDisplayNames();
-
-  const ready = subscribersHandle.ready() && profilesHandle.ready();
-  if (!ready) {
-    return { ready: ready as boolean, unknown: 0, subscribers: [] };
-  }
-
-  let unknown = 0;
-  const subscribers: ViewerSubscriber[] = [];
-
-  // eslint-disable-next-line no-restricted-globals
-  Subscribers.find({ name }).forEach((s) => {
-    if (!s.user) {
-      unknown += 1;
-      return;
-    }
-
-    const profile = Profiles.findOne(s.user);
-    if (!profile || !profile.displayName) {
-      unknown += 1;
-      return;
-    }
-
-    subscribers.push({ user: s.user, name: profile.displayName });
-  });
-
-  return { ready: ready as boolean, unknown, subscribers };
-})(ViewersList);
-
-interface ViewersModalProps {
-  name: string;
-}
-
-interface ViewersModalState {
-  show: boolean;
-}
-
-class ViewersModal extends React.Component<ViewersModalProps, ViewersModalState> {
-  constructor(props: ViewersModalProps) {
-    super(props);
-    this.state = { show: false };
-  }
-
-  show = () => {
-    this.setState({ show: true });
-  };
-
-  close = () => {
-    this.setState({ show: false });
-  };
-
-  render() {
-    return (
-      <Modal show={this.state.show} onHide={this.close}>
-        <Modal.Header closeButton>
-          <Modal.Title>
-            Currently viewing this puzzle
-          </Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          {this.state.show && <ViewersListContainer name={this.props.name} />}
-        </Modal.Body>
-      </Modal>
-    );
-  }
-}
-
-interface ViewCountDisplayProps {
-  count: number;
-  name: string;
-}
-
-class ViewCountDisplay extends React.Component<ViewCountDisplayProps> {
-  modalRef: React.RefObject<ViewersModal>
-
-  constructor(props: ViewCountDisplayProps) {
-    super(props);
-    this.modalRef = React.createRef();
-  }
-
-  showModal = () => {
-    this.modalRef.current!.show();
-  };
-
-  render() {
-    const text = `See ${this.props.count} ${this.props.count === 1 ? 'viewer' : 'viewers'}`;
-    return (
-      <span className="puzzle-metadata-viewers-button">
-        <ViewersModal ref={this.modalRef} name={this.props.name} />
-        <Button className="btn-info" onClick={this.showModal}>{text}</Button>
-      </span>
-    );
-  }
-}
 
 interface RelatedPuzzleSectionProps {
   activePuzzle: PuzzleType;
@@ -507,6 +379,7 @@ interface ChatSectionProps {
   chatMessages: FilteredChatMessageType[];
   displayNames: Record<string, string>;
   puzzleId: string;
+  huntId: string;
 }
 
 class ChatSection extends React.PureComponent<ChatSectionProps> {
@@ -529,6 +402,7 @@ class ChatSection extends React.PureComponent<ChatSectionProps> {
     return (
       <div className="chat-section">
         {this.props.chatReady ? null : <span>loading...</span>}
+        <ChatPeople huntId={this.props.huntId} puzzleId={this.props.puzzleId} />
         <ChatHistory ref={this.historyRef} chatMessages={this.props.chatMessages} displayNames={this.props.displayNames} />
         <ChatInput
           puzzleId={this.props.puzzleId}
@@ -548,6 +422,7 @@ interface PuzzlePageSidebarProps {
   chatMessages: FilteredChatMessageType[];
   displayNames: Record<string, string>;
   canUpdate: boolean;
+  huntId: string;
   isDesktop: boolean;
   isStackable: boolean;
   showRelated: boolean;
@@ -612,6 +487,7 @@ class PuzzlePageSidebar extends React.PureComponent<PuzzlePageSidebarProps> {
               chatReady={this.props.chatReady}
               chatMessages={this.props.chatMessages}
               displayNames={this.props.displayNames}
+              huntId={this.props.huntId}
               puzzleId={this.props.activePuzzle._id}
             />
           </SplitPanePlus>
@@ -631,7 +507,6 @@ interface PuzzlePageMetadataParams {
 }
 
 interface PuzzlePageMetadataProps extends PuzzlePageMetadataParams {
-  viewCount: number;
   canUpdate: boolean;
   hasGuessQueue: boolean;
 }
@@ -777,10 +652,6 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
               <DocumentDisplay document={this.props.document} displayMode="link" />
             </span>
           )}
-          <ViewCountDisplay
-            count={this.props.viewCount}
-            name={`puzzle:${this.props.puzzle._id}`}
-          />
           {
             !isAdministrivia && (
               this.props.hasGuessQueue ?
@@ -819,11 +690,9 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
 }
 
 const PuzzlePageMetadataContainer = withTracker(({ puzzle }: PuzzlePageMetadataParams) => {
-  const count = SubscriberCounters.findOne(`puzzle:${puzzle._id}`);
   const hunt = Hunts.findOne(puzzle.hunt);
   const hasGuessQueue = !!(hunt && hunt.hasGuessQueue);
   return {
-    viewCount: count ? count.value : 0,
     canUpdate: Roles.userHasPermission(Meteor.userId(), 'mongo.puzzles.update'),
     hasGuessQueue,
   };
@@ -1351,6 +1220,7 @@ class PuzzlePage extends React.Component<PuzzlePageProps, PuzzlePageState> {
         onChangeSidebarConfig={this.onChangeSidebarConfig}
         isDesktop={this.state.isDesktop}
         isStackable={this.state.isStackable}
+        huntId={this.props.match.params.huntId}
       />
     );
 
@@ -1420,10 +1290,12 @@ const tracker = withTracker(({ match }: PuzzlePageWithRouterParams) => {
 
   // Add the current user to the collection of people viewing this puzzle.
   // Don't use the subs manager - we don't want this cached.
-  Meteor.subscribe('subscribers.inc', `puzzle:${params.puzzleId}`, {
+  const subscribersTopic = `puzzle:${params.puzzleId}`;
+  Meteor.subscribe('subscribers.inc', subscribersTopic, {
     puzzle: params.puzzleId,
     hunt: params.huntId,
   });
+  const subscribersHandle = Meteor.subscribe('subscribers.fetch', subscribersTopic);
 
   const displayNamesHandle = Profiles.subscribeDisplayNames();
   let displayNames = {};
@@ -1439,7 +1311,7 @@ const tracker = withTracker(({ match }: PuzzlePageWithRouterParams) => {
   // Track the tally of people viewing this puzzle.
   Meteor.subscribe('subscribers.counts', { hunt: params.huntId });
 
-  const puzzlesReady = puzzlesHandle.ready() && tagsHandle.ready() && guessesHandle.ready() && documentsHandle.ready() && displayNamesHandle.ready();
+  const puzzlesReady = puzzlesHandle.ready() && tagsHandle.ready() && guessesHandle.ready() && documentsHandle.ready() && subscribersHandle.ready() && displayNamesHandle.ready();
 
   let allPuzzles: PuzzleType[];
   let allTags: TagType[];

--- a/imports/client/components/Routes.tsx
+++ b/imports/client/components/Routes.tsx
@@ -14,7 +14,7 @@ import RootRedirector from './RootRedirector';
 import SetupPage from './SetupPage';
 import UnauthenticatedRoute from './UnauthenticatedRoute';
 
-class Routes extends React.Component {
+class Routes extends React.PureComponent {
   render() {
     return (
       <DocumentTitle title="Jolly Roger">

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -1120,6 +1120,7 @@ interface CircuitBreakerSectionProps {
   flagDisableGdrivePermissions: boolean;
   flagDisableApplause: boolean;
   flagDisableWebrtc: boolean;
+  flagDisableSpectra: boolean;
 }
 
 class CircuitBreakerSection extends React.Component<CircuitBreakerSectionProps> {
@@ -1216,6 +1217,23 @@ class CircuitBreakerSection extends React.Component<CircuitBreakerSectionProps> 
             such load once the flag is flipped.
           </p>
         </CircuitBreakerControl>
+        <CircuitBreakerControl
+          title="WebRTC call spectrograms"
+          featureDisabled={this.props.flagDisableSpectra}
+          onChange={(newValue) => this.setFlagValue('disable.spectra', newValue)}
+        >
+          <p>
+            In the WebRTC call UI, we show audio activity via spectrograms.
+            However, this is expensive, since it involves doing FFTs and updating
+            visualizations every frame, for every client.  We provide a feature
+            flag to disable these spectra.
+          </p>
+          <p>
+            Disabling this feature means that Jolly Roger will not show any
+            visual indicator of who in a call is talking, but will use less CPU
+            and battery for members of WebRTC calls.
+          </p>
+        </CircuitBreakerControl>
       </section>
     );
   }
@@ -1242,6 +1260,7 @@ interface SetupPageRewriteProps {
   flagDisableGdrivePermissions: boolean;
   flagDisableApplause: boolean;
   flagDisableWebrtc: boolean;
+  flagDisableSpectra: boolean;
 }
 
 class SetupPageRewrite extends React.Component<SetupPageRewriteProps> {
@@ -1288,6 +1307,7 @@ class SetupPageRewrite extends React.Component<SetupPageRewriteProps> {
           flagDisableGdrivePermissions={this.props.flagDisableGdrivePermissions}
           flagDisableApplause={this.props.flagDisableApplause}
           flagDisableWebrtc={this.props.flagDisableWebrtc}
+          flagDisableSpectra={this.props.flagDisableSpectra}
         />
       </div>
     );
@@ -1328,6 +1348,7 @@ const tracker = withTracker((): SetupPageRewriteProps => {
   const flagDisableGdrivePermissions = Flags.active('disable.gdrive_permissions');
   const flagDisableApplause = Flags.active('disable.applause');
   const flagDisableWebrtc = Flags.active('disable.webrtc');
+  const flagDisableSpectra = Flags.active('disable.spectra');
 
   return {
     ready: settingsHandle.ready(),
@@ -1350,6 +1371,7 @@ const tracker = withTracker((): SetupPageRewriteProps => {
     flagDisableGdrivePermissions,
     flagDisableApplause,
     flagDisableWebrtc,
+    flagDisableSpectra,
   };
 });
 

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -14,6 +14,7 @@ import FormGroup from 'react-bootstrap/FormGroup';
 import FormLabel from 'react-bootstrap/FormLabel';
 import { withBreadcrumb } from 'react-breadcrumbs-context';
 import Flags from '../../flags';
+import PublicSettings from '../../lib/models/public_settings';
 import Settings from '../../lib/models/settings';
 import { DiscordGuilds, DiscordGuildType } from '../discord';
 
@@ -956,6 +957,114 @@ class DiscordIntegrationSection extends React.Component<DiscordIntegrationSectio
   }
 }
 
+interface WebRTCServersFormProps {
+  turnServerUrls: string[];
+}
+
+interface WebRTCServersFormState {
+  url: string;
+  submitState: SubmitState.IDLE | SubmitState.SUBMITTING | SubmitState.SUCCESS | SubmitState.ERROR;
+  submitError: string;
+}
+
+class WebRTCServersForm extends React.Component<WebRTCServersFormProps, WebRTCServersFormState> {
+  constructor(props: WebRTCServersFormProps) {
+    super(props);
+    this.state = {
+      url: props.turnServerUrls.length > 0 ? props.turnServerUrls[0] : '',
+      submitState: SubmitState.IDLE,
+      submitError: '',
+    };
+  }
+
+  dismissAlert = () => {
+    this.setState({
+      submitState: SubmitState.IDLE,
+    });
+  };
+
+  onUrlChange: FormControlProps['onChange'] = (e) => {
+    this.setState({
+      url: e.currentTarget.value,
+    });
+  };
+
+  onSubmit = (e: React.FormEvent<any>) => {
+    e.preventDefault();
+
+    const url = this.state.url.trim();
+
+    this.setState({
+      submitState: SubmitState.SUBMITTING,
+    });
+    Meteor.call('setupTurnServerUrls', [url], (err?: Error) => {
+      if (err) {
+        this.setState({
+          submitState: SubmitState.ERROR,
+          submitError: err.message,
+        });
+      } else {
+        this.setState({
+          submitState: SubmitState.SUCCESS,
+        });
+      }
+    });
+  };
+
+  render() {
+    const shouldDisableForm = this.state.submitState === SubmitState.SUBMITTING;
+    return (
+      <div>
+        {this.state.submitState === 'submitting' ? <Alert variant="info">Saving...</Alert> : null}
+        {this.state.submitState === 'success' ? <Alert variant="success" dismissible onClose={this.dismissAlert}>Saved changes.</Alert> : null}
+        {this.state.submitState === 'error' ? (
+          <Alert variant="danger" dismissible onClose={this.dismissAlert}>
+            Saving failed:
+            {' '}
+            {this.state.submitError}
+          </Alert>
+        ) : null}
+
+        <form onSubmit={this.onSubmit}>
+          <FormGroup>
+            <FormLabel htmlFor="jr-setup-edit-webrtc-turn-server-url">
+              Turn server URL
+            </FormLabel>
+            <FormControl
+              id="jr-setup-edit-webrtc-turn-server-url"
+              type="text"
+              placeholder=""
+              value={this.state.url}
+              disabled={shouldDisableForm}
+              onChange={this.onUrlChange}
+            />
+          </FormGroup>
+          <Button variant="primary" type="submit" onClick={this.onSubmit} disabled={shouldDisableForm}>Save</Button>
+        </form>
+      </div>
+    );
+  }
+}
+
+interface WebRTCSectionProps {
+  turnServerUrls: string[];
+}
+
+class WebRTCSection extends React.Component<WebRTCSectionProps> {
+  render() {
+    return (
+      <section>
+        <h1 className="setup-section-header">
+          <span className="setup-section-header-label">
+            WebRTC
+          </span>
+        </h1>
+        <WebRTCServersForm turnServerUrls={this.props.turnServerUrls} />
+      </section>
+    );
+  }
+}
+
 interface CircuitBreakerControlProps {
   // disabled should be false if the circuit breaker is not intentionally disabling the feature,
   // and true if the feature is currently disabled.
@@ -1127,6 +1236,8 @@ interface SetupPageRewriteProps {
   discordBotToken?: string;
   discordGuild?: DiscordGuildType;
 
+  turnServerUrls: string[];
+
   flagDisableGoogleIntegration: boolean;
   flagDisableGdrivePermissions: boolean;
   flagDisableApplause: boolean;
@@ -1170,6 +1281,9 @@ class SetupPageRewrite extends React.Component<SetupPageRewriteProps> {
           botToken={this.props.discordBotToken}
           guild={this.props.discordGuild}
         />
+        <WebRTCSection
+          turnServerUrls={this.props.turnServerUrls}
+        />
         <CircuitBreakerSection
           flagDisableGdrivePermissions={this.props.flagDisableGdrivePermissions}
           flagDisableApplause={this.props.flagDisableApplause}
@@ -1205,6 +1319,10 @@ const tracker = withTracker((): SetupPageRewriteProps => {
   const discordGuildDoc = Settings.findOne({ name: 'discord.guild' });
   const discordGuild = discordGuildDoc && discordGuildDoc.name === 'discord.guild' ? discordGuildDoc.value.guild : undefined;
 
+  // WebRTC
+  const turnServerConfig = PublicSettings.findOne({ name: 'webrtc.turnserver' });
+  const turnServerUrls = (turnServerConfig && turnServerConfig.name === 'webrtc.turnserver' && turnServerConfig.value.urls) || [];
+
   // Circuit breakers
   const flagDisableGoogleIntegration = Flags.active('disable.google');
   const flagDisableGdrivePermissions = Flags.active('disable.gdrive_permissions');
@@ -1225,6 +1343,8 @@ const tracker = withTracker((): SetupPageRewriteProps => {
     flagDisableDiscord,
     discordBotToken,
     discordGuild,
+
+    turnServerUrls,
 
     flagDisableGoogleIntegration,
     flagDisableGdrivePermissions,

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -1010,6 +1010,7 @@ class CircuitBreakerControl extends React.Component<CircuitBreakerControlProps> 
 interface CircuitBreakerSectionProps {
   flagDisableGdrivePermissions: boolean;
   flagDisableApplause: boolean;
+  flagDisableWebrtc: boolean;
 }
 
 class CircuitBreakerSection extends React.Component<CircuitBreakerSectionProps> {
@@ -1080,6 +1081,32 @@ class CircuitBreakerSection extends React.Component<CircuitBreakerSectionProps> 
             particular hunt when a puzzle in that hunt is solved.
           </p>
         </CircuitBreakerControl>
+        <CircuitBreakerControl
+          title="WebRTC calls"
+          featureDisabled={this.props.flagDisableWebrtc}
+          onChange={(newValue) => this.setFlagValue('disable.webrtc', newValue)}
+        >
+          <p>
+            Jolly Roger has experimental support for making WebRTC audio calls
+            built into each puzzle page.  Jolly Roger provides the signaling
+            server and all members of the call establish a direct connection to
+            all other members of the same call (which is more complex at the
+            edge, but avoids needing to operate a separate high-capacity,
+            latency-sensitive reencoding server).  Note that video calls are
+            not currently supported primarily due to the bandwidth constraints
+            the mesh connectivity would imply -- video consumes 60x the bitrate
+            of audio, and we estimate most residential network connections to
+            only be able to reliably support around 4 call participants at a
+            time before significant degradation.
+          </p>
+          <p>
+            Disabling this feature means that Jolly Roger will not show an
+            audiocall section in the UI on the puzzle page, nor will clients
+            join calls.  The server will still service WebRTC-related
+            subscriptions and methods, but we expect clients to not generate
+            such load once the flag is flipped.
+          </p>
+        </CircuitBreakerControl>
       </section>
     );
   }
@@ -1103,6 +1130,7 @@ interface SetupPageRewriteProps {
   flagDisableGoogleIntegration: boolean;
   flagDisableGdrivePermissions: boolean;
   flagDisableApplause: boolean;
+  flagDisableWebrtc: boolean;
 }
 
 class SetupPageRewrite extends React.Component<SetupPageRewriteProps> {
@@ -1145,6 +1173,7 @@ class SetupPageRewrite extends React.Component<SetupPageRewriteProps> {
         <CircuitBreakerSection
           flagDisableGdrivePermissions={this.props.flagDisableGdrivePermissions}
           flagDisableApplause={this.props.flagDisableApplause}
+          flagDisableWebrtc={this.props.flagDisableWebrtc}
         />
       </div>
     );
@@ -1180,6 +1209,7 @@ const tracker = withTracker((): SetupPageRewriteProps => {
   const flagDisableGoogleIntegration = Flags.active('disable.google');
   const flagDisableGdrivePermissions = Flags.active('disable.gdrive_permissions');
   const flagDisableApplause = Flags.active('disable.applause');
+  const flagDisableWebrtc = Flags.active('disable.webrtc');
 
   return {
     ready: settingsHandle.ready(),
@@ -1199,6 +1229,7 @@ const tracker = withTracker((): SetupPageRewriteProps => {
     flagDisableGoogleIntegration,
     flagDisableGdrivePermissions,
     flagDisableApplause,
+    flagDisableWebrtc,
   };
 });
 

--- a/imports/client/components/Spectrum.tsx
+++ b/imports/client/components/Spectrum.tsx
@@ -86,15 +86,10 @@ class Spectrum extends React.Component<SpectrumProps> {
         const HEIGHT = this.props.height;
         canvasCtx.clearRect(0, 0, WIDTH, HEIGHT);
         const barWidth = (WIDTH / (this.bufferLength / 2));
-        let barHeight;
         let x = 0;
         for (let i = 0; i < (this.bufferLength / 2); i++) {
-          if (this.analyserBuffer[i] < 32) {
-            // minimum bar height reduces some flickering
-            barHeight = HEIGHT * 0.126; // 32 / 255
-          } else {
-            barHeight = (this.analyserBuffer[i] * HEIGHT) / 255;
-          }
+          // minimum bar height reduces some flickering
+          const barHeight = (Math.max(this.analyserBuffer[i], 32) * HEIGHT) / 255;
 
           // bootstrap blue is rgb(0, 123, 255)
           const redness = this.analyserBuffer[i] - 60 < 0 ?

--- a/imports/client/components/Spectrum.tsx
+++ b/imports/client/components/Spectrum.tsx
@@ -30,6 +30,7 @@ class Spectrum extends React.Component<SpectrumProps> {
     this.canvasRef = React.createRef();
     this.analyserNode = this.props.audioContext.createAnalyser();
     this.analyserNode.fftSize = 32;
+    this.analyserNode.smoothingTimeConstant = 0.4;
     this.bufferLength = this.analyserNode.frequencyBinCount;
     this.analyserBuffer = new Uint8Array(this.bufferLength);
   }

--- a/imports/client/components/Spectrum.tsx
+++ b/imports/client/components/Spectrum.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+
+// Note: this is incomplete; I didn't figure out how I wanted to feed a stream
+// to the Spectrum component.  I don't love making it a prop, since I really need
+// to do stuff on change, to make sure that my WebAudio graph is appropriately updated.
+// But I also don't wanna like make it a whole ref and then call methods on it because
+// that also feels a bit weird.  Maybe that's the way to go though?
+
+interface SpectrumProps {
+  width: number;
+  height: number;
+  audioContext: AudioContext;
+  className: string | undefined;
+}
+
+class Spectrum extends React.Component<SpectrumProps> {
+  private canvasRef: React.RefObject<HTMLCanvasElement>;
+
+  private analyserNode: AnalyserNode;
+
+  private bufferLength: number;
+
+  private analyserBuffer: Uint8Array;
+
+  private periodicHandle: number | undefined;
+
+  constructor(props: SpectrumProps) {
+    super(props);
+
+    this.canvasRef = React.createRef();
+    this.analyserNode = this.props.audioContext.createAnalyser();
+    this.analyserNode.fftSize = 32;
+    this.bufferLength = this.analyserNode.frequencyBinCount;
+    this.analyserBuffer = new Uint8Array(this.bufferLength);
+  }
+
+  componentWillUnmount() {
+    if (this.periodicHandle) {
+      window.cancelAnimationFrame(this.periodicHandle);
+      this.periodicHandle = undefined;
+    }
+  }
+
+  connect = (stream: MediaStream) => {
+    // This audio element is a workaround for
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=933677 wherein
+    // audio tracks from a peer connection never deliver data into a WebAudio
+    // context unless they are first made the srcObject of some audio or
+    // video element.
+    const stubAudioElement = document.createElement('audio');
+    stubAudioElement.muted = true;
+    stubAudioElement.srcObject = stream;
+    const wrapperStreamSource = this.props.audioContext.createMediaStreamSource(stream);
+    wrapperStreamSource.connect(this.analyserNode);
+
+    // Schedule periodic spectrogram paintings
+    this.periodicHandle = window.requestAnimationFrame(this.drawSpectrum);
+  };
+
+  drawSpectrum = (_time: number) => {
+    this.periodicHandle = window.requestAnimationFrame(this.drawSpectrum);
+    this.analyserNode.getByteFrequencyData(this.analyserBuffer);
+    const canvas = this.canvasRef.current;
+    if (canvas) {
+      const canvasCtx = canvas.getContext('2d');
+      if (canvasCtx) {
+        const WIDTH = this.props.width;
+        const HEIGHT = this.props.height;
+        canvasCtx.clearRect(0, 0, WIDTH, HEIGHT);
+        // canvasCtx.fillStyle = 'rgb(0, 0, 0)';
+        // canvasCtx.fillRect(0, 0, WIDTH, HEIGHT);
+        const barWidth = (WIDTH / (this.bufferLength / 2));
+        let barHeight;
+        let x = 0;
+        for (let i = 0; i < (this.bufferLength / 2); i++) {
+          barHeight = (this.analyserBuffer[i] * HEIGHT) / 255;
+          const greenness = this.analyserBuffer[i] + 100 > 255 ? 255 : this.analyserBuffer[i] + 100;
+          canvasCtx.fillStyle = `rgb(50,${greenness},50)`;
+          canvasCtx.fillRect(x, HEIGHT - barHeight, barWidth, barHeight);
+          x += barWidth + 1;
+        }
+      }
+    }
+  };
+
+  render() {
+    return (
+      <canvas
+        className={this.props.className}
+        width={this.props.width}
+        height={this.props.height}
+        ref={this.canvasRef}
+      />
+    );
+  }
+}
+
+export default Spectrum;

--- a/imports/client/components/Spectrum.tsx
+++ b/imports/client/components/Spectrum.tsx
@@ -85,15 +85,25 @@ class Spectrum extends React.Component<SpectrumProps> {
         const WIDTH = this.props.width;
         const HEIGHT = this.props.height;
         canvasCtx.clearRect(0, 0, WIDTH, HEIGHT);
-        // canvasCtx.fillStyle = 'rgb(0, 0, 0)';
-        // canvasCtx.fillRect(0, 0, WIDTH, HEIGHT);
         const barWidth = (WIDTH / (this.bufferLength / 2));
         let barHeight;
         let x = 0;
         for (let i = 0; i < (this.bufferLength / 2); i++) {
-          barHeight = (this.analyserBuffer[i] * HEIGHT) / 255;
-          const greenness = this.analyserBuffer[i] + 100 > 255 ? 255 : this.analyserBuffer[i] + 100;
-          canvasCtx.fillStyle = `rgb(50,${greenness},50)`;
+          if (this.analyserBuffer[i] < 32) {
+            // minimum bar height reduces some flickering
+            barHeight = HEIGHT * 0.126; // 32 / 255
+          } else {
+            barHeight = (this.analyserBuffer[i] * HEIGHT) / 255;
+          }
+
+          // bootstrap blue is rgb(0, 123, 255)
+          const redness = this.analyserBuffer[i] - 60 < 0 ?
+            0 :
+            this.analyserBuffer[i] / 2;
+          const greenness = this.analyserBuffer[i] - 60 < 0 ?
+            123 :
+            123 + (this.analyserBuffer[i] - 123) / 2;
+          canvasCtx.fillStyle = `rgb(${redness},${greenness},255)`;
           canvasCtx.fillRect(x, HEIGHT - barHeight, barWidth, barHeight);
           x += barWidth + 1;
         }

--- a/imports/lib/models/call_participants.ts
+++ b/imports/lib/models/call_participants.ts
@@ -1,0 +1,16 @@
+import { Roles } from 'meteor/nicolaslopezj:roles';
+import { huntsMatchingCurrentUser } from '../../model-helpers';
+import CallParticipantsSchema, { CallParticipantType } from '../schemas/call_participants';
+import Base from './base';
+
+const CallParticipants = new Base<CallParticipantType>('call_participants');
+CallParticipants.attachSchema(CallParticipantsSchema);
+CallParticipants.publish(huntsMatchingCurrentUser);
+
+// TODO: these ACLs need work
+// Users can hang up calls they are a part of
+Roles.loggedInRole.allow('mongo.call_participants.remove', (uid, doc) => {
+  return doc.createdBy === uid;
+});
+
+export default CallParticipants;

--- a/imports/lib/models/call_signals.ts
+++ b/imports/lib/models/call_signals.ts
@@ -1,0 +1,8 @@
+import CallSignalsSchema, { CallSignalType } from '../schemas/call_signals';
+import Base from './base';
+
+const CallSignals = new Base<CallSignalType>('call_signals');
+CallSignals.attachSchema(CallSignalsSchema);
+// No publish -- we have custom publication methods in imports/server/calls.ts
+
+export default CallSignals;

--- a/imports/lib/models/facade.ts
+++ b/imports/lib/models/facade.ts
@@ -1,4 +1,6 @@
 import Announcements from './announcements';
+import CallParticipants from './call_participants';
+import CallSignals from './call_signals';
 import ChatMessages from './chats';
 import DocumentPermissions from './document_permissions';
 import Documents from './documents';
@@ -14,6 +16,8 @@ import Tags from './tags';
 
 const Models = {
   Announcements,
+  CallParticipants,
+  CallSignals,
   ChatMessages,
   DocumentPermissions,
   Documents,

--- a/imports/lib/roles.ts
+++ b/imports/lib/roles.ts
@@ -6,6 +6,7 @@ Roles.registerAction('hunt.join', true);
 Roles.registerAction('discord.configureOAuth', true);
 Roles.registerAction('discord.configureBot', true);
 Roles.registerAction('users.makeOperator', true);
+Roles.registerAction('webrtc.configureServers', true);
 
 const InactiveOperatorRole = new Roles.Role('inactiveOperator');
 InactiveOperatorRole.allow('users.makeOperator', () => true);

--- a/imports/lib/schemas/call_participants.ts
+++ b/imports/lib/schemas/call_participants.ts
@@ -1,0 +1,36 @@
+import * as t from 'io-ts';
+import SimpleSchema from 'simpl-schema';
+import { BaseCodec, BaseOverrides } from './base';
+import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
+
+const CallParticipantFields = t.type({
+  hunt: t.string, // used for ACL subscriptions
+  call: t.string, // consider renaming to puzzle?
+
+  // Need a tab ID here too so that different browser tabs won't
+  // try to autoconnect
+  tab: t.string,
+});
+
+const CallParticipantFieldsOverrides: Overrides<t.TypeOf<typeof CallParticipantFields>> = {
+  hunt: {
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  call: {
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  tab: {
+    regEx: SimpleSchema.RegEx.Id,
+  },
+};
+
+const [CallParticipantCodec, CallParticipantOverrides] = inheritSchema(
+  BaseCodec, CallParticipantFields,
+  BaseOverrides, CallParticipantFieldsOverrides,
+);
+export { CallParticipantCodec };
+export type CallParticipantType = t.TypeOf<typeof CallParticipantCodec>;
+
+const CallParticipants = buildSchema(CallParticipantCodec, CallParticipantOverrides);
+
+export default CallParticipants;

--- a/imports/lib/schemas/call_participants.ts
+++ b/imports/lib/schemas/call_participants.ts
@@ -10,6 +10,9 @@ const CallParticipantFields = t.type({
   // Need a tab ID here too so that different browser tabs won't
   // try to autoconnect
   tab: t.string,
+
+  muted: t.boolean,
+  deafened: t.boolean,
 });
 
 const CallParticipantFieldsOverrides: Overrides<t.TypeOf<typeof CallParticipantFields>> = {

--- a/imports/lib/schemas/call_participants.ts
+++ b/imports/lib/schemas/call_participants.ts
@@ -4,6 +4,7 @@ import { BaseCodec, BaseOverrides } from './base';
 import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
 
 const CallParticipantFields = t.type({
+  server: t.string,
   hunt: t.string, // used for ACL subscriptions
   call: t.string, // consider renaming to puzzle?
 
@@ -16,6 +17,9 @@ const CallParticipantFields = t.type({
 });
 
 const CallParticipantFieldsOverrides: Overrides<t.TypeOf<typeof CallParticipantFields>> = {
+  server: {
+    regEx: SimpleSchema.RegEx.Id,
+  },
   hunt: {
     regEx: SimpleSchema.RegEx.Id,
   },

--- a/imports/lib/schemas/call_signals.ts
+++ b/imports/lib/schemas/call_signals.ts
@@ -1,0 +1,40 @@
+import * as t from 'io-ts';
+import SimpleSchema from 'simpl-schema';
+import { BaseCodec, BaseOverrides } from './base';
+import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
+
+const CallSignalMessageFields = t.type({
+  type: t.union([t.literal('sdp'), t.literal('iceCandidate')]),
+  content: t.string,
+});
+
+export type CallSignalMessageType = t.TypeOf<typeof CallSignalMessageFields>;
+
+// TODO: create indexes on both initiator and responder
+const CallSignalFields = t.type({
+  sender: t.string, // CallParticipant ID
+  target: t.string, // CallParticipant ID
+
+  messages: t.array(CallSignalMessageFields),
+});
+
+const CallSignalFieldsOverrides: Overrides<t.TypeOf<typeof CallSignalFields>> = {
+  sender: {
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  target: {
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  // SDP and candidate strings we treat as opaque.
+};
+
+const [CallSignalCodec, CallSignalOverrides] = inheritSchema(
+  BaseCodec, CallSignalFields,
+  BaseOverrides, CallSignalFieldsOverrides,
+);
+export { CallSignalCodec };
+export type CallSignalType = t.TypeOf<typeof CallSignalCodec>;
+
+const CallSignals = buildSchema(CallSignalCodec, CallSignalOverrides);
+
+export default CallSignals;

--- a/imports/server/calls.ts
+++ b/imports/server/calls.ts
@@ -1,0 +1,175 @@
+import { check } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+import CallParticipants from '../lib/models/call_participants';
+import CallSignals from '../lib/models/call_signals';
+import { serverId, registerPeriodicCleanupHook } from './garbage-collection';
+
+// Swap this to true if debugging participant/signal GC
+const debug = false;
+
+function cleanupHook(deadServers: string[]) {
+  // Remove CallParticipants from dead server backends.
+  CallParticipants.remove({ server: { $in: deadServers } });
+
+  // Remove old CallSignals that reference a participant ID no longer found in CallParticipants
+  const liveParticipants = CallParticipants.find({}).map((doc) => doc._id);
+  const deadSignals = CallSignals.remove({
+    $or: [
+      { sender: { $nin: liveParticipants } },
+      { target: { $nin: liveParticipants } },
+    ],
+  });
+
+  if (debug) {
+    // eslint-disable-next-line no-console
+    console.log(`Removed ${deadSignals} dead signals`);
+  }
+}
+registerPeriodicCleanupHook(cleanupHook);
+
+Meteor.methods({
+  signalPeer(selfParticipantId: unknown, peerParticipantId: unknown, args: unknown) {
+    check(this.userId, String);
+    check(selfParticipantId, String);
+    check(peerParticipantId, String);
+    check(args, {
+      type: String,
+      content: String,
+    });
+
+    const selfParticipant = CallParticipants.findOne(selfParticipantId);
+    if (!selfParticipant) {
+      throw new Meteor.Error(404, `CallParticipant ${selfParticipantId} not found`);
+    }
+
+    if (selfParticipant.createdBy !== this.userId) {
+      throw new Meteor.Error(401, `CallParticipant ${selfParticipantId} not created by ${this.userId}`);
+    }
+
+    const peerParticipant = CallParticipants.findOne(peerParticipantId);
+    if (!peerParticipant) {
+      throw new Meteor.Error(404, `CallParticipant ${peerParticipantId} not found`);
+    }
+
+    if (args.type === 'sdp') {
+      CallSignals.upsert({
+        sender: selfParticipantId,
+        target: peerParticipantId,
+      }, {
+        $push: { messages: { type: 'sdp', content: args.content } },
+      });
+    } else if (args.type === 'iceCandidate') {
+      CallSignals.upsert({
+        sender: selfParticipantId,
+        target: peerParticipantId,
+      }, {
+        $push: { messages: { type: 'iceCandidate', content: args.content } },
+      });
+    } else {
+      throw new Meteor.Error(400, `Expected args.type to be either 'sdp' or 'iceCandidate' but got '${args.type}'`);
+    }
+  },
+});
+
+Meteor.publish('call.metadata', function (hunt, call) {
+  check(hunt, String);
+  check(call, String);
+
+  if (!this.userId) {
+    throw new Meteor.Error(401, 'Not logged in');
+  }
+
+  return CallParticipants.find({
+    hunt,
+    call,
+  });
+});
+
+function cleanupCallSub(participantId: string) {
+  // Remove the participant
+  CallParticipants.remove(participantId);
+  // Also remove any signalling documents they created.
+  CallSignals.remove({
+    $or: [
+      { sender: participantId },
+      { target: participantId },
+    ],
+  });
+}
+
+Meteor.publish('call.join', function (hunt, call, tab) {
+  // This could notionally be a call, but making it a subscription means that
+  // as soon as the user navigates away from the page or closes the window
+  // we'll know to run the onStop(), which is good for faster propagation of
+  // users leaving calls.
+  check(hunt, String);
+  check(call, String);
+  check(tab, String);
+
+  if (!this.userId) {
+    throw new Meteor.Error(401, 'Not logged in');
+  }
+
+  // Check if we see evidence that this user has joined this call from the same
+  // tab already.
+  //
+  // This shouldn't happen most of the time, but can happen if the server
+  // crashes or the client gets disconnected and reconnects (possibly to a
+  // different server) before the server that served the client's previous
+  // session notices.
+  //
+  // In the event we see such a record in the DB, we can safely remove it.
+  // Since the tabId alone should not get reissued by different clients, we can
+  // be sure that the client no longer trusts that the previous `call.join` is active,
+  // and we can just take this as a signal to hasten that cleanup.
+  const maybeOldDoc = CallParticipants.findOne({
+    hunt,
+    call,
+    tab,
+    createdBy: this.userId,
+  });
+  if (maybeOldDoc) {
+    cleanupCallSub(maybeOldDoc._id);
+  }
+
+  // TODO: determine call participant ID deterministically for the
+  // (this.userId, hunt, call, tab) tuple, so that server disconnections
+  // allow for recovery on reconnect?  I'm not sure that's actually safe
+  // without updating serverId and checking that serverId matches when
+  // removing, so maybe don't actually bother trying to make this
+  // deterministic.
+  const callParticipant = {
+    server: serverId,
+    hunt,
+    call,
+    tab,
+  };
+  const doc = CallParticipants.insert(callParticipant);
+  this.onStop(() => {
+    cleanupCallSub(doc);
+  });
+
+  // Ensure this doc gets to the client before we mark this sub as ready
+  return CallParticipants.find({ _id: doc });
+});
+
+Meteor.publish('call.signal', function (callerParticipantId) {
+  check(callerParticipantId, String);
+
+  if (!this.userId) {
+    throw new Meteor.Error(401, 'Not logged in');
+  }
+
+  const callerParticipant = CallParticipants.findOne(callerParticipantId);
+  if (!callerParticipant) {
+    throw new Meteor.Error(401, `CallParticipant ${callerParticipantId} not found`);
+  }
+
+  // Only allow the creator of the CallParticipant to subscribe to signaling
+  // for that peer.
+  if (callerParticipant.createdBy !== this.userId) {
+    throw new Meteor.Error(401, `CallParticipant ${callerParticipantId} not created by ${this.userId}`);
+  }
+
+  return CallSignals.find({ target: callerParticipantId });
+});

--- a/imports/server/calls.ts
+++ b/imports/server/calls.ts
@@ -69,6 +69,52 @@ Meteor.methods({
       throw new Meteor.Error(400, `Expected args.type to be either 'sdp' or 'iceCandidate' but got '${args.type}'`);
     }
   },
+
+  setMuted(selfParticipantId: unknown, muted: unknown) {
+    check(this.userId, String);
+    check(selfParticipantId, String);
+    check(muted, Boolean);
+
+    const selfParticipant = CallParticipants.findOne(selfParticipantId);
+    if (!selfParticipant) {
+      throw new Meteor.Error(404, `CallParticipant ${selfParticipantId} not found`);
+    }
+
+    if (selfParticipant.createdBy !== this.userId) {
+      throw new Meteor.Error(401, `CallParticipant ${selfParticipantId} not created by ${this.userId}`);
+    }
+
+    CallParticipants.update({
+      _id: selfParticipantId,
+    }, {
+      $set: {
+        muted,
+      },
+    });
+  },
+
+  setDeafened(selfParticipantId: unknown, deafened: unknown) {
+    check(this.userId, String);
+    check(selfParticipantId, String);
+    check(deafened, Boolean);
+
+    const selfParticipant = CallParticipants.findOne(selfParticipantId);
+    if (!selfParticipant) {
+      throw new Meteor.Error(404, `CallParticipant ${selfParticipantId} not found`);
+    }
+
+    if (selfParticipant.createdBy !== this.userId) {
+      throw new Meteor.Error(401, `CallParticipant ${selfParticipantId} not created by ${this.userId}`);
+    }
+
+    CallParticipants.update({
+      _id: selfParticipantId,
+    }, {
+      $set: {
+        deafened,
+      },
+    });
+  },
 });
 
 Meteor.publish('call.metadata', function (hunt, call) {
@@ -143,6 +189,8 @@ Meteor.publish('call.join', function (hunt, call, tab) {
     hunt,
     call,
     tab,
+    muted: false,
+    deafened: false,
   };
   const doc = CallParticipants.insert(callParticipant);
   this.onStop(() => {

--- a/imports/server/setup.ts
+++ b/imports/server/setup.ts
@@ -6,6 +6,7 @@ import { Roles } from 'meteor/nicolaslopezj:roles';
 import { ServiceConfiguration } from 'meteor/service-configuration';
 import Ansible from '../ansible';
 import { API_BASE } from '../lib/discord';
+import PublicSettings from '../lib/models/public_settings';
 import Settings from '../lib/models/settings';
 import { DiscordBot } from './discord';
 
@@ -161,6 +162,15 @@ Meteor.methods({
     } else {
       Settings.remove({ name: 'discord.guild' });
     }
+  },
+
+  setupTurnServerUrls(urls: unknown) {
+    check(this.userId, String);
+    Roles.checkPermission(this.userId, 'webrtc.configureServers');
+    check(urls, [String]);
+
+    PublicSettings.upsert({ name: 'webrtc.turnserver' },
+      { $set: { 'value.urls': urls } });
   },
 });
 

--- a/server/main.ts
+++ b/server/main.ts
@@ -13,6 +13,7 @@ import '../imports/server/announcements';
 import '../imports/server/ansible';
 import '../imports/server/api-init';
 import '../imports/server/api_keys';
+import '../imports/server/calls';
 import '../imports/server/chat';
 import '../imports/server/discord';
 import '../imports/server/feature_flags';


### PR DESCRIPTION
This change adds a WebRTC audio call to each puzzle.

Karen (@aldeka) provided mocks for the UI and then I went and yolo modified them; all credit for things looking good goes to her and all blame for anything that is ugly/broken goes to me. :)

There's several things I still want to do before submitting this, some of which may not be noted inline:

- [x] Fix server-side garbage collection of CallSignals and CallParticipants.
- [x] Add visualization of call state.
- [x] Give more details about the callee on hover
- [x] Mute/deafen state should get set to false when joining a call
- [x] Use webrtc config editable from /setup rather than hardcoding turn.zarvox.org
- [x] Fix echo cancellation.  I think using WebAudio on the inbound stream from the RTCPeerConnection may be messing with at least Chrome's echo cancellation, which is obnoxious.  I should just use a `muted` prop on the `<audio>` element probably.
- [x] Publish your local muted/deafened state, so that other call participants can know that you're muted/deafened.
- [x] Get better icons for mute/deafened state in the UI (right now they're awful red bars)

I still want to finish the following, but I think I'd probably be happy to punt them to followup PRs:
- [x] Add per-audio-source spectograms (or at least something to help you figure out who's mic is blaring at max volume)
- [ ] Add the ability to prefer a particular audio device
