### PR TITLE
Nudge users missing a Profile object to set one

### DIFF
--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -298,6 +298,28 @@ class AnnouncementMessage extends React.PureComponent<AnnouncementMessageProps> 
   }
 }
 
+interface ProfileMissingMessageProps {
+  onDismiss: () => void;
+}
+function ProfileMissingMessage(props: ProfileMissingMessageProps) {
+  return (
+    <li>
+      <MessengerSpinner />
+      <MessengerContent dismissable>
+        Somehow you don&apos;t seem to have a profile.  (This can happen if you wind
+        up having to do a password reset before you successfully log in for the
+        first time.)  Please set a display name for yourself via
+        {' '}
+        <Link to="/users/me">
+          the profile page
+        </Link>
+        .
+      </MessengerContent>
+      <MessengerDismissButton onDismiss={props.onDismiss} />
+    </li>
+  );
+}
+
 interface NotificationCenterAnnouncement {
   pa: PendingAnnouncementType;
   announcement: AnnouncementType;
@@ -317,10 +339,12 @@ type NotificationCenterProps = {
   guesses?: NotificationCenterGuess[];
   discordEnabledOnServer?: boolean;
   discordConfiguredByUser?: boolean;
+  hasOwnProfile?: boolean;
 }
 
 interface NotificationCenterState {
   hideDiscordSetupMessage: boolean;
+  hideProfileSetupMessage: boolean;
   dismissedGuesses: Record<string, boolean>;
 }
 
@@ -329,6 +353,7 @@ class NotificationCenter extends React.Component<NotificationCenterProps, Notifi
     super(props);
     this.state = {
       hideDiscordSetupMessage: false,
+      hideProfileSetupMessage: false,
       dismissedGuesses: {},
     };
   }
@@ -336,6 +361,12 @@ class NotificationCenter extends React.Component<NotificationCenterProps, Notifi
   hideDiscordSetupMessage = () => {
     this.setState({
       hideDiscordSetupMessage: true,
+    });
+  };
+
+  hideProfileSetupMessage = () => {
+    this.setState({
+      hideProfileSetupMessage: true,
     });
   };
 
@@ -355,6 +386,13 @@ class NotificationCenter extends React.Component<NotificationCenterProps, Notifi
 
     // Build a list of uninstantiated messages with their props, then create them
     const messages: any = [];
+
+    if (!this.props.hasOwnProfile && !this.state.hideProfileSetupMessage) {
+      messages.push(<ProfileMissingMessage
+        key="profile"
+        onDismiss={this.hideProfileSetupMessage}
+      />);
+    }
 
     if (this.props.discordEnabledOnServer &&
         !this.props.discordConfiguredByUser &&
@@ -430,6 +468,7 @@ const NotificationCenterContainer = withTracker((_props: {}): NotificationCenter
     guesses: [] as NotificationCenterGuess[],
     discordEnabledOnServer,
     discordConfiguredByUser: !!(ownProfile && ownProfile.discordAccount),
+    hasOwnProfile: !!(ownProfile),
   };
 
   if (canUpdateGuesses) {

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -259,6 +259,7 @@ class DiscordMessage extends React.PureComponent<DiscordMessageProps, DiscordMes
           </ul>
           {this.state.status === DiscordMessageStatus.ERROR ? this.state.error! : null}
         </MessengerContent>
+        <MessengerDismissButton onDismiss={this.props.onDismiss} />
       </li>
     );
   }


### PR DESCRIPTION
Recall that in #184, users that we invited to Jolly Roger but who did not use their invite
code within Meteor's expiry time have to use password reset to be able to log
in for the first time.  When this happens, the password reset flow does not
perform our usual onboarding, which means that we have no display name or
phone number for that user, and indeed, no `Profile` object at all.  This is an
unfortunate state, and one that we'd like people to get out of promptly should it arise.

This adds another in-memory-dismissible notification that will be shown if the
user has no Profile object associated with their Meteor user id, which will
hopefully guide them to set a display name via the profile page.

(Also I snuck in a one-line fix for a bug -- the equivalent Discord nudge was missing the dismiss button.)

