### PR TITLE
Display Discord handle on the profile page

### DIFF
--- a/imports/client/components/OthersProfilePage.tsx
+++ b/imports/client/components/OthersProfilePage.tsx
@@ -38,6 +38,15 @@ class OthersProfilePage extends React.Component<OthersProfilePageProps> {
             {profile.phoneNumber}
           </div>
         ) : null}
+        {profile.discordAccount ? (
+          <div>
+            Discord handle:
+            {' '}
+            {profile.discordAccount.username}
+            #
+            {profile.discordAccount.discriminator}
+          </div>
+        ) : null}
       </div>
     );
   }


### PR DESCRIPTION
I've wanted to be able to look this up a couple times. It's not perfect (since it doesn't show a custom nick if you've set one on our server), but still seems useful.

I would entertain an argument that this should only be shown to operators or something, but given that everyone's already in the guild, it doesn't feel like the mapping here is super secret information.