### PR TITLE
Puzzle metadata pane cleanup

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -123,6 +123,11 @@ table.puzzle-list {
 // Tags
 .tag-list {
   display: inline;
+
+  .tag-editor {
+    display: inline;
+    min-width: 200px;
+  }
 }
 
 .tag {
@@ -517,6 +522,11 @@ table.puzzle-list {
   align-items: flex-start;
   align-content: flex-start;
   flex-wrap: wrap;
+
+  .tag-editor {
+    flex-basis: 100%;
+    margin: 2px 0;
+  }
 }
 
 .puzzle-metadata-row .btn {

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -1,5 +1,9 @@
 @import "theme";
 
+$solved-puzzle-background-color: #dfffdf;
+$unsolved-puzzle-background-color: #f0f0f0;
+$administrivia-puzzle-background-color: #dfdfff;
+
 // Puzzle components helper styles
 // Puzzle lists/tables
 .puzzle-group:not(:last-child) {
@@ -20,15 +24,15 @@
 
 .puzzle {
   &.unsolved {
-    background-color: #f0f0f0;
+    background-color: $unsolved-puzzle-background-color;
   }
 
   &.solved {
-    background-color: #dfffdf;
+    background-color: $solved-puzzle-background-color;
   }
 
   &.administrivia {
-    background-color: #dfdfff;
+    background-color: $administrivia-puzzle-background-color;
   }
 }
 
@@ -502,7 +506,7 @@ table.puzzle-list {
     margin-left: 2px;
     padding: 0 6px;
     border-radius: 4px;
-    background-color: #00ff00;
+    background-color: $solved-puzzle-background-color;
     color: #000000;
     display: flex;
 

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -181,13 +181,11 @@ table.puzzle-list {
 }
 
 .tag .btn.tag-remove-button {
-  height: 18px;
-  line-height: 16px;
-  width: 18px;
+  height: 16px;
+  width: 16px;
+  line-height: 10px;
+  font-size: 10px;
   padding: 0;
-  display: inline-block;
-  vertical-align: middle;
-  text-align: center;
   margin: 0 0 0 6px;
 }
 

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -134,7 +134,7 @@ table.puzzle-list {
   }
 }
 
-.tag {
+.tag, .tag-like {
   display: inline-flex;
   align-items: center;
   line-height: 24px;
@@ -474,41 +474,41 @@ table.puzzle-list {
   display: flex;
   width: 100%;
   font-size: 14px;
-  line-height: 28px;
   align-items: flex-start;
   align-content: flex-start;
   justify-content: space-between;
 }
 
-.puzzle-metadata-title-set {
-  flex: 0 0 auto;
+.puzzle-metadata-action-row {
+  align-items: center;
+  flex-wrap: nowrap;
 
-  .puzzle-metadata-title {
-    font-weight: bold;
+  a {
+    margin-right: 8px;
+  }
+
+  button {
+    margin: 2px 0 2px 8px;
+
+    &:first-of-type {
+      margin-left: auto;
+    }
   }
 }
 
-.puzzle-metadata .view-count {
-  cursor: pointer;
-  white-space: nowrap;
+.puzzle-metadata-row .puzzle-metadata-answers, .puzzle-metadata-row .tag-list {
+  display: flex;
+  flex-grow: 1;
+  justify-content: flex-start;
+  align-items: flex-start;
+  align-content: flex-start;
+  flex-wrap: wrap;
 }
 
-.puzzle-metadata-answers {
-  flex: 1 1 auto;
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  flex-wrap: wrap;
-
+.puzzle-metadata-row .puzzle-metadata-answers {
   .answer {
-    line-height: 24px;
-    height: 28px;
-    margin-left: 2px;
-    padding: 0 6px;
-    border-radius: 4px;
     background-color: $solved-puzzle-background-color;
     color: #000000;
-    display: flex;
 
     .answer-remove-button {
       color: default;
@@ -519,30 +519,18 @@ table.puzzle-list {
   }
 }
 
-.puzzle-metadata .tag-list {
-  display: flex;
-  flex-grow: 1;
-  justify-content: flex-start;
-  align-items: flex-start;
-  align-content: flex-start;
-  flex-wrap: wrap;
+.puzzle-metadata-row .tag-list {
+  .tag-modify-button {
+    line-height: 22px;
+    padding: 0 6px;
+    margin: 2px 0;
+    position: relative;
+  }
 
   .tag-editor {
     flex-basis: 100%;
     margin: 2px 0;
   }
-}
-
-.puzzle-metadata-row .btn {
-  line-height: 22px;
-  padding: 0 6px;
-  margin: 2px 0;
-  border-width: 1px;
-  display: inline-block;
-}
-
-.puzzle-metadata-action-row {
-  flex-wrap: wrap;
 }
 
 .puzzle-metadata .puzzle-metadata-external-link-button, .puzzle-metadata .gdrive-button {
@@ -552,7 +540,7 @@ table.puzzle-list {
 }
 
 @media (any-pointer: fine) {
-  .puzzle-metadata .tablet-only {
+  .tablet-only {
     display: none;
   }
 }

--- a/imports/client/components/Documents.tsx
+++ b/imports/client/components/Documents.tsx
@@ -44,11 +44,9 @@ class GoogleDocumentDisplay extends React.Component<DocumentDisplayProps> {
         return (
           <DeepLink className="gdrive-button" nativeUrl={deepUrl} browserUrl={url}>
             <a href={url} target="new">
-              <span className="linkLabel">
-                {title}
-                {' '}
-              </span>
               <FontAwesomeIcon fixedWidth icon={icon} />
+              {' '}
+              <span className="link-label">{title}</span>
             </a>
           </DeepLink>
         );

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -444,7 +444,7 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
     const correctGuesses = this.props.guesses.filter((guess) => guess.state === 'correct');
     const numGuesses = this.props.guesses.length;
 
-    const answersElement = correctGuesses.length > 0 && (
+    const answersElement = correctGuesses.length > 0 ? (
       <span className="puzzle-metadata-answers">
         {
           correctGuesses.map((guess) => (
@@ -457,9 +457,9 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
           ))
         }
       </span>
-    );
+    ) : null;
 
-    const puzzleLink = this.props.puzzle.url && (
+    const puzzleLink = this.props.puzzle.url ? (
       <a
         className="puzzle-metadata-external-link-button"
         href={this.props.puzzle.url}
@@ -470,24 +470,25 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
         {' '}
         <span className="link-label">Puzzle</span>
       </a>
-    );
+    ) : null;
 
-    const documentLink = this.props.document && (
+    const documentLink = this.props.document ? (
       <span className={classnames(this.props.isDesktop && 'tablet-only')}>
         <DocumentDisplay document={this.props.document} displayMode="link" />
       </span>
-    );
+    ) : null;
 
-    const editButton = this.props.canUpdate && (
+    const editButton = this.props.canUpdate ? (
       <Button onClick={this.showEditModal} variant="secondary" size="sm" title="Edit puzzle...">
         <FontAwesomeIcon icon={faEdit} />
         {' '}
         Edit
       </Button>
-    );
+    ) : null;
 
-    const guessButton = !isAdministrivia && (
-      this.props.hasGuessQueue ? (
+    let guessButton = null;
+    if (!isAdministrivia) {
+      guessButton = this.props.hasGuessQueue ? (
         <>
           <Button variant="primary" size="sm" className="puzzle-metadata-guess-button" onClick={this.showGuessModal}>
             <FontAwesomeIcon icon={faKey} />
@@ -514,8 +515,8 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
             puzzle={this.props.puzzle}
           />
         </>
-      )
-    );
+      );
+    }
 
     return (
       <div className="puzzle-metadata">

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -437,25 +437,14 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
     this.editModalRef.current!.show();
   };
 
-  editButton = () => {
-    if (this.props.canUpdate) {
-      return (
-        <Button onClick={this.showEditModal} variant="secondary" size="sm" title="Edit puzzle...">
-          <FontAwesomeIcon icon={faEdit} />
-          {' '}
-          Edit
-        </Button>
-      );
-    }
-    return null;
-  };
-
   render() {
     const tagsById = _.indexBy(this.props.allTags, '_id');
     const tags = this.props.puzzle.tags.map((tagId) => { return tagsById[tagId]; }).filter(Boolean);
     const isAdministrivia = tags.find((t) => t.name === 'administrivia');
     const correctGuesses = this.props.guesses.filter((guess) => guess.state === 'correct');
-    const answersElement = correctGuesses.length > 0 ? (
+    const numGuesses = this.props.guesses.length;
+
+    const answersElement = correctGuesses.length > 0 && (
       <span className="puzzle-metadata-answers">
         {
           correctGuesses.map((guess) => (
@@ -468,8 +457,65 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
           ))
         }
       </span>
-    ) : null;
-    const numGuesses = this.props.guesses.length;
+    );
+
+    const puzzleLink = this.props.puzzle.url && (
+      <a
+        className="puzzle-metadata-external-link-button"
+        href={this.props.puzzle.url}
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        <FontAwesomeIcon fixedWidth icon={faPuzzlePiece} />
+        {' '}
+        <span className="link-label">Puzzle</span>
+      </a>
+    );
+
+    const documentLink = this.props.document && (
+      <span className={classnames(this.props.isDesktop && 'tablet-only')}>
+        <DocumentDisplay document={this.props.document} displayMode="link" />
+      </span>
+    );
+
+    const editButton = this.props.canUpdate && (
+      <Button onClick={this.showEditModal} variant="secondary" size="sm" title="Edit puzzle...">
+        <FontAwesomeIcon icon={faEdit} />
+        {' '}
+        Edit
+      </Button>
+    );
+
+    const guessButton = !isAdministrivia && (
+      this.props.hasGuessQueue ? (
+        <>
+          <Button variant="primary" size="sm" className="puzzle-metadata-guess-button" onClick={this.showGuessModal}>
+            <FontAwesomeIcon icon={faKey} />
+            {' Guess '}
+            <Badge variant="light">{numGuesses}</Badge>
+          </Button>
+          {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
+          <PuzzleGuessModal
+            ref={this.guessModalRef}
+            puzzle={this.props.puzzle}
+            guesses={this.props.guesses}
+            displayNames={this.props.displayNames}
+          />
+        </>
+      ) : (
+        <>
+          <Button variant="primary" size="sm" className="puzzle-metadata-answer-button" onClick={this.showAnswerModal}>
+            <FontAwesomeIcon icon={faKey} />
+            {' Answer'}
+          </Button>
+          {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
+          <PuzzleAnswerModal
+            ref={this.answerModalRef}
+            puzzle={this.props.puzzle}
+          />
+        </>
+      )
+    );
 
     return (
       <div className="puzzle-metadata">
@@ -482,58 +528,10 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
           onSubmit={this.onEdit}
         />
         <div className="puzzle-metadata-row puzzle-metadata-action-row">
-          {this.props.puzzle.url && (
-            <a
-              className="puzzle-metadata-external-link-button"
-              href={this.props.puzzle.url}
-              target="_blank"
-              rel="noreferrer noopener"
-            >
-              <FontAwesomeIcon fixedWidth icon={faPuzzlePiece} />
-              {' '}
-              <span className="link-label">Puzzle</span>
-            </a>
-          )}
-          {this.props.document && (
-            <span className={classnames(this.props.isDesktop && 'tablet-only')}>
-              <DocumentDisplay document={this.props.document} displayMode="link" />
-            </span>
-          )}
-          {this.editButton()}
-          {
-            !isAdministrivia && (
-              this.props.hasGuessQueue ?
-                (
-                  <>
-                    <Button variant="primary" size="sm" className="puzzle-metadata-guess-button" onClick={this.showGuessModal}>
-                      <FontAwesomeIcon icon={faKey} />
-                      {' Guess '}
-                      <Badge variant="light">{numGuesses}</Badge>
-                    </Button>
-                    {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
-                    <PuzzleGuessModal
-                      ref={this.guessModalRef}
-                      puzzle={this.props.puzzle}
-                      guesses={this.props.guesses}
-                      displayNames={this.props.displayNames}
-                    />
-                  </>
-                ) :
-                (
-                  <>
-                    <Button variant="primary" size="sm" className="puzzle-metadata-answer-button" onClick={this.showAnswerModal}>
-                      <FontAwesomeIcon icon={faKey} />
-                      {' Answer'}
-                    </Button>
-                    {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
-                    <PuzzleAnswerModal
-                      ref={this.answerModalRef}
-                      puzzle={this.props.puzzle}
-                    />
-                  </>
-                )
-            )
-          }
+          {puzzleLink}
+          {documentLink}
+          {editButton}
+          {guessButton}
         </div>
         <div className="puzzle-metadata-row">
           {answersElement}

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -503,11 +503,9 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
               target="_blank"
               rel="noreferrer noopener"
             >
-              <span className="linkLabel">
-                Puzzle
-                {' '}
-              </span>
               <FontAwesomeIcon fixedWidth icon={faPuzzlePiece} />
+              {' '}
+              <span className="link-label">Puzzle</span>
             </a>
           )}
           {this.props.document && (

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -2,7 +2,12 @@ import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { withTracker } from 'meteor/react-meteor-data';
 import { _ } from 'meteor/underscore';
-import { faEdit, faPuzzlePiece, faPaperPlane } from '@fortawesome/free-solid-svg-icons';
+import {
+  faEdit,
+  faPuzzlePiece,
+  faPaperPlane,
+  faKey,
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 import DOMPurify from 'dompurify';
@@ -10,6 +15,7 @@ import marked from 'marked';
 import moment from 'moment';
 import React from 'react';
 import Alert from 'react-bootstrap/Alert';
+import Badge from 'react-bootstrap/Badge';
 import Button from 'react-bootstrap/Button';
 import Col from 'react-bootstrap/Col';
 import FormControl, { FormControlProps } from 'react-bootstrap/FormControl';
@@ -434,8 +440,10 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
   editButton = () => {
     if (this.props.canUpdate) {
       return (
-        <Button onClick={this.showEditModal} variant="outline-secondary" size="sm" title="Edit puzzle...">
+        <Button onClick={this.showEditModal} variant="secondary" size="sm" title="Edit puzzle...">
           <FontAwesomeIcon icon={faEdit} />
+          {' '}
+          Edit
         </Button>
       );
     }
@@ -447,11 +455,11 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
     const tags = this.props.puzzle.tags.map((tagId) => { return tagsById[tagId]; }).filter(Boolean);
     const isAdministrivia = tags.find((t) => t.name === 'administrivia');
     const correctGuesses = this.props.guesses.filter((guess) => guess.state === 'correct');
-    const answerComponent = correctGuesses.length > 0 ? (
+    const answersElement = correctGuesses.length > 0 ? (
       <span className="puzzle-metadata-answers">
         {
           correctGuesses.map((guess) => (
-            <span key={`answer-${guess._id}`} className="answer">
+            <span key={`answer-${guess._id}`} className="answer tag-like">
               <span>{guess.guess}</span>
               {!this.props.hasGuessQueue && (
                 <Button className="answer-remove-button" variant="success" onClick={() => this.onRemoveAnswer(guess._id)}>&#10006;</Button>
@@ -473,28 +481,6 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
           tags={this.props.allTags}
           onSubmit={this.onEdit}
         />
-        <div className="puzzle-metadata-row">
-          <div className="puzzle-metadata-title-set">
-            {this.editButton()}
-            {' '}
-            <span className="puzzle-metadata-title">{this.props.puzzle.title}</span>
-          </div>
-          {this.props.puzzle.answers.length > 0 && answerComponent}
-        </div>
-        <div className={classnames('puzzle-metadata-row', this.props.isDesktop && 'puzzle-metadata-tag-editor-row')}>
-          <TagList
-            puzzle={this.props.puzzle}
-            tags={tags}
-            onCreateTag={this.onCreateTag}
-            onRemoveTag={this.onRemoveTag}
-            linkToSearch={false}
-            showControls={this.props.isDesktop}
-            popoverRelated
-            allPuzzles={this.props.allPuzzles}
-            allTags={this.props.allTags}
-            emptyMessage="No tags yet"
-          />
-        </div>
         <div className="puzzle-metadata-row puzzle-metadata-action-row">
           {this.props.puzzle.url && (
             <a
@@ -513,13 +499,16 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
               <DocumentDisplay document={this.props.document} displayMode="link" />
             </span>
           )}
+          {this.editButton()}
           {
             !isAdministrivia && (
               this.props.hasGuessQueue ?
                 (
                   <>
-                    <Button variant="primary" className="puzzle-metadata-guess-button" onClick={this.showGuessModal}>
-                      { this.props.puzzle.answers.length >= this.props.puzzle.expectedAnswerCount ? `See ${numGuesses} ${numGuesses === 1 ? 'guess' : 'guesses'}` : `Guess (${numGuesses} so far)` }
+                    <Button variant="primary" size="sm" className="puzzle-metadata-guess-button" onClick={this.showGuessModal}>
+                      <FontAwesomeIcon icon={faKey} />
+                      {' Guess '}
+                      <Badge variant="light">{numGuesses}</Badge>
                     </Button>
                     {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
                     <PuzzleGuessModal
@@ -532,8 +521,9 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
                 ) :
                 (
                   <>
-                    <Button variant="primary" className="puzzle-metadata-answer-button" onClick={this.showAnswerModal}>
-                      {`Answer${this.props.puzzle.answers.length > 0 ? ` (${this.props.puzzle.answers.length} so far)` : ''}`}
+                    <Button variant="primary" size="sm" className="puzzle-metadata-answer-button" onClick={this.showAnswerModal}>
+                      <FontAwesomeIcon icon={faKey} />
+                      {' Answer'}
                     </Button>
                     {/* eslint-disable-next-line @typescript-eslint/no-use-before-define */}
                     <PuzzleAnswerModal
@@ -544,6 +534,23 @@ class PuzzlePageMetadata extends React.Component<PuzzlePageMetadataProps> {
                 )
             )
           }
+        </div>
+        <div className="puzzle-metadata-row">
+          {answersElement}
+        </div>
+        <div className="puzzle-metadata-row">
+          <TagList
+            puzzle={this.props.puzzle}
+            tags={tags}
+            onCreateTag={this.onCreateTag}
+            onRemoveTag={this.onRemoveTag}
+            linkToSearch={false}
+            showControls={this.props.isDesktop}
+            popoverRelated
+            allPuzzles={this.props.allPuzzles}
+            allTags={this.props.allTags}
+            emptyMessage="No tags yet"
+          />
         </div>
       </div>
     );

--- a/imports/client/components/Tag.tsx
+++ b/imports/client/components/Tag.tsx
@@ -1,3 +1,5 @@
+import { faTimes } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { detectOverflow } from '@popperjs/core';
 import type { ModifierArguments, Modifier, Padding } from '@popperjs/core';
 import classnames from 'classnames';
@@ -160,7 +162,7 @@ class Tag extends React.Component<TagProps, TagState> {
         {title}
         {this.props.onRemove && (
           <Button className="tag-remove-button" variant="danger" onClick={this.onRemove}>
-            &#10006;
+            <FontAwesomeIcon icon={faTimes} />
           </Button>
         )}
       </div>

--- a/imports/client/components/TagEditor.tsx
+++ b/imports/client/components/TagEditor.tsx
@@ -31,7 +31,7 @@ class TagEditor extends React.Component<TagEditorProps> {
       });
 
     return (
-      <span style={{ display: 'inline-block', minWidth: '200px' }}>
+      <span className="tag-editor">
         <Creatable
           options={options}
           autoFocus


### PR DESCRIPTION
Cleanup the puzzle metadata pane:

- Remove redundant title text and rearrange remaining content (see below)
- Move icons to the left of link text, for consistency
- Restore button height to the natural btn-sm styles and add an icon to the guess button, making them more obviously buttons. Previously, button height was reduced to fit them comfortably on the same row as text, but given the very flat theme and the similarly styled tags nearby, functionality was potentially ambiguous.
- Move verbose guess count text into a button badge
- Change answer background color to match the desaturated green used for solved puzzles elsewhere, both for consistency and to further distinguish answers from buttons
- Move the tag editor (the add tag interface) to its own line, avoiding the layout oddity of the editor increasing the height of the tag list
- Fix the formatting of tag remove buttons
- Refactor the metadata render method, to improve legibility

![metadata](https://user-images.githubusercontent.com/2136874/103448839-405e4c00-4c6d-11eb-8f0b-946d1b0fb57a.png)

Per conversation with @zarvox, this removes the redundant title from the metadata pane. The remainder of that line then needs to be accommodated elsewhere, but the result is (usually) more compact than before (two lines for unsolved puzzles), freeing a little space for the document. The new layout (consistent across screen widths) is:

1. Puzzle and document links, edit button, guess button (between 0 and 4 of these may be present depending on puzzle type, layout type, and viewer's role)
2. Answers (if solved)
3. Tags

This does represent a reorganization of a familiar layout. My goals were as follows:
- Action buttons and links should stay together, in a consistent location unaffected by line wraps (i.e. either the first row or the last)
- Answers should remain prominent and predictably placed. Long or multiple answers should behave predictably.
- The tag list works well in the bottom row, where the new popover can only occlude the document