### PR TITLE
Make initial page load faster for operators

### DIFF
--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -435,13 +435,9 @@ const NotificationCenterContainer = withTracker((_props: {}): NotificationCenter
   const canUpdateGuesses = Roles.userHasPermission(Meteor.userId(), 'mongo.guesses.update');
 
   // Yes this is hideous, but it just makes the logic easier
-  let guessesHandle = { ready: () => true };
-  let puzzlesHandle = { ready: () => true };
-  let huntsHandle = { ready: () => true };
+  let pendingGuessHandle = { ready: () => true };
   if (canUpdateGuesses) {
-    guessesHandle = Meteor.subscribe('mongo.guesses', { state: 'pending' });
-    puzzlesHandle = Meteor.subscribe('mongo.puzzles');
-    huntsHandle = Meteor.subscribe('mongo.hunts');
+    pendingGuessHandle = Meteor.subscribe('pendingGuesses');
   }
 
   // This is overly broad, but we likely already have the data cached locally
@@ -463,7 +459,7 @@ const NotificationCenterContainer = withTracker((_props: {}): NotificationCenter
   const discordEnabledOnServer = !!ServiceConfiguration.configurations.findOne({ service: 'discord' }) && !Flags.active('disable.discord');
 
   const data = {
-    ready: guessesHandle.ready() && puzzlesHandle.ready() && huntsHandle.ready() && paHandle.ready(),
+    ready: pendingGuessHandle.ready() && paHandle.ready(),
     announcements: [] as NotificationCenterAnnouncement[],
     guesses: [] as NotificationCenterGuess[],
     discordEnabledOnServer,

--- a/imports/lib/models/base.ts
+++ b/imports/lib/models/base.ts
@@ -27,10 +27,14 @@ type ValidateShape<T, Shape> =
 class Base<T extends BaseType> extends Mongo.Collection<T> {
   public name: string;
 
+  public tableName: string;
+
   constructor(name: string, options = {}) {
     // Namespace table name in mongo
-    super(`jr_${name}`, options);
+    const tableName = `jr_${name}`;
+    super(tableName, options);
     this.name = name;
+    this.tableName = tableName;
 
     // All models have standard roles
     this.attachRoles(`mongo.${name}`);

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -1,11 +1,16 @@
 import { check } from 'meteor/check';
-import { Meteor } from 'meteor/meteor';
+import { Meteor, Subscription } from 'meteor/meteor';
+import { Mongo } from 'meteor/mongo';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import Ansible from '../ansible';
+import Base from '../lib/models/base';
 import Guesses from '../lib/models/guess';
 import Hunts from '../lib/models/hunts';
 import Puzzles from '../lib/models/puzzles';
+import { BaseType } from '../lib/schemas/base';
 import { GuessType } from '../lib/schemas/guess';
+import { HuntType } from '../lib/schemas/hunts';
+import { PuzzleType } from '../lib/schemas/puzzles';
 import { sendChatMessage } from './chat';
 import GlobalHooks from './global-hooks';
 
@@ -48,6 +53,171 @@ function transitionGuess(guess: GuessType, newState: GuessType['state']) {
     GlobalHooks.runPuzzleNoLongerSolvedHooks(guess.puzzle);
   }
 }
+
+// It's easier to create one observer per object, rather than try and have a
+// single observer with an $in query. It means we don't have to start/stop the
+// observer. Identical queries from different users will get deduped on the
+// server side, and there are relatively few operators, so this should be
+// reasonably safe.
+class RecordUpdateObserver<T extends BaseType> {
+  sub: Subscription;
+
+  tableName: string;
+
+  id: string;
+
+  handle: Meteor.LiveQueryHandle;
+
+  exists: boolean;
+
+  constructor(sub: Subscription, id: string, model: Base<T>) {
+    this.sub = sub;
+    this.tableName = model.tableName;
+    this.id = id;
+    this.exists = false;
+    this.handle = model.find(id).observeChanges({
+      added: (_, fields) => {
+        this.exists = true;
+        this.sub.added(model.tableName, id, fields);
+      },
+      changed: (_, fields) => {
+        this.sub.changed(model.tableName, id, fields);
+      },
+      removed: () => {
+        this.exists = false;
+        this.sub.removed(model.tableName, id);
+      },
+    });
+  }
+
+  destroy() {
+    if (this.exists) {
+      this.sub.removed(this.tableName, this.id);
+    }
+
+    this.handle.stop();
+  }
+}
+
+class RefCountedObserverMap<T extends BaseType> {
+  private sub: Subscription;
+
+  private model: Base<T>;
+
+  private subscribers: Map<string, { refCount: number, subscriber: RecordUpdateObserver<T> }>;
+
+  constructor(sub: Subscription, model: Base<T>) {
+    this.sub = sub;
+    this.model = model;
+    this.subscribers = new Map();
+  }
+
+  incref(id: string) {
+    if (this.subscribers.has(id)) {
+      this.subscribers.get(id)!.refCount += 1;
+    } else {
+      this.subscribers.set(id, {
+        refCount: 1,
+        subscriber: new RecordUpdateObserver(this.sub, id, this.model),
+      });
+    }
+  }
+
+  decref(id: string) {
+    const record = this.subscribers.get(id);
+    if (!record) {
+      return;
+    }
+    record.refCount -= 1;
+    if (record.refCount <= 0) {
+      record.subscriber.destroy();
+      this.subscribers.delete(id);
+    }
+  }
+}
+
+class PendingGuessWatcher {
+  sub: Subscription
+
+  guessCursor: Mongo.Cursor<GuessType>
+
+  guessWatch: Meteor.LiveQueryHandle
+
+  guesses: Record<string, GuessType>
+
+  huntRefCounter: RefCountedObserverMap<HuntType>;
+
+  puzzleRefCounter: RefCountedObserverMap<PuzzleType>
+
+  constructor(sub: Subscription) {
+    this.sub = sub;
+
+    const user = Meteor.users.findOne(sub.userId)!;
+
+    this.guessCursor = Guesses.find({ state: 'pending', hunts: { $in: user.hunts } });
+    this.guesses = {};
+    this.huntRefCounter = new RefCountedObserverMap(sub, Hunts);
+    this.puzzleRefCounter = new RefCountedObserverMap(sub, Puzzles);
+
+    this.guessWatch = this.guessCursor.observeChanges({
+      added: (id, fields) => {
+        this.guesses[id] = { _id: id, ...fields } as GuessType;
+        this.huntRefCounter.incref(fields.hunt!);
+        this.puzzleRefCounter.incref(fields.puzzle!);
+        this.sub.added(Guesses.tableName, id, fields);
+      },
+
+      changed: (id, fields) => {
+        const huntUpdated = Object.prototype.hasOwnProperty.call(fields, 'hunt');
+        const puzzleUpdated = Object.prototype.hasOwnProperty.call(fields, 'puzzle');
+
+        // The order of operations here is important to avoid transient
+        // inconsistencies
+        if (huntUpdated) {
+          this.huntRefCounter.incref(fields.hunt!);
+        }
+        if (puzzleUpdated) {
+          this.puzzleRefCounter.incref(fields.puzzle!);
+        }
+        this.sub.changed(Guesses.tableName, id, fields);
+        if (puzzleUpdated) {
+          this.puzzleRefCounter.decref(this.guesses[id].puzzle);
+        }
+        if (huntUpdated) {
+          this.huntRefCounter.decref(this.guesses[id].hunt);
+        }
+
+        this.guesses[id] = { ...this.guesses[id], ...fields };
+      },
+
+      removed: (id) => {
+        this.sub.removed(Guesses.tableName, id);
+        this.huntRefCounter.decref(this.guesses[id].hunt);
+        this.puzzleRefCounter.decref(this.guesses[id].puzzle);
+        delete this.guesses[id];
+      },
+    });
+
+    this.sub.ready();
+  }
+
+  shutdown() {
+    this.guessWatch.stop();
+  }
+}
+
+// Publish pending guesses enriched with puzzle and hunt. This is a dedicated
+// publish because every operator needs this information for the notification
+// center, and without assistance they need an overly broad subscription to the
+// related collections
+Meteor.publish('pendingGuesses', function () {
+  check(this.userId, String);
+
+  Roles.checkPermission(this.userId, 'mongo.guesses.update');
+
+  const watcher = new PendingGuessWatcher(this);
+  this.onStop(() => watcher.shutdown());
+});
 
 Meteor.methods({
   addGuessForPuzzle(puzzleId: unknown, guess: unknown, direction: unknown, confidence: unknown) {


### PR DESCRIPTION
Historically, in order to display pending guesses, the operator view has loaded all hunts and puzzles. If a Jolly Roger instance has a lot of history, that can be quite expensive. Instead, expose a special subscription that includes pending guesses + the specific hunts/puzzles that they're linked to. This requires more state tracking on the server, but since there are relatively few operators it seems worth that cost.

(FWIW, this could be made even more efficient if we projected puzzles and hunts for just the fields that we care about, but that creates some risk to type safety that I don't really want to touch. It's also possible we could generalize some of this logic for other use cases, e.g. pending announcements + announcements, although we couldn't lean on the assumption that it will only be used by a few people)

Since this is a bit speculative and not a blocker for this weekend, I'm not planning to merge this without a code review.