### PR TITLE
Add mode without guess queue

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -352,8 +352,12 @@ table.puzzle-list {
   justify-content: space-between;
 }
 
-.puzzle-metadata-title {
-  font-weight: bold;
+.puzzle-metadata-title-set {
+  flex: 0 0 auto;
+
+  .puzzle-metadata-title {
+    font-weight: bold;
+  }
 }
 
 .puzzle-metadata .view-count {
@@ -361,16 +365,30 @@ table.puzzle-list {
   white-space: nowrap;
 }
 
-.puzzle-metadata-answer {
+.puzzle-metadata-answers {
+  flex: 1 1 auto;
   display: flex;
+  justify-content: flex-end;
   align-items: center;
-  line-height: 24px;
-  margin: 2px 0;
-  padding: 0 6px;
-  border-radius: 4px;
-  background-color: #00ff00;
-  color: #000000;
-  word-break: break-all;
+  flex-wrap: wrap;
+
+  .answer {
+    line-height: 24px;
+    height: 28px;
+    margin-left: 2px;
+    padding: 0 6px;
+    border-radius: 4px;
+    background-color: #00ff00;
+    color: #000000;
+    display: flex;
+
+    .answer-remove-button {
+      color: default;
+      margin: 0 -6px 0 2px;
+      padding: 0 8px 0 0;
+      height: 28px;
+    }
+  }
 }
 
 .puzzle-metadata .tag-list {

--- a/imports/client/components/HuntListPage.tsx
+++ b/imports/client/components/HuntListPage.tsx
@@ -39,6 +39,7 @@ export interface HuntModalSubmit {
   mailingLists: string[];
   signupMessage: string;
   openSignups: boolean;
+  hasGuessQueue: boolean;
   submitTemplate: string;
 }
 
@@ -79,6 +80,7 @@ class HuntModalForm extends React.Component<HuntModalFormProps, HuntModalFormSta
         mailingLists: this.props.hunt.mailingLists.join(', ') || '',
         signupMessage: this.props.hunt.signupMessage || '',
         openSignups: this.props.hunt.openSignups || false,
+        hasGuessQueue: !!this.props.hunt.hasGuessQueue,
         submitTemplate: this.props.hunt.submitTemplate || '',
       });
     } else {
@@ -87,6 +89,7 @@ class HuntModalForm extends React.Component<HuntModalFormProps, HuntModalFormSta
         mailingLists: '',
         signupMessage: '',
         openSignups: false,
+        hasGuessQueue: true,
         submitTemplate: '',
       });
     }
@@ -115,6 +118,12 @@ class HuntModalForm extends React.Component<HuntModalFormProps, HuntModalFormSta
       openSignups: e.currentTarget.checked,
     });
   };
