### PR TITLE
Add support for Discord firehose

### DIFF
--- a/imports/client/components/HuntListPage.tsx
+++ b/imports/client/components/HuntListPage.tsx
@@ -160,6 +160,7 @@ export interface HuntModalSubmit {
   homepageUrl: string;
   submitTemplate: string;
   puzzleHooksDiscordChannel: SavedDiscordObjectType | undefined;
+  firehoseDiscordChannel: SavedDiscordObjectType | undefined;
   memberDiscordRole: SavedDiscordObjectType | undefined;
 }
 
@@ -204,6 +205,7 @@ class HuntModalForm extends React.Component<HuntModalFormProps, HuntModalFormSta
         homepageUrl: this.props.hunt.homepageUrl || '',
         submitTemplate: this.props.hunt.submitTemplate || '',
         puzzleHooksDiscordChannel: this.props.hunt.puzzleHooksDiscordChannel,
+        firehoseDiscordChannel: this.props.hunt.firehoseDiscordChannel,
         memberDiscordRole: this.props.hunt.memberDiscordRole,
       });
     } else {
@@ -216,6 +218,7 @@ class HuntModalForm extends React.Component<HuntModalFormProps, HuntModalFormSta
         homepageUrl: '',
         submitTemplate: '',
         puzzleHooksDiscordChannel: undefined,
+        firehoseDiscordChannel: undefined,
         memberDiscordRole: undefined,
       });
     }
@@ -268,6 +271,12 @@ class HuntModalForm extends React.Component<HuntModalFormProps, HuntModalFormSta
       puzzleHooksDiscordChannel: next,
     });
   };
