### PR TITLE
Add in-app first-user-creation flow for server admin

### DIFF
--- a/imports/client/components/FirstUserForm.tsx
+++ b/imports/client/components/FirstUserForm.tsx
@@ -1,0 +1,141 @@
+import { Meteor } from 'meteor/meteor';
+import React from 'react';
+import Alert from 'react-bootstrap/Alert';
+import Button from 'react-bootstrap/Button';
+import FormControl, { FormControlProps } from 'react-bootstrap/FormControl';
+import FormGroup from 'react-bootstrap/FormGroup';
+import FormLabel from 'react-bootstrap/FormLabel';
+
+enum SubmitState {
+  IDLE = 'idle',
+  SUBMITTING = 'submitting',
+  SUCCESS = 'success',
+  ERROR = 'error',
+}
+
+interface FirstUserFormProps {
+}
+
+interface FirstUserFormState {
+  email: string;
+  password: string;
+  submitState: SubmitState;
+  submitError: string;
+}
+
+class FirstUserForm extends React.Component<FirstUserFormProps, FirstUserFormState> {
+  constructor(props: FirstUserFormProps) {
+    super(props);
+    this.state = {
+      email: '',
+      password: '',
+      submitState: SubmitState.IDLE,
+      submitError: '',
+    };
+  }
+
+  onEmailChange: FormControlProps['onChange'] = (e) => {
+    this.setState({
+      email: e.currentTarget.value,
+    });
+  };
+
+  onPasswordChange: FormControlProps['onChange'] = (e) => {
+    this.setState({
+      password: e.currentTarget.value,
+    });
+  };
+
+  onSubmit = (e: React.FormEvent<any>) => {
+    e.preventDefault();
+
+    const email = this.state.email.trim();
+    const password = this.state.password;
+
+    if (email.length === 0 || password.length === 0) {
+      this.setState({
+        submitState: SubmitState.ERROR,
+        submitError: 'Must provide both an email and password',
+      });
+    } else {
+      this.setState({
+        submitState: SubmitState.SUBMITTING,
+      });
+      Meteor.call('provisionFirstUser', email, password, (err?: Error) => {
+        if (err) {
+          this.setState({
+            submitState: SubmitState.ERROR,
+            submitError: err.message,
+          });
+        } else {
+          // Success!  Do login.
+          Meteor.loginWithPassword(email, password, (error?: Error) => {
+            if (error) {
+              this.setState({
+                submitState: SubmitState.ERROR,
+                submitError: error.message,
+              });
+            } else {
+              // We've logged in. We should get redirected to /hunts by the
+              // AuthenticatedRoute that's rendering us.
+            }
+          });
+        }
+      });
+    }
+  };
+
+  dismissAlert = () => {
+    this.setState({
+      submitState: SubmitState.IDLE,
+    });
+  };
+
+  render() {
+    const shouldDisableForm = this.state.submitState === SubmitState.SUBMITTING;
+    return (
+      <form onSubmit={this.onSubmit}>
+        <h1>Create first user</h1>
+        <p>This user will have server admin and operator privileges.</p>
+        {this.state.submitState === SubmitState.SUBMITTING ? <Alert variant="info">Creating first user...</Alert> : null}
+        {this.state.submitState === SubmitState.SUCCESS ? <Alert variant="success" dismissible onClose={this.dismissAlert}>Created user.</Alert> : null}
+        {this.state.submitState === SubmitState.ERROR ? (
+          <Alert variant="danger" dismissible onClose={this.dismissAlert}>
+            Saving failed:
+            {' '}
+            {this.state.submitError}
+          </Alert>
+        ) : null}
+        <FormGroup>
+          <FormLabel htmlFor="jr-first-user-email">
+            Email
+          </FormLabel>
+          <FormControl
+            id="jr-first-user-email"
+            type="text"
+            value={this.state.email}
+            disabled={shouldDisableForm}
+            onChange={this.onEmailChange}
+          />
+        </FormGroup>
+        <FormGroup>
+          <FormLabel htmlFor="jr-first-user-password">
+            Password
+          </FormLabel>
+          <FormControl
+            id="jr-first-user-password"
+            type="password"
+            value={this.state.password}
+            disabled={shouldDisableForm}
+            onChange={this.onPasswordChange}
+          />
+        </FormGroup>
+        <Button variant="primary" type="submit" disabled={shouldDisableForm} onSubmit={this.onSubmit}>
+          Create first user
+        </Button>
+      </form>
+    );
+  }
+}
+
+export default FirstUserForm;

--- a/imports/client/components/RootRedirector.tsx
+++ b/imports/client/components/RootRedirector.tsx
@@ -2,10 +2,13 @@ import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
 import React from 'react';
 import { Redirect } from 'react-router';
+import HasUsers from '../has_users';
 
 interface RootRedirectorProps {
   loggingIn: boolean;
   userId: string | null;
+  hasUsersReady: boolean;
+  hasUser: boolean;
 }
 
 class RootRedirector extends React.Component<RootRedirectorProps> {
@@ -15,17 +18,32 @@ class RootRedirector extends React.Component<RootRedirectorProps> {
     }
 
     if (this.props.userId) {
+      // Logged in.
       return <Redirect to={{ pathname: '/hunts' }} />;
-    } else {
+    }
+
+    // Definitely not logged in.  Wait for the hasUsers sub to be ready,
+    // and then if there's a user, go to the login page, and if not, go
+    // to the create-first-user page.
+    if (!this.props.hasUsersReady) {
+      return <div>loading redirector...</div>;
+    } else if (this.props.hasUser) {
       return <Redirect to={{ pathname: '/login' }} />;
+    } else {
+      return <Redirect to={{ pathname: '/create-first-user' }} />;
     }
   }
 }
 
 const RootRedirectorContainer = withTracker(() => {
+  const hasUsersHandle = Meteor.subscribe('hasUsers');
+  const hasUser = !!HasUsers.findOne({});
+
   return {
     loggingIn: Meteor.loggingIn(),
     userId: Meteor.userId(),
+    hasUsersReady: hasUsersHandle.ready(),
+    hasUser,
   };
 })(RootRedirector);
 