+
+  onHasGuessQueueChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    this.setState({
+      hasGuessQueue: e.currentTarget.checked,
+    });
+  }
 
   onSubmitTemplateChanged: FormControlProps['onChange'] = (e) => {
     this.setState({
@@ -223,6 +232,23 @@ class HuntModalForm extends React.Component<HuntModalFormProps, HuntModalFormSta
             />
             <FormText>
               If open invites are enabled, then any current member of the hunt can add a new member to the hunt. Otherwise, only operators can add new members.
+            </FormText>
+          </Col>
+        </FormGroup>
+
+        <FormGroup as={Row}>
+          <FormLabel column xs={3} htmlFor={`${idPrefix}has-guess-queue`}>
+            Guess queue
+          </FormLabel>
+          <Col xs={9}>
+            <FormCheck
+              id={`${idPrefix}has-guess-queue`}
+              checked={this.state.hasGuessQueue}
+              onChange={this.onHasGuessQueueChanged}
+              disabled={disableForm}
+            />
+            <FormText>
+              If enabled, users can submit guesses for puzzles but operators must mark them as correct. If disabled, any user can enter the puzzle answer.
             </FormText>
           </Col>
         </FormGroup>

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -1100,7 +1100,6 @@ class PuzzleAnswerModal extends React.Component<PuzzleAnswerModalProps, PuzzleAn
           });
           console.log('ERROR:', error);
         } else {
-          // Clear the input box.  Don't dismiss the dialog.
           this.setState({
             answer: '',
             submitState: PuzzleAnswerSubmitState.IDLE,
@@ -1117,7 +1116,6 @@ class PuzzleAnswerModal extends React.Component<PuzzleAnswerModalProps, PuzzleAn
         title={`Submit answer to ${this.props.puzzle.title}`}
         onSubmit={this.onSubmit}
         submitLabel={this.state.submitState === PuzzleAnswerSubmitState.SUBMITTING ? 'Confirm Submit' : 'Submit'}
-        // disabled={submitState === PuzzleAnswerSubmitState.SUBMITTING}
       >
         <FormGroup as={Row}>
           <FormLabel column xs={3} htmlFor="jr-puzzle-answer">

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -820,7 +820,7 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
 const PuzzlePageMetadataContainer = withTracker(({ puzzle }: PuzzlePageMetadataParams) => {
   const count = SubscriberCounters.findOne(`puzzle:${puzzle._id}`);
   const hunt = Hunts.findOne(puzzle.hunt);
-  const hasGuessQueue = hunt && hunt.hasGuessQueue;
+  const hasGuessQueue = !!(hunt && hunt.hasGuessQueue);
   return {
     viewCount: count ? count.value : 0,
     canUpdate: Roles.userHasPermission(Meteor.userId(), 'mongo.puzzles.update'),

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -717,7 +717,9 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
           this.props.puzzle.answers.map((answer) => (
             <span className="answer">
               <span>{answer}</span>
-              <Button className="answer-remove-button" variant="success" onClick={() => this.onRemoveAnswer(answer)}>&#10006;</Button>
+              {!this.props.hasGuessQueue && (
+                <Button className="answer-remove-button" variant="success" onClick={() => this.onRemoveAnswer(answer)}>&#10006;</Button>
+              )}
             </span>
           ))
         }

--- a/imports/lib/schemas/hunts.ts
+++ b/imports/lib/schemas/hunts.ts
@@ -12,6 +12,9 @@ const HuntFields = t.type({
   // If this is true, then any member of this hunt is allowed to add others to
   // it. Otherwise, you must be an operator to add someone to the hunt.
   openSignups: t.boolean,
+  // If this is true, an operator must mark guesses as correct or not.
+  // If this is false, users enter answers directly without the guess step.
+  guessQueue: t.boolean,
   // If this is provided, then this is used to generate links to puzzles' guess
   // submission pages. The format is interpreted as a Mustache template
   // (https://mustache.github.io/). It's passed as context a parsed URL

--- a/imports/lib/schemas/hunts.ts
+++ b/imports/lib/schemas/hunts.ts
@@ -14,7 +14,7 @@ const HuntFields = t.type({
   openSignups: t.boolean,
   // If this is true, an operator must mark guesses as correct or not.
   // If this is false, users enter answers directly without the guess step.
-  guessQueue: t.boolean,
+  hasGuessQueue: t.boolean,
   // If this is provided, then this is used to generate links to puzzles' guess
   // submission pages. The format is interpreted as a Mustache template
   // (https://mustache.github.io/). It's passed as context a parsed URL

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -130,19 +130,12 @@ Meteor.methods({
       guess: answer,
       state: 'correct',
     });
+
     const savedAnswer = Guesses.findOne(answerId);
     if (!savedAnswer) {
       throw new Meteor.Error(404, 'No such correct guess');
     }
-    Guesses.update({
-      _id: savedAnswer._id,
-    }, {
-      $set: {
-        state: 'correct',
-      },
-    });
     addChatMessage(savedAnswer, 'correct');
-
     Puzzles.update({
       _id: savedAnswer.puzzle,
     }, {
@@ -158,23 +151,21 @@ Meteor.methods({
     check(puzzleId, String);
     check(answer, String);
 
-    const hunt = Puzzles.findOne({
+    const puzzle = Puzzles.findOne({
       _id: puzzleId,
     }, {
       fields: {
         hunt: 1,
       },
     });
-    const huntId = hunt && hunt.hunt;
-    const fullHuntObject = Hunts.findOne({ _id: huntId });
-    if (!huntId || !fullHuntObject || fullHuntObject.hasGuessQueue) {
+    const huntId = puzzle && puzzle.hunt;
+    const hunt = Hunts.findOne({ _id: huntId });
+    if (!huntId || !hunt || hunt.hasGuessQueue) {
       throw new Error(`Hunt ${huntId} does not support self-service answers`);
     }
 
     const guess = Guesses.findOne({ puzzle: puzzleId, guess: answer });
-
     if (!guess) return;
-
     transitionGuess(guess, 'incorrect');
   },
 

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -146,10 +146,10 @@ Meteor.methods({
     GlobalHooks.runPuzzleSolvedHooks(savedAnswer.puzzle);
   },
 
-  removeAnswerFromPuzzle(puzzleId: unknown, answer: unknown) {
+  removeAnswerFromPuzzle(puzzleId: unknown, guessId: unknown) {
     check(this.userId, String);
     check(puzzleId, String);
-    check(answer, String);
+    check(guessId, String);
 
     const puzzle = Puzzles.findOne({
       _id: puzzleId,
@@ -164,7 +164,7 @@ Meteor.methods({
       throw new Error(`Hunt ${huntId} does not support self-service answers`);
     }
 
-    const guess = Guesses.findOne({ puzzle: puzzleId, guess: answer });
+    const guess = Guesses.findOne({ puzzle: puzzleId, _id: guessId });
     if (!guess) return;
     transitionGuess(guess, 'incorrect');
   },

--- a/imports/server/migrations/27-hunt-has-guess-queue.ts
+++ b/imports/server/migrations/27-hunt-has-guess-queue.ts
@@ -2,10 +2,10 @@ import { Migrations } from 'meteor/percolate:migrations';
 import Hunts from '../../lib/models/hunts';
 
 Migrations.add({
-  version: 28,
+  version: 27,
   name: 'Add hasGuessQueue to Hunt model for whether to have a guess queue or direct answers',
   up() {
-    Hunts.find(<any>{}).forEach((hunt) => {
+    Hunts.find({}).forEach((hunt) => {
       Hunts.update(hunt._id, {
         $set: { hasGuessQueue: true },
       }, <any>{

--- a/imports/server/migrations/28-hunt-has-guess-queue.ts
+++ b/imports/server/migrations/28-hunt-has-guess-queue.ts
@@ -1,0 +1,16 @@
+import { Migrations } from 'meteor/percolate:migrations';
+import Hunts from '../../lib/models/hunts';
+
+Migrations.add({
+  version: 28,
+  name: 'Add hasGuessQueue to Hunt model for whether to have a guess queue or direct answers',
+  up() {
+    Hunts.find(<any>{}).forEach((hunt) => {
+      Hunts.update(hunt._id, {
+        $set: { hasGuessQueue: true },
+      }, <any>{
+        validate: false,
+      });
+    });
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -25,3 +25,4 @@ import './23-serviceconfigurations-remove-slack';
 import './24-hunts-remove-slack-fields';
 import './25-remove-slack-featureflag';
 import './26-remove-subcounter-feature-flags';
+import './27-hunt-has-guess-queue';


### PR DESCRIPTION
This adds a hasGuessQueue attribute to the Hunt model. Said attribute is on by default, so the user guess -> operator approval flow will still be the case for instances unless this is explicitly set by the operator.

When hasGuessQueue is false, users can able to submit answers directly, without the guess UI or operator approval. In that mode, additionally, users can remove answer(s) from the list on the puzzle page (if, e.g. they made a typo the first time).