### PR TITLE
Fix tag editor in puzzle creation modal

### DIFF
--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -102,12 +102,24 @@ class PuzzleModalForm extends React.Component<PuzzleModalFormProps, PuzzleModalF
     });
   };
 
-  onTagsChange = (value: {label: string, value: string}[] | undefined | null) => {
-    if (!value) {
-      return;
+  onTagsChange = (value: {label: string, value: string}[] | undefined | null, action: { action: string }) => {
+    let newTags = [];
+    switch (action.action) {
+      case 'clear':
+      case 'create-option':
+      case 'deselect-option':
+      case 'pop-value':
+      case 'remove-value':
+      case 'select-option':
+      case 'set-value':
+        newTags = value ? value.map((v) => v.value) : [];
+        break;
+      default:
+        return;
     }
+
     this.setState({
-      tags: value.map((v) => v.value),
+      tags: newTags,
       tagsDirty: true,
     });
   };


### PR DESCRIPTION
https://react-select.com/props explains a bit more about what arguments we get
passed here.  We should treat "no value" as "empty list", and otherwise update
the tags list in our state with whatever the callback says we have now.

Fixes #372.