### PR TITLE
Extract Discord firehose chat behavior to a hook

### DIFF
--- a/imports/server/chat.ts
+++ b/imports/server/chat.ts
@@ -1,11 +1,8 @@
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import ChatMessages from '../lib/models/chats';
-import Hunts from '../lib/models/hunts';
-import Profiles from '../lib/models/profiles';
 import Puzzles from '../lib/models/puzzles';
-import Settings from '../lib/models/settings';
-import { DiscordBot } from './discord';
+import GlobalHooks from './global-hooks';
 
 // eslint-disable-next-line import/prefer-default-export
 export const sendChatMessage = (puzzleId: string, message: string, sender: string | undefined) => {
@@ -22,53 +19,7 @@ export const sendChatMessage = (puzzleId: string, message: string, sender: strin
     timestamp: new Date(),
   });
 
-  const discordBotTokenDoc = Settings.findOne({ name: 'discord.bot' });
-  const botToken = discordBotTokenDoc && discordBotTokenDoc.name === 'discord.bot' && discordBotTokenDoc.value.token;
-
-  const hunt = Hunts.findOne(puzzle.hunt)!;
-  if (botToken && hunt.firehoseDiscordChannel) {
-    const channel = hunt.firehoseDiscordChannel.id;
-
-    let name: string;
-    if (!sender) {
-      name = 'Jolly Roger';
-    } else {
-      name = sender;
-      const profile = Profiles.findOne(sender);
-      if (profile && profile.discordAccount) {
-        name = profile.discordAccount.username;
-      } else if (profile && profile.displayName) {
-        name = profile.displayName;
-      }
-    }
-
-    const url = Meteor.absoluteUrl(`hunts/${puzzle.hunt}/puzzles/${puzzleId}`);
-    let title = puzzle.title;
-    if (title.length > 25) {
-      title = `${title.substring(0, 24)}…`;
-    }
-
-    const msg = {
-      embed: {
-        author: {
-          name,
-        },
-        url,
-        title,
-        description: message,
-      },
-      nonce: msgId,
-      allowed_mentions: {
-        parse: [],
-      },
-    };
-
-    Meteor.defer(() => {
-      // send actual message
-      const bot = new DiscordBot(botToken);
-      bot.postMessageToChannel(channel, msg);
-    });
-  }
+  GlobalHooks.runChatMessageCreatedHooks(msgId);
 };
 
 Meteor.methods({

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -2,7 +2,6 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import Ansible from '../ansible';
-import ChatMessages from '../lib/models/chats';
 import Guesses from '../lib/models/guess';
 import Hunts from '../lib/models/hunts';
 import Puzzles from '../lib/models/puzzles';
@@ -13,13 +12,6 @@ import GlobalHooks from './global-hooks';
 function addChatMessage(guess: GuessType, newState: GuessType['state']): void {
   const message = `Guess ${guess.guess} was marked ${newState}`;
   sendChatMessage(guess.puzzle, message, undefined);
-  const puzzle = Puzzles.findOne(guess.puzzle)!;
-  ChatMessages.insert({
-    hunt: puzzle.hunt,
-    puzzle: guess.puzzle,
-    text: message,
-    timestamp: new Date(),
-  });
 }
 
 function transitionGuess(guess: GuessType, newState: GuessType['state']) {

--- a/imports/server/hooks/hooks-registry.ts
+++ b/imports/server/hooks/hooks-registry.ts
@@ -46,6 +46,15 @@ class HooksRegistry {
       }
     }
   }
+
+  runChatMessageCreatedHooks(chatMessageId: string) {
+    for (let i = 0; i < this.registeredHooks.length; i++) {
+      const hook = this.registeredHooks[i];
+      if (hook.onChatMessageCreated) {
+        hook.onChatMessageCreated(chatMessageId);
+      }
+    }
+  }
 }
 
 export default HooksRegistry;

--- a/imports/server/hooks/hookset.ts
+++ b/imports/server/hooks/hookset.ts
@@ -20,6 +20,10 @@ interface Hookset {
   // Triggered when a puzzle that was marked solved is marked unsolved (by a
   // guess previously marked correct being unwound to a different state).
   onPuzzleNoLongerSolved?: (puzzleId: string) => void;
+
+  // Triggered when a new message is added to a puzzle's chat (either from a
+  // user or e.g. in response to a guess transitioning state).
+  onChatMessageCreated?: (chatMessageId: string) => void;
 }
 
 export default Hookset;


### PR DESCRIPTION
Pluggable actions to take with optional integrations when a chat message is
created seems like exactly the sort of use case the hook system was designed
to support.

Shifting the code there made it easy to notice and fix a couple of bugs along the way:

* The firehose did not respect the `disable.discord` flag.
* System ChatMessages created in response to guesses transitioning states were
  double-created.