### PR TITLE
Make viewer and caller lists collapsible

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -302,21 +302,15 @@ table.puzzle-list {
 }
 
 .chatter-subsection {
-  position: relative;
-  padding-top: 6px;
-
   header {
-    position: absolute;
-    top: 6px;
-    left: 2px;
-    z-index: 20;
+    margin: 4px 2px;
+    cursor: pointer;
   }
 
   .people-list {
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-end;
-    min-height: 12px; // So that when there's no people it doesn't collapse entirely
   }
 
   .people-item {

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -311,6 +311,10 @@ table.puzzle-list {
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-end;
+
+    &.collapsed {
+      display: none;
+    }
   }
 
   .people-item {

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -156,24 +156,22 @@ class RTCCallSection extends React.Component<RTCCallSectionProps> {
             <FontAwesomeIcon fixedWidth icon={callersHeaderIcon} />
             {`${callerCount} caller${callerCount !== 1 ? 's' : ''}`}
           </header>
-          {this.props.callersExpanded && (
-            <div className="people-list">
-              {this.renderSelfBox()}
-              {this.props.signalsReady && this.props.selfParticipant && others.map((p) => {
-                return (
-                  <CallLinkBox
-                    key={p._id}
-                    rtcConfig={this.props.rtcConfig!}
-                    selfParticipant={this.props.selfParticipant!}
-                    peerParticipant={p}
-                    localStream={this.props.localStream}
-                    audioContext={this.props.audioContext}
-                    deafened={this.props.deafened}
-                  />
-                );
-              })}
-            </div>
-          )}
+          <div className={classnames('people-list', { collapsed: !this.props.callersExpanded })}>
+            {this.renderSelfBox()}
+            {this.props.signalsReady && this.props.selfParticipant && others.map((p) => {
+              return (
+                <CallLinkBox
+                  key={p._id}
+                  rtcConfig={this.props.rtcConfig!}
+                  selfParticipant={this.props.selfParticipant!}
+                  peerParticipant={p}
+                  localStream={this.props.localStream}
+                  audioContext={this.props.audioContext}
+                  deafened={this.props.deafened}
+                />
+              );
+            })}
+          </div>
         </div>
       </>
     );

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -1,6 +1,11 @@
 import { Meteor } from 'meteor/meteor';
 import { withTracker } from 'meteor/react-meteor-data';
-import { faMicrophoneSlash, faVolumeMute } from '@fortawesome/free-solid-svg-icons';
+import {
+  faMicrophoneSlash,
+  faVolumeMute,
+  faCaretDown,
+  faCaretRight,
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 import React from 'react';
@@ -27,6 +32,8 @@ interface RTCCallSectionParams {
   deafened: boolean;
   audioContext: AudioContext;
   localStream: MediaStream;
+  callersExpanded: boolean;
+  onToggleCallersExpanded(): void;
 }
 
 interface RTCCallSectionProps extends RTCCallSectionParams {
@@ -123,6 +130,8 @@ class RTCCallSection extends React.Component<RTCCallSectionProps> {
     const callerCount = this.props.participants.length;
     const others = this.nonSelfParticipants();
 
+    const callersHeaderIcon = this.props.callersExpanded ? faCaretDown : faCaretRight;
+
     return (
       <>
         <div className="av-actions">
@@ -143,25 +152,28 @@ class RTCCallSection extends React.Component<RTCCallSectionProps> {
           <Button variant="danger" size="sm" onClick={this.leaveCall}>leave call</Button>
         </div>
         <div className="chatter-subsection av-chatters">
-          <header>
+          <header onClick={this.props.onToggleCallersExpanded}>
+            <FontAwesomeIcon fixedWidth icon={callersHeaderIcon} />
             {`${callerCount} caller${callerCount !== 1 ? 's' : ''}`}
           </header>
-          <div className="people-list">
-            {this.renderSelfBox()}
-            {this.props.signalsReady && this.props.selfParticipant && others.map((p) => {
-              return (
-                <CallLinkBox
-                  key={p._id}
-                  rtcConfig={this.props.rtcConfig!}
-                  selfParticipant={this.props.selfParticipant!}
-                  peerParticipant={p}
-                  localStream={this.props.localStream}
-                  audioContext={this.props.audioContext}
-                  deafened={this.props.deafened}
-                />
-              );
-            })}
-          </div>
+          {this.props.callersExpanded && (
+            <div className="people-list">
+              {this.renderSelfBox()}
+              {this.props.signalsReady && this.props.selfParticipant && others.map((p) => {
+                return (
+                  <CallLinkBox
+                    key={p._id}
+                    rtcConfig={this.props.rtcConfig!}
+                    selfParticipant={this.props.selfParticipant!}
+                    peerParticipant={p}
+                    localStream={this.props.localStream}
+                    audioContext={this.props.audioContext}
+                    deafened={this.props.deafened}
+                  />
+                );
+              })}
+            </div>
+          )}
         </div>
       </>
     );

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -3,6 +3,7 @@ import { Random } from 'meteor/random';
 import { withTracker } from 'meteor/react-meteor-data';
 import { faCaretDown, faCaretRight } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import classnames from 'classnames';
 import React, { ReactChild } from 'react';
 import Button from 'react-bootstrap/Button';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
@@ -333,11 +334,9 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
                 <FontAwesomeIcon fixedWidth icon={callersHeaderIcon} />
                 {`${rtcViewers.length} caller${rtcViewers.length !== 1 ? 's' : ''}`}
               </header>
-              {this.state.callersExpanded && (
-                <div className="people-list">
-                  {rtcViewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}-${viewer.tab}`} {...viewer} />)}
-                </div>
-              )}
+              <div className={classnames('people-list', { collapsed: !this.state.callersExpanded })}>
+                {rtcViewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}-${viewer.tab}`} {...viewer} />)}
+              </div>
             </div>
           </>
         );
@@ -394,11 +393,9 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
             <FontAwesomeIcon fixedWidth icon={viewersHeaderIcon} />
             {`${totalViewers} viewer${totalViewers !== 1 ? 's' : ''}`}
           </header>
-          {this.state.viewersExpanded && (
-            <div className="people-list">
-              {viewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}`} {...viewer} />)}
-            </div>
-          )}
+          <div className={classnames('people-list', { collapsed: !this.state.viewersExpanded })}>
+            {viewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}`} {...viewer} />)}
+          </div>
         </div>
       </section>
     );

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -125,7 +125,7 @@ class ChatPeople extends React.Component<ChatPeopleProps, ChatPeopleState> {
       muted: false,
       deafened: false,
       callersExpanded: true,
-      viewersExpanded: false,
+      viewersExpanded: true,
 
       audioContext: undefined,
       rawMediaSource: undefined,


### PR DESCRIPTION
The call pane can take up a lot of space when many players are viewing a puzzle. As this space is better used for chat, give players the option to collapse the lists of viewers and callers. The default state is expanded caller list and collapsed viewer list.

My original intent was to collapse the two together, permitting even more space savings when fully collapsed, as caller and viewer counts could be displayed on a single line. However, the natural interface for this is the familiar collapsing hierarchy from the puzzle list page and it's a little odd to link collapses in that presentation. Additionally, perhaps the most natural state is to see callers but not passing-through viewers. The independent controls require an extra line in the fully collapsed state, but I think the tradeoff is worthwhile.

As always, open to suggestions.