### PR TITLE
Render tagless group consistently

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -169,6 +169,10 @@ table.puzzle-list {
   &.tag-priority {
     background-color: #aaaaff;
   }
+  &.tag-none {
+    background-color: transparent;
+    color: #808080;
+  }
 }
 
 .tag-link, .tag-link:active, .tag-link:focus, .tag-link:hover {

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -308,7 +308,7 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
           return (
             <RelatedPuzzleGroup
               key={g.sharedTag ? g.sharedTag._id : 'ungrouped'}
-              sharedTag={g.sharedTag || null}
+              sharedTag={g.sharedTag}
               noSharedTagLabel="(no group specified)"
               relatedPuzzles={g.puzzles}
               allTags={this.props.allTags}

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -305,33 +305,18 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
       case 'group': {
         const puzzleGroups = this.puzzleGroupsByRelevance();
         const groupComponents = puzzleGroups.map((g) => {
-          if (g.sharedTag) {
-            return (
-              <RelatedPuzzleGroup
-                key={g.sharedTag._id}
-                sharedTag={g.sharedTag}
-                relatedPuzzles={g.puzzles}
-                allTags={this.props.allTags}
-                includeCount={false}
-                layout="grid"
-                canUpdate={this.props.canUpdate}
-              />
-            );
-          } else {
-            return (
-              <div key="ungrouped" className="puzzle-list-ungrouped">
-                <div>Puzzles in no group:</div>
-                <div className="puzzles">
-                  <PuzzleList
-                    puzzles={g.puzzles}
-                    allTags={this.props.allTags}
-                    layout="grid"
-                    canUpdate={this.props.canUpdate}
-                  />
-                </div>
-              </div>
-            );
-          }
+          return (
+            <RelatedPuzzleGroup
+              key={g.sharedTag ? g.sharedTag._id : 'ungrouped'}
+              sharedTag={g.sharedTag || null}
+              noSharedTagLabel="(no group specified)"
+              relatedPuzzles={g.puzzles}
+              allTags={this.props.allTags}
+              includeCount={false}
+              layout="grid"
+              canUpdate={this.props.canUpdate}
+            />
+          );
         });
         bodyComponent = (
           <div>

--- a/imports/client/components/RelatedPuzzleGroup.tsx
+++ b/imports/client/components/RelatedPuzzleGroup.tsx
@@ -12,12 +12,12 @@ import puzzleInterestingness from './puzzleInterestingness';
 
 function sortPuzzlesByRelevanceWithinPuzzleGroup(
   puzzles: PuzzleType[],
-  sharedTag: TagType,
+  sharedTag: TagType | null,
   indexedTags: Record<string, TagType>
 ) {
   // If sharedTag is a meta:<something> tag, sort a puzzle with a meta-for:<something> tag at top.
   let group: string;
-  if (sharedTag.name.lastIndexOf('group:', 0) === 0) {
+  if (sharedTag && sharedTag.name.lastIndexOf('group:', 0) === 0) {
     group = sharedTag.name.slice('group:'.length);
   }
 
@@ -37,7 +37,9 @@ function sortPuzzlesByRelevanceWithinPuzzleGroup(
 }
 
 interface RelatedPuzzleGroupProps {
-  sharedTag: TagType;
+  sharedTag: TagType | null;
+  // noSharedTagLabel is used to label the group only if sharedTag is null.
+  noSharedTagLabel: String;
   relatedPuzzles: PuzzleType[];
   allTags: TagType[];
   includeCount?: boolean;
@@ -51,6 +53,10 @@ interface RelatedPuzzleGroupState {
 
 class RelatedPuzzleGroup extends React.Component<RelatedPuzzleGroupProps, RelatedPuzzleGroupState> {
   static displayName = 'RelatedPuzzleGroup';
+
+  static defaultProps: Partial<RelatedPuzzleGroupProps> = {
+    noSharedTagLabel: '(no tag)',
+  };
 
   constructor(props: RelatedPuzzleGroupProps) {
     super(props);
@@ -76,7 +82,7 @@ class RelatedPuzzleGroup extends React.Component<RelatedPuzzleGroupProps, Relate
       <div className="puzzle-group">
         <div className="puzzle-group-header" onClick={this.toggleCollapse}>
           <FontAwesomeIcon fixedWidth icon={this.state.collapsed ? faCaretRight : faCaretDown} />
-          <Tag tag={this.props.sharedTag} linkToSearch={false} />
+          {this.props.sharedTag ? <Tag tag={this.props.sharedTag} linkToSearch={false} /> : <div className="tag tag-none">{this.props.noSharedTagLabel}</div>}
           {this.props.includeCount && <span>{`(${this.props.relatedPuzzles.length} other ${this.props.relatedPuzzles.length === 1 ? 'puzzle' : 'puzzles'})`}</span>}
         </div>
         {this.state.collapsed ? null : (
@@ -86,7 +92,7 @@ class RelatedPuzzleGroup extends React.Component<RelatedPuzzleGroupProps, Relate
               allTags={this.props.allTags}
               layout={this.props.layout}
               canUpdate={this.props.canUpdate}
-              suppressTags={[this.props.sharedTag._id]}
+              suppressTags={this.props.sharedTag ? [this.props.sharedTag._id] : []}
             />
           </div>
         )}

--- a/imports/client/components/RelatedPuzzleGroup.tsx
+++ b/imports/client/components/RelatedPuzzleGroup.tsx
@@ -12,7 +12,7 @@ import puzzleInterestingness from './puzzleInterestingness';
 
 function sortPuzzlesByRelevanceWithinPuzzleGroup(
   puzzles: PuzzleType[],
-  sharedTag: TagType | null,
+  sharedTag: TagType | undefined,
   indexedTags: Record<string, TagType>
 ) {
   // If sharedTag is a meta:<something> tag, sort a puzzle with a meta-for:<something> tag at top.
@@ -37,8 +37,8 @@ function sortPuzzlesByRelevanceWithinPuzzleGroup(
 }
 
 interface RelatedPuzzleGroupProps {
-  sharedTag: TagType | null;
-  // noSharedTagLabel is used to label the group only if sharedTag is null.
+  sharedTag: TagType | undefined;
+  // noSharedTagLabel is used to label the group only if sharedTag is undefined.
   noSharedTagLabel: String;
   relatedPuzzles: PuzzleType[];
   allTags: TagType[];


### PR DESCRIPTION
Render tagless puzzle groups in the same way as ordinary groups, including collapse behavior. Achieved by giving RelatedPuzzleGroup support for null sharedTag. (Though the .tag class is used to achieve consistent styling, the Tag component has not been extended to support no tag.)

Closes #347 