### PR TITLE
Add `PublicSettings` for server-specific settings that should be public

### DIFF
--- a/imports/lib/models/facade.ts
+++ b/imports/lib/models/facade.ts
@@ -7,6 +7,7 @@ import Guesses from './guess';
 import Hunts from './hunts';
 import PendingAnnouncements from './pending_announcements';
 import Profiles from './profiles';
+import PublicSettings from './public_settings';
 import Puzzles from './puzzles';
 import Settings from './settings';
 import Tags from './tags';
@@ -21,6 +22,7 @@ const Models = {
   Hunts,
   PendingAnnouncements,
   Profiles,
+  PublicSettings,
   Puzzles,
   Settings,
   Tags,

--- a/imports/lib/models/public_settings.ts
+++ b/imports/lib/models/public_settings.ts
@@ -7,7 +7,7 @@ PublicSettings.attachSchema(PublicSettingsSchema);
 
 // All public settings are accessible by all clients at all times, including to
 // not-logged-in-users.
-PublicSettings.publish();
+Meteor.publish('mongo.public_settings', () => PublicSettings.find());
 
 // Public settings should always be subscribed to by all clients.
 if (Meteor.isClient) {

--- a/imports/lib/models/public_settings.ts
+++ b/imports/lib/models/public_settings.ts
@@ -1,0 +1,17 @@
+import { Meteor } from 'meteor/meteor';
+import PublicSettingsSchema, { PublicSettingType } from '../schemas/public_settings';
+import Base from './base';
+
+const PublicSettings = new Base<PublicSettingType>('public_settings');
+PublicSettings.attachSchema(PublicSettingsSchema);
+
+// All public settings are accessible by all clients at all times, including to
+// not-logged-in-users.
+PublicSettings.publish();
+
+// Public settings should always be subscribed to by all clients.
+if (Meteor.isClient) {
+  Meteor.subscribe('mongo.public_settings');
+}
+
+export default PublicSettings;

--- a/imports/lib/schemas/public_settings.ts
+++ b/imports/lib/schemas/public_settings.ts
@@ -1,0 +1,42 @@
+import * as t from 'io-ts';
+import { BaseCodec, BaseOverrides } from './base';
+import { inheritSchema, buildSchema } from './typedSchemas';
+
+// We can't represent tagged unions in SimpleSchema, so we use different types
+// for the actual type vs. the type used to derive the schema.
+export const PublicSettingCodec = t.intersection([
+  BaseCodec,
+  t.taggedUnion('name', [
+    t.type({
+      name: t.literal('webrtc.turnserver'),
+      value: t.type({
+        urls: t.array(t.string),
+      }),
+    }),
+    // TODO: not actually implemented/used yet, but I needed a second possible
+    // value for io-ts to not choke on this being premptively labeled a tagged
+    // union
+    t.type({
+      name: t.literal('branding'),
+      value: t.type({
+        // TODO: add fields for rebranding
+        // servername: t.string, // "Jolly Roger"
+      }),
+    }),
+  ]),
+]);
+export type PublicSettingType = t.TypeOf<typeof PublicSettingCodec>;
+
+const PublicSettingFields = t.type({
+  name: t.string,
+  value: t.object,
+});
+
+const [PublicSettingSchemaCodec, PublicSettingOverrides] = inheritSchema(
+  BaseCodec, PublicSettingFields,
+  BaseOverrides, {},
+);
+
+const PublicSettings = buildSchema(PublicSettingSchemaCodec, PublicSettingOverrides);
+
+export default PublicSettings;


### PR DESCRIPTION
"public" here means "published to all clients at all times, no ACLs
whatsoever".  It's a transport mechanism for things you'd put in source code if
you didn't want to support different values in different deployments.

This will be used for WebRTC STUN/TURN server configuration, and could be used
for rebranding.