### PR TITLE
Fix fixture hunt creation

### DIFF
--- a/imports/server/fixture.ts
+++ b/imports/server/fixture.ts
@@ -21,6 +21,7 @@ Meteor.methods({
         _id: huntId,
         name: data.title,
         openSignups: true,
+        hasGuessQueue: true,
       });
     }
 


### PR DESCRIPTION
This broke when we added a new required field to the Hunt schema that we didn't
specify in the `createFixtureHunt` method.