### PR TITLE
Add Discord puzzle created/solved hooks

### DIFF
--- a/imports/client/discord.ts
+++ b/imports/client/discord.ts
@@ -12,6 +12,15 @@ export type DiscordGuildType = {
 }
 export const DiscordGuilds = new Mongo.Collection<DiscordGuildType>('discord.guilds');
 
+// Pseudo-collection used by hunt config for selecting channel
+export type DiscordChannelType = {
+  _id: string;
+  name: string;
+  type: number;
+  position: number | undefined;
+}
+export const DiscordChannels = new Mongo.Collection<DiscordChannelType>('discord.channels');
+
 function requestDiscordCredential(credentialRequestCompleteCallback: any) {
   const options = {};
   const config = ServiceConfiguration.configurations.findOne({ service: 'discord' });

--- a/imports/lib/active-operator-role.ts
+++ b/imports/lib/active-operator-role.ts
@@ -2,5 +2,6 @@ import { Roles } from 'meteor/nicolaslopezj:roles';
 
 const ActiveOperatorRole = new Roles.Role('operator');
 ActiveOperatorRole.allow('users.makeOperator', () => true);
+ActiveOperatorRole.allow('discord.listChannels', () => true);
 
 export default ActiveOperatorRole;

--- a/imports/lib/roles.ts
+++ b/imports/lib/roles.ts
@@ -5,6 +5,7 @@ Roles.registerAction('google.configureOAuth', true);
 Roles.registerAction('hunt.join', true);
 Roles.registerAction('discord.configureOAuth', true);
 Roles.registerAction('discord.configureBot', true);
+Roles.registerAction('discord.listChannels', true);
 Roles.registerAction('users.makeOperator', true);
 Roles.registerAction('webrtc.configureServers', true);
 

--- a/imports/lib/schemas/hunts.ts
+++ b/imports/lib/schemas/hunts.ts
@@ -3,6 +3,13 @@ import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from './base';
 import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
 
+export const SavedDiscordChannelFields = t.type({
+  id: t.string,
+  name: t.string,
+});
+
+export type SavedDiscordChannelType = t.TypeOf<typeof SavedDiscordChannelFields>;
+
 const HuntFields = t.type({
   name: t.string,
   // Everyone that joins the hunt will be added to these mailing lists
@@ -22,7 +29,13 @@ const HuntFields = t.type({
   // (https://nodejs.org/api/url.html#url_class_url), which provides variables
   // like "host" and "pathname".
   submitTemplate: t.union([t.string, t.undefined]),
+  // If provided, then this is a link to the overall root hunt homepage and will
+  // be shown in the PuzzleListPage navbar.
   homepageUrl: t.union([t.string, t.undefined]),
+  // If provided, this is an object containing a Discord channel id and cached
+  // channel name (for local presentation) to which we should post puzzle
+  // create/solve messages as the server-configured Discord bot.
+  puzzleHooksDiscordChannel: t.union([SavedDiscordChannelFields, t.undefined]),
 });
 
 const HuntFieldsOverrides: Overrides<t.TypeOf<typeof HuntFields>> = {

--- a/imports/lib/schemas/public_settings.ts
+++ b/imports/lib/schemas/public_settings.ts
@@ -14,7 +14,7 @@ export const PublicSettingCodec = t.intersection([
       }),
     }),
     // TODO: not actually implemented/used yet, but I needed a second possible
-    // value for io-ts to not choke on this being premptively labeled a tagged
+    // value for io-ts to not choke on this being preemptively labeled a tagged
     // union
     t.type({
       name: t.literal('branding'),

--- a/imports/server/discord.ts
+++ b/imports/server/discord.ts
@@ -1,9 +1,12 @@
 import { HTTP } from 'meteor/http';
 import { Meteor } from 'meteor/meteor';
+import { Roles } from 'meteor/nicolaslopezj:roles';
 import { OAuth } from 'meteor/oauth';
 import { ServiceConfiguration } from 'meteor/service-configuration';
-// import Flags from '../flags'; // TODO: allow disabling via featureflag
+import Ansible from '../ansible';
+import Flags from '../flags';
 import { API_BASE, DiscordOAuthScopes } from '../lib/discord';
+import Settings from '../lib/models/settings';
 
 class DiscordAPIClient {
   private accessToken: string;
@@ -96,6 +99,38 @@ class DiscordBot {
       );
     }
   };
+
+  listGuildChannels = (guildId: string) => {
+    let response;
+    try {
+      const opts = {
+        ...this.authHeaders(),
+      };
+      response = HTTP.get(`${API_BASE}/guilds/${guildId}/channels`, opts);
+    } catch (err) {
+      throw Object.assign(
+        new Meteor.Error(`Failed to list channels of guild ${guildId}. ${err.message}`),
+        { response: err.response }
+      );
+    }
+
+    return response.data;
+  };
+
+  postMessageToChannel = (channelId: string, message: object) => {
+    try {
+      const opts = {
+        ...this.authHeaders(),
+        data: message,
+      };
+      HTTP.post(`${API_BASE}/channels/${channelId}/messages`, opts);
+    } catch (err) {
+      throw Object.assign(
+        new Meteor.Error(`Failed to post message to channel ${channelId}. ${err.message}`),
+        { response: err.response }
+      );
+    }
+  };
 }
 
 const handleOauthRequest = (query: any) => {
@@ -139,5 +174,66 @@ const handleOauthRequest = (query: any) => {
 };
 
 OAuth.registerService('discord', 2, null, handleOauthRequest);
+
+const cacheDuration = 5000;
+let channelsCache: any[] = [];
+let channelsCacheTimestamp = 0;
+
+Meteor.publish('discord.channels', function () {
+  if (!this.userId || !Roles.userHasPermission(this.userId, 'discord.listChannels')) {
+    Ansible.log('Sub to discord.channels not logged in as operator');
+    return [];
+  }
+
+  if (Flags.active('disable.discord')) {
+    return [];
+  }
+
+  const botSettings = Settings.findOne({ name: 'discord.bot' });
+  if (!botSettings || botSettings.name !== 'discord.bot') {
+    return [];
+  }
+
+  const token = botSettings.value && botSettings.value.token;
+  if (!token) {
+    Ansible.log('Sub to discord.channels: no bot token');
+    return [];
+  }
+
+  const guildSetting = Settings.findOne({ name: 'discord.guild' });
+  if (!guildSetting || guildSetting.name !== 'discord.guild') {
+    Ansible.log('No discord guild configured; will not enumerate channels');
+    return [];
+  }
+
+  const guildId = guildSetting.value && guildSetting.value.guild && guildSetting.value.guild._id;
+  if (!guildId) {
+    Ansible.log('No discord guild configured; will not enumerate channels');
+    return [];
+  }
+
+  // Fetch channels from the Discord API.
+  const bot = new DiscordBot(token);
+  if (Date.now() > channelsCacheTimestamp + cacheDuration) {
+    try {
+      channelsCache = bot.listGuildChannels(guildId);
+      channelsCacheTimestamp = Date.now();
+    } catch (err) {
+      Ansible.log('Sub to discord.channels: discord remote error', { err: JSON.stringify(err) });
+      return [];
+    }
+  }
+
+  channelsCache.forEach((channel: any) => {
+    this.added('discord.channels', channel.id, {
+      name: channel.name,
+      type: channel.type,
+      position: channel.position,
+    });
+  });
+  this.ready();
+  // eslint-disable-next-line
+  return;
+});
 
 export { DiscordAPIClient, DiscordBot };

--- a/imports/server/global-hooks.ts
+++ b/imports/server/global-hooks.ts
@@ -1,7 +1,9 @@
+import DiscordHooks from './hooks/discord-hooks';
 import HooksRegistry from './hooks/hooks-registry';
 
 // Instantiate the application-global hookset list.
 const GlobalHooks = new HooksRegistry();
-// Add all hooksets.  There are currently no hook implementations.
+// Add all hooksets.  Right now that's just Discord.
+GlobalHooks.addHookSet(DiscordHooks);
 
 export default GlobalHooks;

--- a/imports/server/hooks/discord-hooks.ts
+++ b/imports/server/hooks/discord-hooks.ts
@@ -1,0 +1,89 @@
+import { Meteor } from 'meteor/meteor';
+import Flags from '../../flags';
+import Hunts from '../../lib/models/hunts';
+import Puzzles from '../../lib/models/puzzles';
+import Settings from '../../lib/models/settings';
+import Tags from '../../lib/models/tags';
+import { DiscordBot } from '../discord';
+import Hookset from './hookset';
+
+function makeDiscordBotFromSettings(): DiscordBot | undefined {
+  // Above all else, obey the circuit breaker
+  if (Flags.active('disable.discord')) {
+    return undefined;
+  }
+
+  const botSettings = Settings.findOne({ name: 'discord.bot' });
+  if (!botSettings || botSettings.name !== 'discord.bot') {
+    return undefined;
+  }
+
+  const token = botSettings.value && botSettings.value.token;
+  if (!token) {
+    return undefined;
+  }
+
+  return new DiscordBot(token);
+}
+
+const DiscordHooks: Hookset = {
+  onPuzzleCreated(puzzleId: string) {
+    const bot = makeDiscordBotFromSettings();
+    if (!bot) {
+      return;
+    }
+
+    const puzzle = Puzzles.findOne(puzzleId)!;
+    const hunt = Hunts.findOne(puzzle.hunt)!;
+    if (hunt.puzzleHooksDiscordChannel) {
+      const title = `${puzzle.title} unlocked`;
+      const url = Meteor.absoluteUrl(`hunts/${puzzle.hunt}/puzzles/${puzzle._id}`);
+      const tagNameList = puzzle.tags.map((tId) => {
+        const t = Tags.findOne(tId);
+        return t ? t.name : '';
+      }).filter((t) => t.length > 0);
+      const tags = tagNameList.map((tagName) => `\`${tagName}\``).join(', ');
+      const messageObj = {
+        embed: {
+          title,
+          url,
+          fields: [
+            { name: 'Tags', value: tags, inline: true },
+          ],
+        },
+      };
+      bot.postMessageToChannel(hunt.puzzleHooksDiscordChannel.id, messageObj);
+    }
+  },
+
+  onPuzzleSolved(puzzleId: string) {
+    const bot = makeDiscordBotFromSettings();
+    if (!bot) {
+      return;
+    }
+
+    const puzzle = Puzzles.findOne(puzzleId)!;
+    const hunt = Hunts.findOne(puzzle.hunt)!;
+    if (hunt.puzzleHooksDiscordChannel) {
+      const url = Meteor.absoluteUrl(`hunts/${puzzle.hunt}/puzzles/${puzzle._id}`);
+      const answers = puzzle.answers.map((answer) => `\`${answer}\``).join(', ');
+      const answerLabel = `Answer${puzzle.expectedAnswerCount > 1 ? 's' : ''}`;
+      const completed = puzzle.answers.length === puzzle.expectedAnswerCount;
+      const color = completed ? 0x00ff00 : 0xffff00;
+      const title = `${puzzle.title} ${completed ? '' : 'partially'} solved`;
+      const messageObj = {
+        embed: {
+          color,
+          title,
+          url,
+          fields: [
+            { name: answerLabel, value: answers, inline: true },
+          ],
+        },
+      };
+      bot.postMessageToChannel(hunt.puzzleHooksDiscordChannel.id, messageObj);
+    }
+  },
+};
+
+export default DiscordHooks;

--- a/imports/server/models/lock.ts
+++ b/imports/server/models/lock.ts
@@ -63,7 +63,7 @@ const Locks = new class extends Mongo.Collection<LockType> {
         const cursor = this.find({ name });
 
         // Setup the watch now so we don't race between when we check
-        // for the lock and when we wait for premption
+        // for the lock and when we wait for preemption
         const removed = new Future<LockType | undefined>();
         handle = cursor.observeChanges({
           removed() {
@@ -102,7 +102,7 @@ const Locks = new class extends Mongo.Collection<LockType> {
         // If we time out, then preempt
         const preemptableLock = removed.wait();
         if (preemptableLock) {
-          Ansible.log('Prempting lock', { id: preemptableLock._id, name });
+          Ansible.log('Preempting lock', { id: preemptableLock._id, name });
           this.remove({ _id: preemptableLock._id, renewedAt: preemptableLock.renewedAt });
         }
       } finally {

--- a/imports/server/setup.ts
+++ b/imports/server/setup.ts
@@ -252,7 +252,7 @@ Meteor.publish('discord.guilds', function () {
   try {
     guilds = bot.listGuilds();
   } catch (err) {
-    Ansible.log('Sub to discord.guilds: discord remote error', { err });
+    Ansible.log('Sub to discord.guilds: discord remote error', { err: JSON.stringify(err) });
     return [];
   }
 


### PR DESCRIPTION
This adds:

* an optional object in Hunt for the id and name of a Discord channel
* a server-side publish to list Discord channels, guarded by
* a permission `discord.listChannels`, granted to operators
* UI to select the channel from a dropdown
* hook implementations to post a message to the channel when a puzzle
  is added or solved, with a link to the Jolly Roger page for the puzzle

There's a couple other commits for some related code cleanups.

Example renderings:

![Screenshot_20210102_211923](https://user-images.githubusercontent.com/307325/103472252-4cffa480-4d40-11eb-8a29-25a989f9d0db.png)