+
+  onFirehoseDiscordChannelChanged = (next: SavedDiscordObjectType | undefined) => {
+    this.setState({
+      firehoseDiscordChannel: next,
+    });
+  }
 
   onMemberDiscordRoleChanged = (next: SavedDiscordObjectType | undefined) => {
     this.setState({
@@ -472,6 +481,23 @@ class HuntModalForm extends React.Component<HuntModalFormProps, HuntModalFormSta
             />
             <FormText>
               If this field is specified, when a puzzle in this hunt is added or solved, a message will be sent to the specified channel.
+            </FormText>
+          </Col>
+        </FormGroup>
+
+        <FormGroup as={Row}>
+          <FormLabel column xs={3} htmlFor={`${idPrefix}firehose-discord-channel`}>
+            Firehose Discord channel
+          </FormLabel>
+          <Col xs={9}>
+            <DiscordChannelSelector
+              id={`${idPrefix}firehose-discord-channel`}
+              disable={disableForm}
+              value={this.state.firehoseDiscordChannel}
+              onChange={this.onFirehoseDiscordChannelChanged}
+            />
+            <FormText>
+              If this field is specified, all chat messages written in puzzles associated with this hunt will be mirrored to the specified Discord channel.
             </FormText>
           </Col>
         </FormGroup>

--- a/imports/lib/schemas/hunts.ts
+++ b/imports/lib/schemas/hunts.ts
@@ -36,6 +36,9 @@ const HuntFields = t.type({
   // channel name (for local presentation) to which we should post puzzle
   // create/solve messages as the server-configured Discord bot.
   puzzleHooksDiscordChannel: t.union([SavedDiscordObjectFields, t.undefined]),
+  // If provided, then any message sent in chat for a puzzle associated with
+  // this hunt will be mirrored to the specified Discord channel.
+  firehoseDiscordChannel: t.union([SavedDiscordObjectFields, t.undefined]),
   // If provided, then members of the hunt who have also linked their Discord
   // profile will be added to this role.
   memberDiscordRole: t.union([SavedDiscordObjectFields, t.undefined]),

--- a/imports/server/chat.ts
+++ b/imports/server/chat.ts
@@ -1,7 +1,75 @@
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import ChatMessages from '../lib/models/chats';
+import Hunts from '../lib/models/hunts';
+import Profiles from '../lib/models/profiles';
 import Puzzles from '../lib/models/puzzles';
+import Settings from '../lib/models/settings';
+import { DiscordBot } from './discord';
+
+// eslint-disable-next-line import/prefer-default-export
+export const sendChatMessage = (puzzleId: string, message: string, sender: string | undefined) => {
+  const puzzle = Puzzles.findOne(puzzleId);
+  if (!puzzle) {
+    throw new Meteor.Error(404, 'Unknown puzzle');
+  }
+
+  const msgId = ChatMessages.insert({
+    puzzle: puzzleId,
+    hunt: puzzle.hunt,
+    text: message,
+    sender,
+    timestamp: new Date(),
+  });
+
+  const discordBotTokenDoc = Settings.findOne({ name: 'discord.bot' });
+  const botToken = discordBotTokenDoc && discordBotTokenDoc.name === 'discord.bot' && discordBotTokenDoc.value.token;
+
+  const hunt = Hunts.findOne(puzzle.hunt)!;
+  if (botToken && hunt.firehoseDiscordChannel) {
+    const channel = hunt.firehoseDiscordChannel.id;
+
+    let name: string;
+    if (!sender) {
+      name = 'Jolly Roger';
+    } else {
+      name = sender;
+      const profile = Profiles.findOne(sender);
+      if (profile && profile.discordAccount) {
+        name = profile.discordAccount.username;
+      } else if (profile && profile.displayName) {
+        name = profile.displayName;
+      }
+    }
+
+    const url = Meteor.absoluteUrl(`hunts/${puzzle.hunt}/puzzles/${puzzleId}`);
+    let title = puzzle.title;
+    if (title.length > 25) {
+      title = `${title.substring(0, 24)}…`;
+    }
+
+    const msg = {
+      embed: {
+        author: {
+          name,
+        },
+        url,
+        title,
+        description: message,
+      },
+      nonce: msgId,
+      allowed_mentions: {
+        parse: [],
+      },
+    };
+
+    Meteor.defer(() => {
+      // send actual message
+      const bot = new DiscordBot(botToken);
+      bot.postMessageToChannel(channel, msg);
+    });
+  }
+};
 
 Meteor.methods({
   sendChatMessage(puzzleId: unknown, message: unknown) {
@@ -9,17 +77,6 @@ Meteor.methods({
     check(puzzleId, String);
     check(message, String);
 
-    const puzzle = Puzzles.findOne(puzzleId);
-    if (!puzzle) {
-      throw new Meteor.Error(404, 'Unknown puzzle');
-    }
-
-    ChatMessages.insert({
-      puzzle: puzzleId,
-      hunt: puzzle.hunt,
-      text: message,
-      sender: this.userId,
-      timestamp: new Date(),
-    });
+    sendChatMessage(puzzleId, message, this.userId);
   },
 });

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -7,10 +7,12 @@ import Guesses from '../lib/models/guess';
 import Hunts from '../lib/models/hunts';
 import Puzzles from '../lib/models/puzzles';
 import { GuessType } from '../lib/schemas/guess';
+import { sendChatMessage } from './chat';
 import GlobalHooks from './global-hooks';
 
 function addChatMessage(guess: GuessType, newState: GuessType['state']): void {
   const message = `Guess ${guess.guess} was marked ${newState}`;
+  sendChatMessage(guess.puzzle, message, undefined);
   const puzzle = Puzzles.findOne(guess.puzzle)!;
   ChatMessages.insert({
     hunt: puzzle.hunt,


### PR DESCRIPTION
<img width="552" alt="Screenshot 2021-01-12 21 22 47" src="https://user-images.githubusercontent.com/28167/104410076-74165d00-551c-11eb-821b-5334a6a5e068.png">

Somewhat annoyingly, you can spoof username with a webhook, but not with a bot channel post, so I'm using the embed formatting. It's not perfect, but it's probably good enough.