### PR TITLE
Support TURN for peer discovery

### DIFF
--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -313,7 +313,7 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
                 {`${rtcViewers.length} caller${rtcViewers.length !== 1 ? 's' : ''}`}
               </header>
               <div className="people-list">
-                {rtcViewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}`} {...viewer} />)}
+                {rtcViewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}-${viewer.tab}`} {...viewer} />)}
               </div>
             </div>
           </>

--- a/imports/client/rtc_config.ts
+++ b/imports/client/rtc_config.ts
@@ -1,0 +1,11 @@
+// Pseudo-collection used to pull down RTC config
+import { Mongo } from 'meteor/mongo';
+
+export type RTCConfigType = {
+  _id: string;
+  username: string;
+  credential: string;
+  urls: string[];
+}
+
+export const RTCConfig = new Mongo.Collection<RTCConfigType>('rtcconfig');

--- a/imports/lib/models/facade.ts
+++ b/imports/lib/models/facade.ts
@@ -9,7 +9,6 @@ import Guesses from './guess';
 import Hunts from './hunts';
 import PendingAnnouncements from './pending_announcements';
 import Profiles from './profiles';
-import PublicSettings from './public_settings';
 import Puzzles from './puzzles';
 import Settings from './settings';
 import Tags from './tags';
@@ -26,7 +25,6 @@ const Models = {
   Hunts,
   PendingAnnouncements,
   Profiles,
-  PublicSettings,
   Puzzles,
   Settings,
   Tags,

--- a/imports/lib/schemas/settings.ts
+++ b/imports/lib/schemas/settings.ts
@@ -38,6 +38,13 @@ export const SettingCodec = t.intersection([
         guild: GuildType,
       }),
     }),
+    t.type({
+      name: t.literal('webrtc.turnserver'),
+      value: t.type({
+        secret: t.string,
+        urls: t.array(t.string),
+      }),
+    }),
   ]),
 ]);
 export type SettingType = t.TypeOf<typeof SettingCodec>;

--- a/imports/server/setup.ts
+++ b/imports/server/setup.ts
@@ -7,7 +7,6 @@ import { Roles } from 'meteor/nicolaslopezj:roles';
 import { ServiceConfiguration } from 'meteor/service-configuration';
 import Ansible from '../ansible';
 import { API_BASE } from '../lib/discord';
-import PublicSettings from '../lib/models/public_settings';
 import Settings from '../lib/models/settings';
 import { DiscordBot } from './discord';
 
@@ -184,13 +183,22 @@ Meteor.methods({
     }
   },
 
-  setupTurnServerUrls(urls: unknown) {
+  setupTurnServerConfig(secret: unknown, urls: unknown) {
     check(this.userId, String);
     Roles.checkPermission(this.userId, 'webrtc.configureServers');
+    check(secret, String);
     check(urls, [String]);
 
-    PublicSettings.upsert({ name: 'webrtc.turnserver' },
-      { $set: { 'value.urls': urls } });
+    if (secret || urls.length > 0) {
+      Settings.upsert({ name: 'webrtc.turnserver' }, {
+        $set: {
+          'value.secret': secret,
+          'value.urls': urls,
+        },
+      });
+    } else {
+      Settings.remove({ name: 'webrtc.turnserver' });
+    }
   },
 });
 


### PR DESCRIPTION
This change shifts how RTC configuration is done, enabling us to use
authenticated TURN servers (which unlocks the ability to route traffic for
peers that cannot reach each other directly).

To accomplish this, the TURN server needs to be able to authenticate its
clients.  While there's a bunch of complicated ways to do this, there's also
one pleasantly simple approach in [1] that requires no more shared state than a
single shared secret between a web service (for us, the Meteor backend) and the
TURN server (for us, `coturn`).

We implement the token generation scheme with HMAC-SHA1 as specified, and
publish the resulting username/credential in a pseudocollection called
`rtcconfig`.  Since now TURN integration requires a secret, and since we're not
giving TURN config to non-authenticated users, it's simpler to drop the whole
`PublicConfig` thing that I wrote for the stun server URLs and just stuff the
whole thing in Settings on the server and in the pseudocollection to get it to
the client.  Fewer, fatter structs with shared lifecycle.

Server administrators will need to update their configuration to include the
TURN shared secret and to specify STUN/TURN urls appropriately.

While deployment guides suggest shorter-lived tokens, I'm not worried about
abuse from our users so I made the tokens valid for 3 days, which massively
exceeds the maximum time I imagine any one tab will have joined a call.

You can verify that relaying actually works with your setup by adding
`iceTransportPolicy:"relay"` to the `rtcConfig` passed to `new
RTCPeerConnection` in `CallLinkBox.tsx`, which will force the
`RTCPeerConnection` to only use relay candidates, and then verifying that calls
still work.

[1] - https://tools.ietf.org/html/draft-uberti-behave-turn-rest-00