### PR TITLE
Fix emoji spacing

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -134,7 +134,7 @@ table.puzzle-list {
 @font-face {
   font-family: "Emoji";
   src: "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
-  unicode-range: U+1F300-1FAFF, U+2300-23FF, U+2600-27BF;
+  unicode-range: U+1F300-1FAFF, U+1F100-1F1FF, U+2300-23FF, U+2600-27BF;
 }
 
 .answer, #jr-puzzle-guess {

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -131,9 +131,15 @@ table.puzzle-list {
   margin: 2px;
 }
 
+@font-face {
+  font-family: "Emoji";
+  src: "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
+  unicode-range: U+1F300-1FAFF, U+2300-23FF, U+2600-27BF;
+}
+
 .answer, #jr-puzzle-guess {
   text-transform: uppercase;
-  font-family: "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", monospace;
+  font-family: "Emoji", monospace, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
   font-weight: bold;
 }
 


### PR DESCRIPTION
Addresses the space formatting issue discussed in #291, using @zarvox's suggestion, but does not address the bigger questions raised by @ebroder.

With this change, emoji fonts are prioritized for blocks that people tend to describe as emoji (see below), after which we prefer monospace. For characters not available there, we fall back to the rest of the emoji fonts. My intent was to prefer monospace wherever it makes sense, conceding that it probably doesn't for clearly pictographic symbols.

The prioritized emoji include the self-evident 1F300-1FAFF, but also 2300-23FF (Miscellaneous Technical, which happens to include various timepiece symbols), 2600-26FF (Miscellaneous Symbols), 2700-27BF (Dingbats), and 1F100-1F1FF (Enclosed Alphanumeric Supplement, which includes the regional indicator symbols used for flags). It intentionally does not include arrows and the like, for which I think we should prefer monospace variants when available. That said, I could easily be persuaded to change any of this - the important change is that 0020 return to monospace.