### PR TITLE
Standardize fonts

### DIFF
--- a/client/main.ts
+++ b/client/main.ts
@@ -1,5 +1,3 @@
-import '../node_modules/bootstrap/dist/css/bootstrap.css';
-
 // explicitly import all the stuff from lib/ since mainModule skips autoloading
 // things
 import '../imports/lib/config/accounts';

--- a/client/stylesheets/_theme.scss
+++ b/client/stylesheets/_theme.scss
@@ -1,0 +1,7 @@
+$font-family-sans-serif: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Arial", sans-serif, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
+$font-family-monospace: "Source Code Pro", "Consolas", "Monaco", monospace, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
+$font-family-base: $font-family-sans-serif;
+
+@import "../../node_modules/bootstrap/scss/functions";
+@import "../../node_modules/bootstrap/scss/variables";
+@import "../../node_modules/bootstrap/scss/mixins";

--- a/client/stylesheets/app.scss
+++ b/client/stylesheets/app.scss
@@ -1,3 +1,8 @@
+// Standard font
+@import url("https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,700;1,400;1,700&display=swap");
+// Answer monospace font
+@import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@300&display=swap');
+
 .connection-status {
   position: fixed;
   top: 50px;

--- a/client/stylesheets/app.scss
+++ b/client/stylesheets/app.scss
@@ -3,6 +3,9 @@
 // Answer monospace font
 @import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@300&display=swap');
 
+@import "theme";
+@import "../../node_modules/bootstrap/scss/bootstrap";
+
 .connection-status {
   position: fixed;
   top: 50px;

--- a/client/stylesheets/breadcrumbs.scss
+++ b/client/stylesheets/breadcrumbs.scss
@@ -1,6 +1,4 @@
-@import "../../node_modules/bootstrap/scss/functions";
-@import "../../node_modules/bootstrap/scss/variables";
-@import "../../node_modules/bootstrap/scss/mixins";
+@import "theme";
 
 .jolly-roger .nav-breadcrumbs ol {
   height: 50px; // navbar height

--- a/client/stylesheets/index.css
+++ b/client/stylesheets/index.css
@@ -20,5 +20,5 @@
 }
 
 .jolly-roger {
-    font-family: "Helvetica Neue", "Helvetica", "Arial", sans-serif, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
+    font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Arial", sans-serif, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
 }

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -1,5 +1,4 @@
-@import "../../node_modules/bootstrap/scss/functions";
-@import "../../node_modules/bootstrap/scss/variables";
+@import "theme";
 
 // Puzzle components helper styles
 // Puzzle lists/tables
@@ -123,7 +122,7 @@ table.puzzle-list {
 
 .answer, #jr-puzzle-guess {
   text-transform: uppercase;
-  font-family: "Emoji", "Source Code Pro", "Consolas", "Monaco", monospace, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: "Emoji", $font-family-monospace;
   font-weight: 300;
 }
 

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -72,12 +72,6 @@
     flex: 3;
     overflow-wrap: break-word;
     overflow: hidden;
-    // Don't let .puzzle-answer set the height unless it's more lines than .puzzle-title
-    // Courier New (frequently the default monospace font) has slightly different ascender and
-    // descender heights, causing .puzzle to render taller than intended when aligned by baseline
-    // (Line-height is large enough that this fix doesn't actually crop anything)
-    // Revisit once we choose a preferred monospace font
-    margin-bottom: -1px;
   }
 
   .tag-list {
@@ -121,10 +115,6 @@ table.puzzle-list {
   }
 }
 
-.puzzle-title {
-  font-weight: bold;
-}
-
 @font-face {
   font-family: "Emoji";
   src: "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
@@ -133,8 +123,8 @@ table.puzzle-list {
 
 .answer, #jr-puzzle-guess {
   text-transform: uppercase;
-  font-family: "Emoji", monospace, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji", sans-serif;
-  font-weight: bold;
+  font-family: "Emoji", "Source Code Pro", "Consolas", "Monaco", monospace, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
+  font-weight: 300;
 }
 
 // Tags

--- a/client/stylesheets/puzzlelist.scss
+++ b/client/stylesheets/puzzlelist.scss
@@ -1,5 +1,4 @@
-@import "../../node_modules/bootstrap/scss/functions";
-@import "../../node_modules/bootstrap/scss/variables";
+@import "theme";
 
 @media (max-width: 767px) {
   .puzzle-view-controls>* {


### PR DESCRIPTION
Previously, the global font stack was Helvetica Neue, Helvetica, Arial, while the answer font was simply system monospace. Both left a lot of room for inter-system variability, as many Linux systems will have none of those fonts installed, Helvetica Neue has significantly different metrics from Helvetica and Arial, and default monospace fonts vary significantly. As a result of incompatible metrics, this also led to layout variation, such as the vertical alignment issue noted by @zarvox in #367.

This standardizes on freely available fonts, ensuring consistent layout. It also drops bold styling of titles and answers in puzzle lists, which I believe was unnecessary and decreased legibility while taking up extra space.

The font chosen for answers had to meet the following requirements:
- Monospace
- Thorough coverage of digits, capital letters, diacritic combinations typical in European languages, and capital greek letters
- Good legibility in uppercase
- Easily distinguished 0/O and 1/I
- Freely available

Source Code Pro met these requirements and shares vertical metrics with Source Code Sans (itself very similar to its predecessor Helvetica Neue), making same-line alignment simple. Uppercase monospace answers felt heavier than the mixed-case proportional titles beside them, so the weight of answers was reduced to 300 to compensate.