### PR TITLE
Cleanup future handling in lock implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -466,6 +466,12 @@
         "@types/range-parser": "*"
       }
     },
+    "@types/fibers": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/fibers/-/fibers-3.1.0.tgz",
+      "integrity": "sha512-1o3I9xtk2PZFxwaLCC6gTaBfBZ5rvw/DSZZPK89fwuwO6LNrzSbC6rEs1xI0bQ3fCRWmO+uNJQQeD2J56oTMDg==",
+      "dev": true
+    },
     "@types/history": {
       "version": "4.7.8",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/enzyme": "^3.10.7",
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "@types/express": "^4.17.8",
+    "@types/fibers": "^3.1.0",
     "@types/logfmt": "^1.2.1",
     "@types/marked": "^0.6.5",
     "@types/md5": "^2.2.0",


### PR DESCRIPTION
Any time that an event fires that will resolve the future, we want to make sure to clear all other watches so it doesn't resolve multiple times.

I think this should fix the error that @zarvox reported:

```
I20210102-01:38:47.423(-8)? Exception in removedobserveChanges callback: Error: Future resolved more than once
I20210102-01:38:47.423(-8)?     at Future.return (/home/zarvox/.meteor/packages/meteor-tool/.1.12.0.4zjno.40411w++os.linux.x86_64+web.browser+web.browser.legacy+web.cordova/mt-os.linux.x86_64/dev_bundle/server-lib/node_modules/fibers/future.js:261:10)
I20210102-01:38:47.423(-8)?     at removed (imports/server/models/lock.ts:58:13)
I20210102-01:38:47.424(-8)?     at runWithEnvironment (packages/meteor.js:1286:24)
I20210102-01:38:47.424(-8)?     at packages/meteor.js:1299:14
I20210102-01:38:47.424(-8)?     at packages/mongo/observe_multiplex.js:178:30
I20210102-01:38:47.424(-8)?     at Array.forEach (<anonymous>)
I20210102-01:38:47.425(-8)?     at Function._.each._.forEach (packages/underscore.js:139:11)
I20210102-01:38:47.425(-8)?     at Object.task (packages/mongo/observe_multiplex.js:172:9)
I20210102-01:38:47.426(-8)?     at Meteor._SynchronousQueue.SQp._run (packages/meteor.js:917:16)
I20210102-01:38:47.426(-8)?     at packages/meteor.js:894:12
```