### PR TITLE
Index call collections & soft-delete CallParticipants

### DIFF
--- a/imports/lib/models/call_participants.ts
+++ b/imports/lib/models/call_participants.ts
@@ -1,4 +1,3 @@
-import { Roles } from 'meteor/nicolaslopezj:roles';
 import { huntsMatchingCurrentUser } from '../../model-helpers';
 import CallParticipantsSchema, { CallParticipantType } from '../schemas/call_participants';
 import Base from './base';
@@ -6,11 +5,5 @@ import Base from './base';
 const CallParticipants = new Base<CallParticipantType>('call_participants');
 CallParticipants.attachSchema(CallParticipantsSchema);
 CallParticipants.publish(huntsMatchingCurrentUser);
-
-// TODO: these ACLs need work
-// Users can hang up calls they are a part of
-Roles.loggedInRole.allow('mongo.call_participants.remove', (uid, doc) => {
-  return doc.createdBy === uid;
-});
 
 export default CallParticipants;

--- a/imports/server/calls.ts
+++ b/imports/server/calls.ts
@@ -13,7 +13,7 @@ const debug = false;
 
 function cleanupHook(deadServers: string[]) {
   // Remove CallParticipants from dead server backends.
-  CallParticipants.remove({ server: { $in: deadServers } });
+  CallParticipants.destroy({ server: { $in: deadServers } });
 
   // Remove old CallSignals that reference a participant ID no longer found in CallParticipants
   const liveParticipants = CallParticipants.find({}).map((doc) => doc._id);
@@ -179,7 +179,7 @@ Meteor.publish('call.metadata', function (hunt, call) {
 
 function cleanupCallSub(participantId: string) {
   // Remove the participant
-  CallParticipants.remove(participantId);
+  CallParticipants.destroy(participantId);
   // Also remove any signalling documents they created.
   CallSignals.remove({
     $or: [

--- a/imports/server/migrations/30-index-call-participants.ts
+++ b/imports/server/migrations/30-index-call-participants.ts
@@ -1,0 +1,17 @@
+import { Migrations } from 'meteor/percolate:migrations';
+import CallParticipants from '../../lib/models/call_participants';
+
+Migrations.add({
+  version: 30,
+  name: 'Add indexes on CallParticipants',
+  up() {
+    // The `call.metadata` publish queries by { hunt, call }.
+    // The `call.join` publish does a point query for { hunt, call, tab, createdBy }.
+    CallParticipants._ensureIndex({
+      deleted: 1, hunt: 1, call: 1, tab: 1, createdBy: 1,
+    });
+
+    // Garbage collection queries by server.
+    CallParticipants._ensureIndex({ deleted: 1, server: 1 });
+  },
+});

--- a/imports/server/migrations/31-index-call-signals.ts
+++ b/imports/server/migrations/31-index-call-signals.ts
@@ -1,0 +1,19 @@
+import { Migrations } from 'meteor/percolate:migrations';
+import CallSignals from '../../lib/models/call_signals';
+
+Migrations.add({
+  version: 31,
+  name: 'Add indexes on CallSignals',
+  up() {
+    // `call.signal` publish makes a query by target.
+    CallSignals._ensureIndex({ deleted: 1, target: 1 });
+
+    // Various other methods do queries which can match by sender, or by
+    // target, or exact match on both.
+    //
+    // The below index with Mongo's index prefixes, combined with the above
+    // index and Mongo's index intersection should hasten all of our access
+    // patterns.
+    CallSignals._ensureIndex({ deleted: 1, sender: 1, target: 1 });
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -28,3 +28,5 @@ import './26-remove-subcounter-feature-flags';
 import './27-hunt-has-guess-queue';
 import './28-discord-cache-indexes';
 import './29-fix-guild-setting-id';
+import './30-index-call-participants';
+import './31-index-call-signals';


### PR DESCRIPTION
This patch series:

* Makes it possible to soft-delete multiple documents at once
* Adds indices for the various access patterns to `CallParticipants` and `CallSignals`.
* Swaps `CallParticipants.remove()` (hard-delete) to `CallParticipants.destroy()` (soft-delete) so we can collect some usage data during hunt and get a better picture of how the features get used (how many avg. concurrent users, largest mesh, call duration, do people disconnect/reconnect, etc.)
* Removes a stale unused ACL on CallParticipants; the server methods themselves implement all relevant logic.