### PR TITLE
Block until fully connected to Discord

### DIFF
--- a/imports/server/discord-client-refresher.ts
+++ b/imports/server/discord-client-refresher.ts
@@ -95,7 +95,9 @@ class DiscordClientRefresher {
 
           // Otherwise, if we get the lock, we're responsible for opening the
           // websocket gateway connection
-          MeteorPromise.await(client.login(this.botToken));
+          const ready = new Promise<void>((r) => client.on('ready', r));
+          client.login(this.botToken);
+          MeteorPromise.await(ready);
 
           while (client.token !== null && client.ws.status === Discord.Constants.Status.READY) {
             Locks.renew(lock);


### PR DESCRIPTION
I thought that `client.login` returned a promise that wasn't fulfilled until the
client was fully connected, but that doesn't seem to be the case. I observed
circumstances where the connection status was `IDLE` immediately after the
promise resolved, which would cause the connection management loop to exit
immediately, leaving nobody holding the gateway connection.

Instead use the ready event as a trigger.

@zarvox I think this fixes the issue you described where you could end up with no lock holder. (AIUI you also ended up with no gateway connection)