--- a/imports/client/components/Routes.tsx
+++ b/imports/client/components/Routes.tsx
@@ -5,6 +5,7 @@ import { Route, Switch } from 'react-router';
 import AllProfileListPage from './AllProfileListPage';
 import AuthenticatedRoute from './AuthenticatedRoute';
 import EnrollForm from './EnrollForm';
+import FirstUserForm from './FirstUserForm';
 import HuntApp from './HuntApp';
 import HuntListPage from './HuntListPage';
 import LoginForm from './LoginForm';
@@ -34,6 +35,7 @@ class Routes extends React.Component {
             <UnauthenticatedRoute path="/login" component={LoginForm} />
             <UnauthenticatedRoute path="/reset-password/:token" component={PasswordResetForm} />
             <UnauthenticatedRoute path="/enroll/:token" component={EnrollForm} />
+            <UnauthenticatedRoute path="/create-first-user" component={FirstUserForm} />
           </Switch>
         </BreadcrumbsProvider>
       </DocumentTitle>

--- a/imports/client/has_users.ts
+++ b/imports/client/has_users.ts
@@ -1,0 +1,6 @@
+import { Mongo } from 'meteor/mongo';
+
+// Pseudo-collection used to determine if we should expose first-user setup
+const HasUsers = new Mongo.Collection('hasUsers');
+
+export default HasUsers;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "lint": "tsc --noEmit && eslint --ext js,jsx,ts,tsx .",
-    "test": "TEST_BROWSER_DRIVER=puppeteer meteor test --once --driver-package meteortesting:mocha"
+    "test": "TEST_BROWSER_DRIVER=puppeteer meteor test --full-app --once --driver-package meteortesting:mocha"
   },
   "dependencies": {
     "@babel/runtime": "^7.11.2",

--- a/tests/acceptance/authentication.tsx
+++ b/tests/acceptance/authentication.tsx
@@ -19,21 +19,47 @@ Meteor.methods({
   },
 });
 
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 if (Meteor.isClient) {
   const Routes: typeof import('../../imports/client/components/Routes').default =
     require('../../imports/client/components/Routes').default;
 
-  describe('unauthenticated users', function () {
-    it('redirects to the login page', function () {
+  describe('no users', function () {
+    it('redirects to the create-first-user page', async function () {
       const history = createMemoryHistory();
       mount(
         <Router history={history}>
           <Routes />
         </Router>
       );
+      // Give some time for the RootRedirector's hasUsers sub to complete
+      await sleep(500);
+      assert.equal(history.location.pathname, '/create-first-user');
+    });
+  });
+
+  describe('has users but not logged in', function () {
+    before(async function () {
+      await Meteor.callPromise('test.resetDatabase');
+      await Meteor.callPromise('test.authentication.createUser');
+    });
+
+    it('redirects to the login page', async function () {
+      const history = createMemoryHistory();
+      mount(
+        <Router history={history}>
+          <Routes />
+        </Router>
+      );
+      // Give some time for the RootRedirector's hasUsers sub to complete
+      await sleep(500);
       assert.equal(history.location.pathname, '/login');
 
       history.push('/hunts');
+      await sleep(500);
       assert.equal(history.location.pathname, '/login');
     });
   });

--- a/tests/acceptance/lib.ts
+++ b/tests/acceptance/lib.ts
@@ -6,9 +6,11 @@ import Adapter from 'enzyme-adapter-react-16';
 
 configure({ adapter: new Adapter() });
 
-Meteor.methods({
-  'test.resetDatabase': function () {
-    resetDatabase();
-    Migrations.migrateTo('latest');
-  },
-});
+if (Meteor.isServer) {
+  Meteor.methods({
+    'test.resetDatabase': function () {
+      resetDatabase();
+      Migrations.migrateTo('latest');
+    },
+  });
+}

--- a/tests/acceptance/lib.ts
+++ b/tests/acceptance/lib.ts
@@ -1,4 +1,5 @@
 import { Meteor } from 'meteor/meteor';
+import { Migrations } from 'meteor/percolate:migrations';
 import { resetDatabase } from 'meteor/xolvio:cleaner';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
@@ -8,5 +9,6 @@ configure({ adapter: new Adapter() });
 Meteor.methods({
   'test.resetDatabase': function () {
     resetDatabase();
+    Migrations.migrateTo('latest');
   },
 });


### PR DESCRIPTION
It's actually kinda hard to set up a new production Jolly Roger deployment,
since there's no good way to get a meteor shell with a connection to the real
DB to create the first account.  You either have to figure out how to get a
shell hooked up to your production DB (which we don't document), or you have to
bring a row from your development users table via a mongo client, or something else
ridiculous.  We can do better.

This change adds:

* a pseudocollection that simply indicates whether there are any
  users in the Meteor users table
* a Meteor method to provision the initial admin user provided there
  are no users in the Meteor users table yet
* a page with a form to enter an email address/password to be used with the
  aforementioned Meteor method
* logic in the root redirector to send you to that form if you are not logged in
  and the server has no users

Then, when setting up a new server, you navigate to the root page, it redirects
to the first-account-creation page, and you can just create the admin user
through the UI.

![Screenshot_20201203_032249](https://user-images.githubusercontent.com/307325/101009308-d3914e00-3516-11eb-9363-361cc325c57e.png)

cc @aldeka since this was a pain point in setting up a test Jolly Roger instance for Rages