### PR TITLE
Polish puzzle list page

### DIFF
--- a/client/stylesheets/app.scss
+++ b/client/stylesheets/app.scss
@@ -12,6 +12,15 @@
 @import "theme";
 @import "../../node_modules/bootstrap/scss/bootstrap";
 
+// Give outline buttons distinct hover and active styles
+$btn-outline-hover-tint: 80%;
+@each $color, $value in $theme-colors {
+  .btn-outline-#{$color}:hover {
+    background-color: mix(white, $value, $btn-outline-hover-tint);
+    color: $value;
+  }
+}
+
 .connection-status {
   position: fixed;
   top: 50px;

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -19,7 +19,7 @@ $administrivia-puzzle-background-color: #dfdfff;
 }
 
 .puzzle-list-wrapper {
-  padding-left: 16px;
+  padding-left: 1.25em;
 }
 
 .puzzle {

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -38,8 +38,8 @@ $administrivia-puzzle-background-color: #dfdfff;
 
 .puzzle-answer > .answer {
   display: block;
-  text-indent: -2ch;
-  padding-left: 2ch;
+  text-indent: -1.2em;
+  padding-left: 1.2em;
 }
 
 .puzzle.puzzle-grid {

--- a/client/stylesheets/puzzlelist.scss
+++ b/client/stylesheets/puzzlelist.scss
@@ -4,15 +4,14 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  >* {
-    margin-bottom:12px;
+  .btn-toolbar:not(:last-child) {
+    margin-right: 0.5em;
   }
-  .btn-toolbar {
-    margin-right: 4px;
-  }
-  .form-group {
+  .puzzle-list-filter-toolbar {
     flex: 1 1 0;
-    margin-right: 4px;
+    > .input-group {
+      width: 100%;
+    }
   }
 }
 
@@ -81,9 +80,12 @@
 }
 
 @include media-breakpoint-down(xs) {
-  .puzzle-view-controls>* {
-    width: 100%;
-    margin-right: 0;
+  .puzzle-view-controls > .btn-toolbar {
+    flex-basis: 100%;
+    &:not(:last-child) {
+      margin-right: 0;
+      margin-bottom: 0.5em;
+    }
   }
 
   .puzzle-list-link-label {

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -7,6 +7,7 @@ import {
   faMap,
   faReceipt,
   faUsers,
+  faEraser,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
@@ -358,15 +359,15 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
           <div className="puzzle-view-controls">
             <ButtonToolbar>
               <ToggleButtonGroup type="radio" className="mr-2" name="puzzle-view" defaultValue="group" value={this.state.displayMode} onChange={this.switchView}>
-                <ToggleButton variant="outline-secondary" value="group">Group</ToggleButton>
-                <ToggleButton variant="outline-secondary" value="unlock">Unlock</ToggleButton>
+                <ToggleButton variant="light" value="group">Group</ToggleButton>
+                <ToggleButton variant="light" value="unlock">Unlock</ToggleButton>
               </ToggleButtonGroup>
               <ToggleButtonGroup
                 type="checkbox"
                 value={this.state.showSolved ? ['true'] : []}
                 onChange={this.changeShowSolved}
               >
-                <ToggleButton variant="outline-secondary" value="true">Show solved</ToggleButton>
+                <ToggleButton variant="light" value="true">Show solved</ToggleButton>
               </ToggleButtonGroup>
             </ButtonToolbar>
             <ButtonToolbar className="puzzle-list-filter-toolbar">
@@ -381,8 +382,8 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
                   onChange={this.onSearchStringChange}
                 />
                 <InputGroup.Append>
-                  <Button variant="outline-secondary" onClick={this.clearSearch}>
-                    Clear
+                  <Button variant="danger" onClick={this.clearSearch}>
+                    <FontAwesomeIcon icon={faEraser} />
                   </Button>
                 </InputGroup.Append>
               </InputGroup>

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -359,15 +359,15 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
           <div className="puzzle-view-controls">
             <ButtonToolbar>
               <ToggleButtonGroup type="radio" className="mr-2" name="puzzle-view" defaultValue="group" value={this.state.displayMode} onChange={this.switchView}>
-                <ToggleButton variant="light" value="group">Group</ToggleButton>
-                <ToggleButton variant="light" value="unlock">Unlock</ToggleButton>
+                <ToggleButton variant="outline-info" value="group">Group</ToggleButton>
+                <ToggleButton variant="outline-info" value="unlock">Unlock</ToggleButton>
               </ToggleButtonGroup>
               <ToggleButtonGroup
                 type="checkbox"
                 value={this.state.showSolved ? ['true'] : []}
                 onChange={this.changeShowSolved}
               >
-                <ToggleButton variant="light" value="true">Show solved</ToggleButton>
+                <ToggleButton variant="outline-info" value="true">Show solved</ToggleButton>
               </ToggleButtonGroup>
             </ButtonToolbar>
             <ButtonToolbar className="puzzle-list-filter-toolbar">
@@ -382,7 +382,7 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
                   onChange={this.onSearchStringChange}
                 />
                 <InputGroup.Append>
-                  <Button variant="danger" onClick={this.clearSearch}>
+                  <Button variant="secondary" onClick={this.clearSearch}>
                     <FontAwesomeIcon icon={faEraser} />
                   </Button>
                 </InputGroup.Append>

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -341,7 +341,7 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
       }
     }
     const addPuzzleContent = this.props.canAdd && (
-      <div className="add-puzzle-content">
+      <>
         <Button variant="primary" onClick={this.showAddModal}>Add a puzzle</Button>
         <PuzzleModalForm
           huntId={this.props.huntId}
@@ -349,13 +349,13 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
           ref={this.addModalRef}
           onSubmit={this.onAdd}
         />
-      </div>
+      </>
     );
     return (
       <div>
-        <FormLabel htmlFor="jr-puzzle-search">View puzzles by:</FormLabel>
-        <div className="puzzle-view-controls">
-          <div>
+        <FormGroup>
+          <FormLabel htmlFor="jr-puzzle-search">View puzzles by:</FormLabel>
+          <div className="puzzle-view-controls">
             <ButtonToolbar>
               <ToggleButtonGroup type="radio" className="mr-2" name="puzzle-view" defaultValue="group" value={this.state.displayMode} onChange={this.switchView}>
                 <ToggleButton variant="outline-secondary" value="group">Group</ToggleButton>
@@ -369,27 +369,29 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
                 <ToggleButton variant="outline-secondary" value="true">Show solved</ToggleButton>
               </ToggleButtonGroup>
             </ButtonToolbar>
+            <ButtonToolbar className="puzzle-list-filter-toolbar">
+              <InputGroup>
+                <FormControl
+                  id="jr-puzzle-search"
+                  as="input"
+                  type="text"
+                  ref={this.searchBarRef}
+                  placeholder="Filter by title, answer, or tag"
+                  value={this.getSearchString()}
+                  onChange={this.onSearchStringChange}
+                />
+                <InputGroup.Append>
+                  <Button variant="outline-secondary" onClick={this.clearSearch}>
+                    Clear
+                  </Button>
+                </InputGroup.Append>
+              </InputGroup>
+            </ButtonToolbar>
+            <ButtonToolbar>
+              {addPuzzleContent}
+            </ButtonToolbar>
           </div>
-          <FormGroup>
-            <InputGroup>
-              <FormControl
-                id="jr-puzzle-search"
-                as="input"
-                type="text"
-                ref={this.searchBarRef}
-                placeholder="Filter by title, answer, or tag"
-                value={this.getSearchString()}
-                onChange={this.onSearchStringChange}
-              />
-              <InputGroup.Append>
-                <Button variant="outline-secondary" onClick={this.clearSearch}>
-                  Clear
-                </Button>
-              </InputGroup.Append>
-            </InputGroup>
-          </FormGroup>
-          {addPuzzleContent}
-        </div>
+        </FormGroup>
         {bodyComponent}
       </div>
     );


### PR DESCRIPTION
- Multiline answer indents didn't render correctly in Safari, as ch does not size as expected with font fallback. Since we know the font, express in terms of em instead.
- Adjust puzzle group margin to align with header
- Fix inconsistent margins in puzzle list page controls
- Make puzzle list page control markup consistent
- Prefer standard to outline style buttons in radio and toggle bottoms, as the latter use the same colors for hover and active
- Use icon for clear button