### PR TITLE
Close popover when clicking into iframe

### DIFF
--- a/imports/client/components/Tag.tsx
+++ b/imports/client/components/Tag.tsx
@@ -93,6 +93,19 @@ class Tag extends React.Component<TagProps, TagState> {
     };
   }
 
+  componentDidMount() {
+    window.addEventListener('blur', this.onWindowBlur);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('blur', this.onWindowBlur);
+  }
+
+  // Necessary to ensure popover close when entering the iframe on devices that don't support hover
+  onWindowBlur = () => {
+    this.setState({ showPopover: false });
+  };
+
   onRemove = () => {
     if (this.props.onRemove) {
       this.props.onRemove(this.props.tag._id);
@@ -198,7 +211,7 @@ class Tag extends React.Component<TagProps, TagState> {
         <OverlayTrigger
           placement="bottom"
           overlay={popover}
-          trigger={['hover', 'focus']}
+          trigger={['hover', 'click']}
           onToggle={this.onOverlayTriggerToggle}
           show={this.state.showPopover}
           popperConfig={


### PR DESCRIPTION
Previously, on devices that do not support hover, clicking into an iframe did not dismiss the popover. Per @zarvox's suggestion, solve this by adding a blur event handler to the window. This has the side effect of closing popovers when switching tabs (on mobile - elsewhere they were already closed by mouseLeave).

This fix requires switching from focus to click as the secondary trigger. As a result, clicking the tag can also close the popover (on any platform), which seems reasonable.

Closes #377 