### PR TITLE
Cache Discord API objects from the gateway

### DIFF
--- a/imports/lib/active-operator-role.ts
+++ b/imports/lib/active-operator-role.ts
@@ -3,5 +3,6 @@ import { Roles } from 'meteor/nicolaslopezj:roles';
 const ActiveOperatorRole = new Roles.Role('operator');
 ActiveOperatorRole.allow('users.makeOperator', () => true);
 ActiveOperatorRole.allow('discord.listChannels', () => true);
+ActiveOperatorRole.allow('discord.viewCache', () => true);
 
 export default ActiveOperatorRole;

--- a/imports/lib/models/discord_cache.ts
+++ b/imports/lib/models/discord_cache.ts
@@ -1,0 +1,31 @@
+import { check, Match } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+import { Mongo } from 'meteor/mongo';
+import { Roles } from 'meteor/nicolaslopezj:roles';
+import Ansible from '../../ansible';
+import DiscordCacheSchema, { DiscordCacheType } from '../schemas/discord_cache';
+import { FindOptions } from './base';
+
+const DiscordCache = new Mongo.Collection<DiscordCacheType>('discord_cache');
+DiscordCache.attachSchema(DiscordCacheSchema);
+Meteor.publish('discord.cache', function (
+  q: Mongo.Selector<DiscordCacheType> = {},
+  opts: FindOptions = {},
+) {
+  check(q, Object);
+  check(opts, {
+    fields: Match.Maybe(Object),
+    sort: Match.Maybe(Object),
+    skip: Match.Maybe(Number),
+    limit: Match.Maybe(Number),
+  });
+
+  if (!this.userId || !Roles.userHasPermission(this.userId, 'discord.viewCache')) {
+    Ansible.log('Sub to mongo.discord_cache not logged in as operator');
+    return [];
+  }
+
+  return DiscordCache.find(q, opts);
+});
+
+export default DiscordCache;

--- a/imports/lib/roles.ts
+++ b/imports/lib/roles.ts
@@ -6,6 +6,7 @@ Roles.registerAction('hunt.join', true);
 Roles.registerAction('discord.configureOAuth', true);
 Roles.registerAction('discord.configureBot', true);
 Roles.registerAction('discord.listChannels', true);
+Roles.registerAction('discord.viewCache', true);
 Roles.registerAction('users.makeOperator', true);
 Roles.registerAction('webrtc.configureServers', true);
 

--- a/imports/lib/schemas/discord_cache.ts
+++ b/imports/lib/schemas/discord_cache.ts
@@ -7,6 +7,7 @@ import { buildSchema, Overrides } from './typedSchemas';
 export const DiscordCacheCodec = t.type({
   _id: t.string,
   createdAt: date,
+  updatedAt: t.union([date, t.undefined]),
   snowflake: t.string,
   type: t.string,
   object: t.object,
@@ -23,6 +24,16 @@ const DiscordCacheOverrides: Overrides<t.TypeOf<typeof DiscordCacheCodec>> = {
         this.unset(); // Prevent user from supplying their own value
         return undefined;
       }
+    },
+  },
+
+  updatedAt: {
+    denyInsert: true,
+    autoValue() {
+      if (this.isUpdate) {
+        return new Date();
+      }
+      return undefined;
     },
   },
 

--- a/imports/lib/schemas/discord_cache.ts
+++ b/imports/lib/schemas/discord_cache.ts
@@ -1,0 +1,38 @@
+import * as t from 'io-ts';
+import { date } from 'io-ts-types';
+import { buildSchema, Overrides } from './typedSchemas';
+
+// Don't use the BaseCodec here - unlike most database objects, this isn't
+// manipulated by users, so many of the fields don't make sense
+export const DiscordCacheCodec = t.type({
+  _id: t.string,
+  createdAt: date,
+  snowflake: t.string,
+  type: t.string,
+  object: t.object,
+});
+
+const DiscordCacheOverrides: Overrides<t.TypeOf<typeof DiscordCacheCodec>> = {
+  createdAt: {
+    autoValue() {
+      if (this.isInsert) {
+        return new Date();
+      } else if (this.isUpsert) {
+        return { $setOnInsert: new Date() };
+      } else {
+        this.unset(); // Prevent user from supplying their own value
+        return undefined;
+      }
+    },
+  },
+
+  snowflake: {
+    regEx: /[0-9]+/,
+  },
+};
+
+export type DiscordCacheType = t.TypeOf<typeof DiscordCacheCodec>;
+
+const DiscordCache = buildSchema(DiscordCacheCodec, DiscordCacheOverrides);
+
+export default DiscordCache;


### PR DESCRIPTION
Set up a mongo cache that is updated whenever the Discord gateway client gets
notifications of object updates. In theory, we could use this to replace our own
API fetches of state.