### PR TITLE
Add hunt homepage link to landing pages

### DIFF
--- a/client/stylesheets/puzzlelist.scss
+++ b/client/stylesheets/puzzlelist.scss
@@ -1,3 +1,6 @@
+@import "../../node_modules/bootstrap/scss/functions";
+@import "../../node_modules/bootstrap/scss/variables";
+
 @media (max-width: 767px) {
   .puzzle-view-controls>* {
     width: 100%;
@@ -43,17 +46,17 @@
   width: 100%;
   margin: 0 0 8px 0;
   padding: 0;
-  border-color: #ccc;
+  border-color: #cfcfcf;
   border-style: solid;
   border-width: 1px 0;
   li {
     display: flex;
     align-items: stretch;
     flex: 1 1 0;
-    min-width: 120px;
     a {
       flex: 1 1 0;
       display: flex;
+      height: 38px;
       align-items: center;
       align-content: center;
       justify-content: center;
@@ -65,11 +68,28 @@
         background-color: #f8f8f8;
       }
     }
+    .puzzle-list-link-label {
+      margin-left: 4px;
+    }
+
+    &.puzzle-list-link-external {
+      flex: 0 0 40px;
+      a {
+        background-color: $primary;
+        color: white;
+        &:hover {
+          background-color: darken($primary, 7.5%);
+        }
+      }
+      .puzzle-list-link-label {
+        display: none;
+      }
+    }
   }
 }
 
-@media (max-width: 389px) {
-  .puzzle-list-links li {
-    min-width: 100%;
+@media (max-width: 506px) {
+  .puzzle-list-link-label {
+    display: none;
   }
 }

--- a/imports/client/components/HuntListPage.tsx
+++ b/imports/client/components/HuntListPage.tsx
@@ -40,6 +40,7 @@ export interface HuntModalSubmit {
   signupMessage: string;
   openSignups: boolean;
   hasGuessQueue: boolean;
+  homepageUrl: string;
   submitTemplate: string;
 }
 
@@ -81,6 +82,7 @@ class HuntModalForm extends React.Component<HuntModalFormProps, HuntModalFormSta
         signupMessage: this.props.hunt.signupMessage || '',
         openSignups: this.props.hunt.openSignups || false,
         hasGuessQueue: !!this.props.hunt.hasGuessQueue,
+        homepageUrl: this.props.hunt.homepageUrl || '',
         submitTemplate: this.props.hunt.submitTemplate || '',
       });
     } else {
@@ -90,6 +92,7 @@ class HuntModalForm extends React.Component<HuntModalFormProps, HuntModalFormSta
         signupMessage: '',
         openSignups: false,
         hasGuessQueue: true,
+        homepageUrl: '',
         submitTemplate: '',
       });
     }
@@ -123,13 +126,19 @@ class HuntModalForm extends React.Component<HuntModalFormProps, HuntModalFormSta
     this.setState({
       hasGuessQueue: e.currentTarget.checked,
     });
