### PR TITLE
Fix navbar breadcrumb padding and iframe border

### DIFF
--- a/client/stylesheets/breadcrumbs.scss
+++ b/client/stylesheets/breadcrumbs.scss
@@ -1,6 +1,7 @@
 $breadcrumb-line-height: 22px;
 $breadcrumb-max-lines: 2;
 $breadcrumb-indent: 1rem;
+$breadcrumb-padding-x: 0.75rem;
 
 .jolly-roger .nav-breadcrumbs {
   display: flex;
@@ -15,9 +16,8 @@ $breadcrumb-indent: 1rem;
     max-height: 100%;
     overflow: hidden;
     text-indent: (0 - $breadcrumb-indent);
-    margin: 0 0 0 $breadcrumb-indent;
-    padding-top: 0;
-    padding-bottom: 0;
+    padding: 0 $breadcrumb-padding-x 0 $breadcrumb-padding-x + $breadcrumb-indent;
+    margin: 0;
 
     li {
       display: inline;

--- a/client/stylesheets/breadcrumbs.scss
+++ b/client/stylesheets/breadcrumbs.scss
@@ -1,6 +1,6 @@
 $breadcrumb-line-height: 22px;
 $breadcrumb-max-lines: 2;
-$breadcrumb-indent: 2ch;
+$breadcrumb-indent: 1rem;
 
 .jolly-roger .nav-breadcrumbs {
   display: flex;

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -573,6 +573,7 @@ table.puzzle-list {
   right: 0;
   bottom: 0;
   left: 0;
+  border: 0;
 }
 
 .popover.related-puzzle-popover {


### PR DESCRIPTION
Collection of minor fixes:
- Remove border around the iframe (bug introduced in bae327a)
- Fix a issue with the navbar breadcrumb padding in Safari
- Reduce navbar breadcrumb padding