### PR TITLE
Workaround react-bootstrap autoFocus bug by disabling animations

### DIFF
--- a/imports/client/components/ModalForm.tsx
+++ b/imports/client/components/ModalForm.tsx
@@ -52,8 +52,20 @@ class ModalForm extends React.Component<ModalFormProps, ModalFormState> {
   };
 
   render() {
+    // Note: the animation=false is working around a regression in
+    // react-bootstrap that otherwise breaks autofocus:
+    // https://github.com/react-bootstrap/react-bootstrap/issues/5102
+    // There's a way to avoid breaking things without losing animation,
+    // but then we'd need to hold a ref to the `autoFocus` child to explicitly
+    // focus it in the Modal's `onEntered` callback, and from within this
+    // class we don't know which of the children should receive focus. So
+    // we just disable animations for now.  Makes the UI feel snappier anyway.
     return (
-      <Modal show={this.state.show} onHide={this.close}>
+      <Modal
+        animation={false}
+        show={this.state.show}
+        onHide={this.close}
+      >
         <form className="form-horizontal" onSubmit={this.submit}>
           <Modal.Header closeButton>
             <Modal.Title>


### PR DESCRIPTION
See https://github.com/react-bootstrap/react-bootstrap/issues/5102

This (`animation={false}`) is the simple workaround for the react-bootstrap
issue linked above.  We could do some slightly more involved workarounds to
preserve the animation, but they'd break some abstractions (have to have a ref
of the child to focus, which limits the code's reusability) and honestly I find
the site feels slightly snappier without them.

So we just turn off `Modal` animations entirely.

Fixes #359.