### PR TITLE
Use common breakpoints

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -90,7 +90,7 @@
     }
   }
 
-  @media (max-width: 507px) {
+  @include media-breakpoint-down(xs) {
     flex-wrap: wrap;
 
     /* Push to new row in narrow views */
@@ -549,12 +549,6 @@ table.puzzle-list {
   display: inline-block;
   font-weight: bold;
   white-space: nowrap;
-  /* On very narrow windows, desperately try to prevent line wrap */
-  @media (max-width: 374px) {
-    .linkLabel {
-      display: none;
-    }
-  }
 }
 
 @media (any-pointer: fine) {

--- a/client/stylesheets/puzzlelist.scss
+++ b/client/stylesheets/puzzlelist.scss
@@ -1,12 +1,5 @@
 @import "theme";
 
-@media (max-width: 767px) {
-  .puzzle-view-controls>* {
-    width: 100%;
-    margin-right: 0;
-  }
-}
-
 .puzzle-view-controls {
   display: flex;
   flex-wrap: wrap;
@@ -87,7 +80,12 @@
   }
 }
 
-@media (max-width: 506px) {
+@include media-breakpoint-down(xs) {
+  .puzzle-view-controls>* {
+    width: 100%;
+    margin-right: 0;
+  }
+
   .puzzle-list-link-label {
     display: none;
   }

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -49,10 +49,12 @@ import TagList from './TagList';
 const FilteredChatFields: ('_id' | 'puzzle' | 'text' | 'sender' | 'timestamp')[] = ['_id', 'puzzle', 'text', 'sender', 'timestamp'];
 type FilteredChatMessageType = Pick<ChatMessageType, typeof FilteredChatFields[0]>
 
-const MinimumDesktopWidth = 600;
-const MinimumSidebarWidth = 150;
-const MinimumDocumentWidth = 375;
+// It doesn't need to be, but this is consistent with the 576px transition used in other pages' css
+const MinimumSidebarWidth = 176;
+const MinimumDocumentWidth = 400;
 const DefaultSidebarWidth = 300;
+
+const MinimumDesktopWidth = MinimumSidebarWidth + MinimumDocumentWidth;
 
 // PuzzlePage has some pretty unique properties:
 //


### PR DESCRIPTION
Previously, viewport width breakpoints were determined on a per-component basis. They're all close enough, however, that I think it makes more sense to have everything switch at common points and Bootstrap's default 576px sm breakpoint is a pretty good choice.

Dropped the old very small breakpoint responsible for hiding link text on phone-sized displays. With the viewers data moved elsewhere, there's plenty of space even on 320px wide viewports (and I don't think there's much to be gained by targeting devices narrower than that).

It's a deliberate choice not to use Bootstrap's `d-` classes in the couple of places where they could have worked in here. My preference is to keep that behavior together in the stylesheets (especially since we have a fair amount of more complicated breakpoint styling) and it's easy to consistently reference the Bootstrap breakpoints.