### PR TITLE
Suggestion: Remove "Tags:" label from puzzle page

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -214,6 +214,11 @@ table.puzzle-list {
   margin: 0 0 0 6px;
 }
 
+.tag-list-empty-label {
+  color: #808080;
+  margin-right: 4px;
+}
+
 /*Guessing and History Modal */
 .guess-history-table td.answer {
   word-break: break-all;
@@ -543,7 +548,6 @@ table.puzzle-list {
   align-items: flex-start;
   align-content: flex-start;
   flex-wrap: wrap;
-  margin-left: 4px;
 }
 
 .puzzle-metadata-row .btn {

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -480,7 +480,6 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
           {this.props.puzzle.answers.length > 0 && answerComponent}
         </div>
         <div className={classnames('puzzle-metadata-row', this.props.isDesktop && 'puzzle-metadata-tag-editor-row')}>
-          <div className="puzzle-metadata-tags-label">Tags: </div>
           <TagList
             puzzle={this.props.puzzle}
             tags={tags}
@@ -491,6 +490,7 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
             popoverRelated
             allPuzzles={this.props.allPuzzles}
             allTags={this.props.allTags}
+            emptyMessage="No tags yet"
           />
         </div>
         <div className="puzzle-metadata-row puzzle-metadata-action-row">

--- a/imports/client/components/TagList.tsx
+++ b/imports/client/components/TagList.tsx
@@ -16,6 +16,7 @@ interface BaseTagListProps {
   onRemoveTag?: (tagId: string) => void; // callback if user wants to remove a tag
   linkToSearch: boolean;
   showControls?: boolean;
+  emptyMessage: string;
 }
 
 interface DoNotPopoverRelatedProps {
@@ -38,7 +39,10 @@ interface TagListState {
 class TagList extends React.PureComponent<TagListProps, TagListState> {
   static displayName = 'TagList';
 
-  static defaultProps = { showControls: true };
+  static defaultProps = {
+    showControls: true,
+    emptyMessage: '',
+  };
 
   constructor(props: TagListProps) {
     super(props);
@@ -134,6 +138,12 @@ class TagList extends React.PureComponent<TagListProps, TagListState> {
           allPuzzles={this.props.popoverRelated ? this.props.allPuzzles : []}
           allTags={this.props.popoverRelated ? this.props.allTags : []}
         />
+      );
+    }
+
+    if (tags.length === 0 && this.props.emptyMessage) {
+      components.push(
+        <span className="tag-list-empty-label" key="noTagLabel">{this.props.emptyMessage}</span>
       );
     }
 


### PR DESCRIPTION
We actually [discussed this in January](https://github.com/deathandmayhem/jolly-roger/pull/215#discussion_r248921246), but it might be worth revisiting in light of recent layout changes.

Removing the label frees up some space and generally makes the layout cleaner, in my opinion, and hopefully the purpose of tags is pretty self-evident even without the label. I added a "No tags yet" label, so the + button makes sense in that context.

When I put this together, I had forgotten that we already discussed this. @zarvox, please feel free to just cite the old discussion if your opinion hasn't changed.