### PR TITLE
Suggestion: Full-width metadata

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -227,24 +227,21 @@ table.puzzle-list {
   bottom: 0px;
   left: 0px;
   right: 0px;
-
-  .Pane > .puzzle-content, .Pane > .chat-section {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-  }
-
-  &.narrow {
-    display: flex;
-    flex-direction: column;
-  }
-}
-
-.puzzle-content {
   display: flex;
   flex-direction: column;
+
+  > .SplitPanePlus {
+    flex: 1 1 auto;
+    position: relative;
+
+    .puzzle-document, .chat-section {
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+  }
 }
 
 // Chat
@@ -577,11 +574,6 @@ table.puzzle-list {
 }
 
 .puzzle-document {
-  width: 100%;
-  height: 100%;
-  flex: auto;
-  position: relative;
-
   > .puzzle-document-message {
     display: block;
     width: 100%;

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -80,10 +80,10 @@ const DefaultSidebarWidth = 300;
 //
 //   Wide (>=MinimiumDesktopWidth) - "desktop"
 //    _____________________________
-//   |      |         b            |
-//   |  a   |______________________|
+//   |              b              |
+//   |_____________________________|
 //   |      |                      |
-//   |      |                      |
+//   |   a  |                      |
 //   |      |         c            |
 //   |      |                      |
 //   |______|______________________|
@@ -988,17 +988,6 @@ class PuzzlePage extends React.PureComponent<PuzzlePageProps, PuzzlePageState> {
       return <div className="puzzle-page" ref={(el) => { this.puzzlePageEl = el; }}><span>loading...</span></div>;
     }
     const activePuzzle = findPuzzleById(this.props.allPuzzles, this.props.match.params.puzzleId)!;
-    const metadata = (
-      <PuzzlePageMetadataContainer
-        puzzle={activePuzzle}
-        allTags={this.props.allTags}
-        allPuzzles={this.props.allPuzzles}
-        guesses={this.props.allGuesses}
-        displayNames={this.props.displayNames}
-        isDesktop={this.state.isDesktop}
-        document={this.props.document}
-      />
-    );
     const chat = (
       <ChatSection
         chatReady={this.props.chatReady}
@@ -1010,8 +999,17 @@ class PuzzlePage extends React.PureComponent<PuzzlePageProps, PuzzlePageState> {
     );
     return (
       <DocumentTitle title={`${activePuzzle.title} :: Jolly Roger`}>
-        {this.state.isDesktop ? (
-          <div className="puzzle-page" ref={(el) => { this.puzzlePageEl = el; }}>
+        <div className={classnames('puzzle-page', !this.state.isDesktop && 'narrow')} ref={(el) => { this.puzzlePageEl = el; }}>
+          <PuzzlePageMetadataContainer
+            puzzle={activePuzzle}
+            allTags={this.props.allTags}
+            allPuzzles={this.props.allPuzzles}
+            guesses={this.props.allGuesses}
+            displayNames={this.props.displayNames}
+            isDesktop={this.state.isDesktop}
+            document={this.props.document}
+          />
+          {this.state.isDesktop ? (
             <SplitPanePlus
               split="vertical"
               minSize={MinimumSidebarWidth}
@@ -1023,18 +1021,12 @@ class PuzzlePage extends React.PureComponent<PuzzlePageProps, PuzzlePageState> {
               onPaneChanged={this.onChangeSideBarSize}
             >
               {chat}
-              <div className="puzzle-content">
-                {metadata}
-                <PuzzlePageMultiplayerDocument document={this.props.document} />
-              </div>
+              <PuzzlePageMultiplayerDocument document={this.props.document} />
             </SplitPanePlus>
-          </div>
-        ) : (
-          <div className="puzzle-page narrow">
-            {metadata}
-            {chat}
-          </div>
-        )}
+          ) : (
+            chat
+          )}
+        </div>
       </DocumentTitle>
     );
   }


### PR DESCRIPTION
This makes the puzzle metadata span the entire top of the puzzle page, rather than having chat span the entire left.

Pros
- Arguably more natural to have the puzzle information start at the left of the screen, directly below navigation
- More space for puzzle title and tags list before wrapping

Cons
- Less vertical space for chat

This is intended as a demonstration of the layout to spur discussion. My preference is weakly for this layout, but I can see both arguments.