### PR TITLE
Fix emoji font usage

### DIFF
--- a/client/stylesheets/_theme.scss
+++ b/client/stylesheets/_theme.scss
@@ -1,5 +1,5 @@
-$font-family-sans-serif: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Arial", sans-serif, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
-$font-family-monospace: "Source Code Pro", "Consolas", "Monaco", monospace, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
+$font-family-sans-serif: "Platform Emoji", "Source Sans Pro", "Helvetica Neue", "Helvetica", "Arial", sans-serif, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
+$font-family-monospace: "Platform Emoji", "Source Code Pro", "Consolas", "Monaco", monospace, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
 $font-family-base: $font-family-sans-serif;
 
 $navbar-padding-y: 0;

--- a/client/stylesheets/app.scss
+++ b/client/stylesheets/app.scss
@@ -3,6 +3,12 @@
 // Answer monospace font
 @import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@300&display=swap');
 
+@font-face {
+  font-family: "Platform Emoji";
+  src: local("Noto Color Emoji"), local("Apple Color Emoji"), local("Segoe UI Emoji");
+  unicode-range: U+1F300-1FAFF, U+1F100-1F1FF, U+200D, U+2300-23FF, U+2600-27BF;
+}
+
 @import "theme";
 @import "../../node_modules/bootstrap/scss/bootstrap";
 

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -114,15 +114,9 @@ table.puzzle-list {
   }
 }
 
-@font-face {
-  font-family: "Platform Emoji";
-  src: "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji";
-  unicode-range: U+1F300-1FAFF, U+1F100-1F1FF, U+2300-23FF, U+2600-27BF;
-}
-
 .answer, #jr-puzzle-guess {
   text-transform: uppercase;
-  font-family: "Platform Emoji", $font-family-monospace;
+  font-family: $font-family-monospace;
   font-weight: 300;
 }
 


### PR DESCRIPTION
The "Platform Emoji" font-family was never getting used, because we were not
specifying valid `src` declarations for local fonts.  If a bare string is
provided, it is interpreted as a URL; we must specify `local()` to imply a
system-local font.

Once we started applying `local()` correctly, I found that we were missing the
ZWJ character needed to display the Jolly Roger pirate flag character: 🏴‍☠️
so I added it to the `unicode-range` for Platform Emoji.

Promoting "Platform Emoji" to lead the Bootstrap theme font families means that
we get reasonable emoji behavior throughout the app -- we'll use the platform
emoji fonts for those unicode ranges, and fall back to Source Sans Pro (or
Source Code Pro for monospace usages), and then try emoji fonts one more time
in case we missed the unicode-range in Platform Emoji and the other fonts don't
provide those glyphs.  This way we get consistent emoji support in puzzle
titles, input boxes, and so on, even if the Source fonts or monospace fonts
provide (poor, black-and-white) glyphs for those codepoints.