-  }
+  };
+
+  onHomepageUrlChanged: FormControlProps['onChange'] = (e) => {
+    this.setState({
+      homepageUrl: e.currentTarget.value,
+    });
+  };
 
   onSubmitTemplateChanged: FormControlProps['onChange'] = (e) => {
     this.setState({
       submitTemplate: e.currentTarget.value,
     });
-  }
+  };
 
   onFormSubmit = (callback: () => void) => {
     this.setState({ submitState: HuntModalFormSubmitState.SUBMITTING });
@@ -249,6 +258,24 @@ class HuntModalForm extends React.Component<HuntModalFormProps, HuntModalFormSta
             />
             <FormText>
               If enabled, users can submit guesses for puzzles but operators must mark them as correct. If disabled, any user can enter the puzzle answer.
+            </FormText>
+          </Col>
+        </FormGroup>
+
+        <FormGroup as={Row}>
+          <FormLabel column xs={3} htmlFor={`${idPrefix}homepage-url`}>
+            Homepage URL
+          </FormLabel>
+          <Col xs={9}>
+            <FormControl
+              id={`${idPrefix}homepage-url`}
+              type="text"
+              value={this.state.homepageUrl}
+              onChange={this.onHomepageUrlChanged}
+              disabled={disableForm}
+            />
+            <FormText>
+              If provided, a link to the hunt homepage will be placed on the landing page.
             </FormText>
           </Col>
         </FormGroup>

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -419,12 +419,12 @@ interface PuzzleListPageProps extends PuzzleListPageWithRouterParams {
   canUpdate: boolean;
   allPuzzles: PuzzleType[];
   allTags: TagType[];
-  hunt?: HuntType;
+  hunt: HuntType;
 }
 
 class PuzzleListPage extends React.Component<PuzzleListPageProps> {
   render() {
-    const leadLinks = this.props.hunt?.homepageUrl && (
+    const leadLinks = this.props.hunt.homepageUrl && (
       <p className="lead">
         <a href={this.props.hunt.homepageUrl} target="_blank" rel="noopener noreferrer" title="Open the hunt homepage">
           <FontAwesomeIcon icon={faExternalLinkAlt} />
@@ -469,14 +469,15 @@ const PuzzleListPageContainer = withTracker(({ match }: PuzzleListPageWithRouter
   Meteor.subscribe('subscribers.counts', { hunt: match.params.huntId });
 
   const ready = puzzlesHandle.ready() && tagsHandle.ready();
-  const hunt = Hunts.findOne({ _id: match.params.huntId });
+  // Assertion is safe because hunt is already subscribed and checked by HuntApp
+  const hunt = Hunts.findOne({ _id: match.params.huntId })!;
   return {
     ready,
     canAdd: ready && Roles.userHasPermission(Meteor.userId(), 'mongo.puzzles.insert'),
     canUpdate: ready && Roles.userHasPermission(Meteor.userId(), 'mongo.puzzles.update'),
     allPuzzles: ready ? Puzzles.find({ hunt: match.params.huntId }).fetch() : [],
     allTags: ready ? Tags.find({ hunt: match.params.huntId }).fetch() : [],
-    ...(hunt ? { hunt } : { }),
+    hunt,
   };
 })(PuzzleListPage);
 

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -2,7 +2,12 @@ import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { withTracker } from 'meteor/react-meteor-data';
 import { _ } from 'meteor/underscore';
-import { faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons';
+import {
+  faBullhorn,
+  faMap,
+  faReceipt,
+  faUsers,
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import Button from 'react-bootstrap/Button';
@@ -424,14 +429,13 @@ interface PuzzleListPageProps extends PuzzleListPageWithRouterParams {
 
 class PuzzleListPage extends React.Component<PuzzleListPageProps> {
   render() {
-    const leadLinks = this.props.hunt.homepageUrl && (
-      <p className="lead">
+    const huntLink = this.props.hunt.homepageUrl && (
+      <li className="puzzle-list-link-external">
         <a href={this.props.hunt.homepageUrl} target="_blank" rel="noopener noreferrer" title="Open the hunt homepage">
-          <FontAwesomeIcon icon={faExternalLinkAlt} />
-          {' '}
-          Hunt homepage
+          <FontAwesomeIcon icon={faMap} />
+          <span className="puzzle-list-link-label">Hunt homepage</span>
         </a>
-      </p>
+      </li>
     );
     const puzzleList = this.props.ready ? (
       <PuzzleListView
@@ -449,11 +453,26 @@ class PuzzleListPage extends React.Component<PuzzleListPageProps> {
     );
     return (
       <div>
-        {leadLinks}
         <ul className="puzzle-list-links">
-          <li><Link to={`/hunts/${this.props.match.params.huntId}/announcements`}>Announcements</Link></li>
-          <li><Link to={`/hunts/${this.props.match.params.huntId}/guesses`}>Guess queue</Link></li>
-          <li><Link to={`/hunts/${this.props.match.params.huntId}/hunters`}>Hunters</Link></li>
+          {huntLink}
+          <li>
+            <Link to={`/hunts/${this.props.match.params.huntId}/announcements`}>
+              <FontAwesomeIcon icon={faBullhorn} />
+              <span className="puzzle-list-link-label">Announcements</span>
+            </Link>
+          </li>
+          <li>
+            <Link to={`/hunts/${this.props.match.params.huntId}/guesses`}>
+              <FontAwesomeIcon icon={faReceipt} />
+              <span className="puzzle-list-link-label">Guess queue</span>
+            </Link>
+          </li>
+          <li>
+            <Link to={`/hunts/${this.props.match.params.huntId}/hunters`}>
+              <FontAwesomeIcon icon={faUsers} />
+              <span className="puzzle-list-link-label">Hunters</span>
+            </Link>
+          </li>
         </ul>
         {puzzleList}
       </div>

--- a/imports/lib/schemas/hunts.ts
+++ b/imports/lib/schemas/hunts.ts
@@ -1,4 +1,5 @@
 import * as t from 'io-ts';
+import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from './base';
 import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
 
@@ -21,6 +22,7 @@ const HuntFields = t.type({
   // (https://nodejs.org/api/url.html#url_class_url), which provides variables
   // like "host" and "pathname".
   submitTemplate: t.union([t.string, t.undefined]),
+  homepageUrl: t.union([t.string, t.undefined]),
 });
 
 const HuntFieldsOverrides: Overrides<t.TypeOf<typeof HuntFields>> = {
@@ -29,6 +31,9 @@ const HuntFieldsOverrides: Overrides<t.TypeOf<typeof HuntFields>> = {
   },
   openSignups: {
     defaultValue: false,
+  },
+  homepageUrl: {
+    regEx: SimpleSchema.RegEx.Url,
   },
 };
 


### PR DESCRIPTION
Add an optional field to Hunts to store hunt homepage urls, rendered as a link on the puzzle list page. Also, no longer wait for puzzle and tag data to render the hunt navigation links. General cleanup of PuzzleListPage, including removal of redundant and unreferenced markup.

No migration added, as it appears we aren't creating migrations for the creation of optional fields. Please correct me if I'm wrong.

Closes #292 