### PR TITLE
Reject calls to `insert()` that have extra field not declared in schema

### DIFF
--- a/imports/lib/models/base.ts
+++ b/imports/lib/models/base.ts
@@ -19,6 +19,11 @@ export type FindOptions = FindOneOptions & {
   limit?: number;
 }
 
+type ValidateShape<T, Shape> =
+    T extends Partial<Shape> ?
+    Exclude<keyof T, keyof Shape> extends never ?
+    T : never : never;
+
 class Base<T extends BaseType> extends Mongo.Collection<T> {
   public name: string;
 
@@ -35,7 +40,7 @@ class Base<T extends BaseType> extends Mongo.Collection<T> {
   //   autovalues, it doesn't know which fields are actually required. This is a
   //   coarse workaround, but it's hard to pick the autoValue out from just the
   //   types.
-  insert(doc: Partial<T>, callback?: Function): string {
+  insert<U>(doc: ValidateShape<U, Partial<T>>, callback?: Function): string {
     return super.insert(<any>doc, callback);
   }
 


### PR DESCRIPTION
f66ec97c375f46717def29a5a4d653ff178540b8 fixed a bug in which I failed to add a
field to the schema, which caused the field to be dropped when serialized to
the database, which caused garbage collection of `CallParticipants` to do
nothing.

I expected `insert()` to reject types with fields that were not known to the
schema, but Typescript is generally permissive.

With this change, we reject arguments with unknown fields.  It catches the bug
fixed above via the typechecker.