### PR TITLE
Button consistency

### DIFF
--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -2,6 +2,8 @@ import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { withTracker } from 'meteor/react-meteor-data';
 import { _ } from 'meteor/underscore';
+import { faEraser } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 import React from 'react';
 import Button from 'react-bootstrap/Button';
@@ -230,8 +232,8 @@ class GuessQueuePage extends React.Component<GuessQueuePageProps> {
               onChange={this.onSearchStringChange}
             />
             <InputGroup.Append>
-              <Button variant="outline-secondary" onClick={this.clearSearch}>
-                Clear
+              <Button variant="secondary" onClick={this.clearSearch}>
+                <FontAwesomeIcon icon={faEraser} />
               </Button>
             </InputGroup.Append>
           </InputGroup>

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -1,4 +1,6 @@
 import { Meteor } from 'meteor/meteor';
+import { faEraser } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
@@ -140,8 +142,8 @@ class ProfileList extends React.Component<ProfileListProps, ProfileListState> {
               onChange={this.onSearchStringChange}
             />
             <InputGroup.Append>
-              <Button variant="outline-secondary" onClick={this.clearSearch}>
-                Clear
+              <Button variant="secondary" onClick={this.clearSearch}>
+                <FontAwesomeIcon icon={faEraser} />
               </Button>
             </InputGroup.Append>
           </InputGroup>

--- a/imports/client/components/TagList.tsx
+++ b/imports/client/components/TagList.tsx
@@ -171,7 +171,7 @@ class TagList extends React.PureComponent<TagListProps, TagListState> {
         <ButtonGroup key="editRemoveGroup">
           {this.props.onCreateTag && (
             <Button
-              variant="outline-secondary"
+              variant="secondary"
               title="Add tag..."
               key="startEditing"
               className="tag-modify-button"
@@ -182,7 +182,7 @@ class TagList extends React.PureComponent<TagListProps, TagListState> {
           )}
           {this.props.onRemoveTag && tags.length > 0 && (
             <Button
-              variant="outline-secondary"
+              variant="secondary"
               title="Remove tag..."
               key="startRemoving"
               className="tag-modify-button"


### PR DESCRIPTION
Update button styles elsewhere to match #405, in which outline classes are used exclusively for toggle and radio buttons.

(While the buttons in voice chat are toggle-like, they also change their own text and color and behave more like swapping buttons than toggles. They are unchanged here.)