### PR TITLE
Improve puzzle list presentation

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -20,9 +20,6 @@
 }
 
 .puzzle {
-  margin-bottom: 4px;
-  vertical-align: top;
-
   &.unsolved {
     background-color: #f0f0f0;
   }
@@ -36,99 +33,90 @@
   }
 }
 
-.puzzle-grid {
+.puzzle.puzzle-grid {
   display: flex;
   flex-direction: row;
-  flex-wrap: wrap;
-  align-items: center;
+  align-items: first baseline;
   justify-content: flex-start;
-  padding-left: 4px;
-  min-height: 32px;
+  line-height: 24px;
+  padding: 4px 2px;
+  margin-bottom: 4px;
+
+  > * {
+    padding: 0 2px;
+    display: inline-block;
+    flex: none;
+  }
 
   .puzzle-title {
-    flex: 1 0 35%;
-    display: inline-block;
-    vertical-align: top;
-    word-wrap: break-word;
-    font-weight: bold;
+    flex: 4;
   }
 
   .puzzle-link {
-    flex: 1 1 1em;
-    display: inline-block;
-    vertical-align: top;
+    width: 26px;
     text-align: center;
   }
 
   .puzzle-view-count {
-    flex: 1 1 40px;
-    display: inline-block;
+    width: 5ch;
     text-align: center;
   }
 
   .puzzle-answer {
-    flex: 1 1 25%;
-    display: inline-block;
-    word-wrap: break-word;
-    word-break: break-all;
-    .answer-wrapper {
-      margin: 0;
+    flex: 3;
+    overflow-wrap: break-word;
+    overflow: hidden;
+    // Don't let .puzzle-answer set the height unless it's more lines than .puzzle-title
+    // Courier New (frequently the default monospace font) has slightly different ascender and
+    // descender heights, causing .puzzle to render taller than intended when aligned by baseline
+    // (Line-height is large enough that this fix doesn't actually crop anything)
+    // Revisit once we choose a preferred monospace font
+    margin-bottom: -1px;
+  }
+
+  .tag-list {
+    flex: 3;
+    margin: -2px -4px -2px 0;
+  }
+
+  .puzzle-edit-button {
+    align-self: flex-start;
+
+    // Resize button to fit in one line-height
+    button {
+      display: block;
+      height: 24px;
+      width: 24px;
       padding: 0;
     }
   }
 
-  .tag-list {
-    flex: 1 10 25%;
-    display: inline-block;
-  }
-}
+  @media (max-width: 507px) {
+    flex-wrap: wrap;
 
-@media (max-width: 499px) {
-  .puzzle-title {
-    flex-basis: 35%;
-  }
-
-  .puzzle-link {
-    flex-basis: 15%;
-  }
-
-  .puzzle-view-count {
-    flex-basis: 5%;
-  }
-
-  .puzzle-answer {
-    flex-basis: 45%
-  }
-
-  .puzzle-grid .tag-list {
-     /* Push tags to new row in narrow views */
-    flex-basis: 100%;
-    width: 100%;
+    /* Push to new row in narrow views */
+    .puzzle-answer, .tag-list {
+      flex: 0 0 100%;
+    }
   }
 }
 
 table.puzzle-list {
   width: 100%;
   max-width: 100%;
-}
+  border-collapse: separate;
+  border-spacing: 0 4px;
 
-.puzzle-table-row {
-  .puzzle-title {
-    padding: 4px 0;
-    font-weight: bold;
-    word-wrap: break-word;
-  }
-
-  .puzzle-answer {
-    word-break: normal;
+  .puzzle.puzzle-table-row {
+    td {
+      padding: 0px 4px;
+      vertical-align: baseline;
+    }
   }
 }
 
-.answer-wrapper {
-  display: inline-block;
-  vertical-align: top;
-  padding: 2px;
-  margin: 2px;
+.puzzle-title {
+  font-weight: bold;
 }
 
 @font-face {

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -33,6 +33,12 @@
   }
 }
 
+.puzzle-answer > .answer {
+  display: block;
+  text-indent: -2ch;
+  padding-left: 2ch;
+}
+
 .puzzle.puzzle-grid {
   display: flex;
   flex-direction: row;

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -114,9 +114,12 @@ class Puzzle extends React.PureComponent<PuzzleProps, PuzzleState> {
             showOnMount
           />
         ) : null}
+        {this.props.canUpdate && (
+          <div className="puzzle-edit-button">
+            {this.editButton()}
+          </div>
+        )}
         <div className="puzzle-title">
-          {this.editButton()}
-          {' '}
           <Link to={linkTarget}>{this.props.puzzle.title}</Link>
         </div>
         {this.props.layout === 'grid' ? (

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -86,6 +86,13 @@ class Puzzle extends React.PureComponent<PuzzleProps, PuzzleState> {
       this.props.layout === 'table' ? 'puzzle-table-row' : null,
       isAdministrivia ? 'administrivia' : null);
 
+    const answers = this.props.puzzle.answers.map((answer, i) => {
+      return (
+        // eslint-disable-next-line react/no-array-index-key
+        <PuzzleAnswer key={`${i}-${answer}`} answer={answer} />
+      );
+    });
+
     if (this.props.layout === 'table') {
       return (
         <tr className={puzzleClasses}>
@@ -95,7 +102,7 @@ class Puzzle extends React.PureComponent<PuzzleProps, PuzzleState> {
             <Link to={linkTarget}>{this.props.puzzle.title}</Link>
           </td>
           <td className="puzzle-answer">
-            <PuzzleAnswer answer={this.props.puzzle.answers.join(',')} />
+            {answers}
           </td>
         </tr>
       );
@@ -135,7 +142,7 @@ class Puzzle extends React.PureComponent<PuzzleProps, PuzzleState> {
           ) : null}
         </div>
         <div className="puzzle-answer">
-          <PuzzleAnswer answer={this.props.puzzle.answers.join(',')} />
+          {answers}
         </div>
         <TagList puzzle={this.props.puzzle} tags={ownTags} linkToSearch={this.props.layout === 'grid'} popoverRelated={false} />
       </div>

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -122,19 +122,17 @@ class Puzzle extends React.PureComponent<PuzzleProps, PuzzleState> {
         <div className="puzzle-title">
           <Link to={linkTarget}>{this.props.puzzle.title}</Link>
         </div>
-        {this.props.layout === 'grid' ? (
-          <div className="puzzle-link">
-            {this.props.puzzle.url ? (
-              <span>
-                <a href={this.props.puzzle.url} target="_blank" rel="noopener noreferrer" title="Open the puzzle">
-                  <FontAwesomeIcon icon={faPuzzlePiece} />
-                </a>
-              </span>
-            ) : null}
-          </div>
-        ) : null}
         <div className="puzzle-view-count">
           {!(this.props.puzzle.answers.length >= this.props.puzzle.expectedAnswerCount) && !isAdministrivia && <SubscriberCount puzzleId={this.props.puzzle._id} />}
+        </div>
+        <div className="puzzle-link">
+          {this.props.puzzle.url ? (
+            <span>
+              <a href={this.props.puzzle.url} target="_blank" rel="noopener noreferrer" title="Open the puzzle">
+                <FontAwesomeIcon icon={faPuzzlePiece} />
+              </a>
+            </span>
+          ) : null}
         </div>
         <div className="puzzle-answer">
           <PuzzleAnswer answer={this.props.puzzle.answers.join(',')} />

--- a/imports/client/components/PuzzleAnswer.tsx
+++ b/imports/client/components/PuzzleAnswer.tsx
@@ -9,10 +9,8 @@ class PuzzleAnswer extends React.PureComponent<PuzzleAnswerProps> {
 
   render() {
     return (
-      <span className="answer-wrapper">
-        <span className="answer">
-          {this.props.answer}
-        </span>
+      <span className="answer">
+        {this.props.answer}
       </span>
     );
   }

--- a/imports/client/components/Tag.tsx
+++ b/imports/client/components/Tag.tsx
@@ -127,6 +127,17 @@ class Tag extends React.Component<TagProps, TagState> {
       isNeeds ? 'tag-needs' : null,
       isPriority ? 'tag-priority' : null);
 
+    // Browsers won't word-break on hyphens, so suggest
+    // Use wbr instead of zero-width space to make copy-paste reasonable
+    const nameWithBreaks:(String|JSX.Element)[] = [];
+    name.split(':').forEach((part, i, arr) => {
+      const withColon = i < arr.length - 1;
+      nameWithBreaks.push(`${part}${withColon ? ':' : ''}`);
+      if (withColon) {
+        // eslint-disable-next-line react/no-array-index-key
+        nameWithBreaks.push(<wbr key={`wbr-${i}-${part}`} />);
+      }
+    });
     let title;
     if (this.props.linkToSearch) {
       title = (
@@ -137,11 +148,11 @@ class Tag extends React.Component<TagProps, TagState> {
           }}
           className="tag-link"
         >
-          {name}
+          {nameWithBreaks}
         </Link>
       );
     } else {
-      title = name;
+      title = nameWithBreaks;
     }
 
     const tagElement = (


### PR DESCRIPTION
General improvement of puzzle list presentation format and style.
- **All formats**
  - Answers now display stacked one-per-line: _Improved visual inspection of all answers_
  - Answers that wrap are indented: _Distinguishes wrapped answers at a glance_
  - Change alignment to first baseline (Formerly vertically centered): _Visually aligns the two fonts used for title and answer (particularly noticeable in popover tables). In grid format, also places interface elements consistently in rows that wrap._
  - Tags now break at colons: _Better wrapping_
- **Grid format** (as seen on the main puzzle list)
  - Answers now wrap first at word-breaks, then by letter
  - Move answers to a new line on narrow viewports: _Less text wrapping_
  - Move edit button into its own flex item: _Title no longer wraps under it_
  - Resize edit button to fit in the same line-height
  - Swap puzzle-link and viewer count: _Places the viewer count next to the JR link, which is a more natural association, without significantly changing existing user experience_
  - Minor adjustments to flexbox spacing