### PR TITLE
Add experimental dingwords and in-app notifications

### DIFF
--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -345,6 +345,7 @@ interface OwnProfilePageState {
   displayNameValue: string;
   phoneNumberValue: string;
   muteApplause: boolean;
+  dingwords: string;
   submitState: OwnProfilePageSubmitState,
   submitError: string;
 }
@@ -356,6 +357,8 @@ class OwnProfilePage extends React.Component<OwnProfilePageProps, OwnProfilePage
       displayNameValue: this.props.initialProfile.displayName || '',
       phoneNumberValue: this.props.initialProfile.phoneNumber || '',
       muteApplause: this.props.initialProfile.muteApplause || false,
+      dingwords: this.props.initialProfile.dingwords ?
+        this.props.initialProfile.dingwords.join(',') : '',
       submitState: OwnProfilePageSubmitState.IDLE,
     } as OwnProfilePageState;
   }
@@ -378,6 +381,12 @@ class OwnProfilePage extends React.Component<OwnProfilePageProps, OwnProfilePage
     });
   };
 
+  handleDingwordsChange: FormControlProps['onChange'] = (e) => {
+    this.setState({
+      dingwords: e.currentTarget.value,
+    });
+  };
+
   toggleOperating = () => {
     const newState = !this.props.operating;
     if (newState) {
@@ -391,10 +400,14 @@ class OwnProfilePage extends React.Component<OwnProfilePageProps, OwnProfilePage
     this.setState({
       submitState: OwnProfilePageSubmitState.SUBMITTING,
     });
+    const dingwords = this.state.dingwords.split(',').map((x) => {
+      return x.trim().toLowerCase();
+    }).filter((x) => x.length > 0);
     const newProfile = {
       displayName: this.state.displayNameValue,
       phoneNumber: this.state.phoneNumberValue,
       muteApplause: this.state.muteApplause,
+      dingwords,
     };
     Meteor.call('saveProfile', newProfile, (error?: Error) => {
       if (error) {
@@ -485,6 +498,26 @@ class OwnProfilePage extends React.Component<OwnProfilePageProps, OwnProfilePage
           />
           <FormText>
             In case we need to reach you via phone.
+          </FormText>
+        </FormGroup>
+
+        <FormGroup>
+          <FormLabel htmlFor="jr-profile-edit-dingwords">
+            Dingwords (experimental)
+          </FormLabel>
+          <FormControl
+            id="jr-profile-edit-dingwords"
+            type="text"
+            value={this.state.dingwords}
+            disabled={shouldDisableForm}
+            onChange={this.handleDingwordsChange}
+            placeholder="cryptic,biology,chemistry"
+          />
+          <FormText>
+            Get an in-app notification if anyone sends a chat message
+            containing one of your comma-separated, case-insensitive dingwords
+            as a substring.  This feature is experimental and may be disabled
+            without notice.
           </FormText>
         </FormGroup>
 

--- a/imports/client/components/ProfilePage.tsx
+++ b/imports/client/components/ProfilePage.tsx
@@ -71,6 +71,7 @@ const tracker = withTracker(({ match }: ProfilePageWithRouterParams) => {
       displayName: '',
       primaryEmail: defaultEmail,
       phoneNumber: '',
+      dingwords: [],
       deleted: false,
       createdAt: new Date(),
       createdBy: user._id,

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -1188,6 +1188,7 @@ interface CircuitBreakerSectionProps {
   flagDisableApplause: boolean;
   flagDisableWebrtc: boolean;
   flagDisableSpectra: boolean;
+  flagDisableDingwords: boolean;
 }
 
 class CircuitBreakerSection extends React.Component<CircuitBreakerSectionProps> {
@@ -1301,6 +1302,24 @@ class CircuitBreakerSection extends React.Component<CircuitBreakerSectionProps> 
             and battery for members of WebRTC calls.
           </p>
         </CircuitBreakerControl>
+        <CircuitBreakerControl
+          title="Dingwords"
+          featureDisabled={this.props.flagDisableDingwords}
+          onChange={(newValue) => this.setFlagValue('disable.dingwords', newValue)}
+        >
+          <p>
+            User-specified &quot;dingwords&quot; allow users to get notified if anyone
+            mentions a word of particular significance to the user in any of the puzzle
+            chats, so that they can potentially contribute.  However, this involves doing
+            substantial matching work for every chat message sent, and the CPU/DB load
+            involved have not been tested in production yet.
+          </p>
+          <p>
+            Disabling this feature means that Jolly Roger will no longer do expensive
+            work on each chat message sent, and no new dingword notifications will be
+            generated or displayed.
+          </p>
+        </CircuitBreakerControl>
       </section>
     );
   }
@@ -1329,6 +1348,7 @@ interface SetupPageRewriteProps {
   flagDisableApplause: boolean;
   flagDisableWebrtc: boolean;
   flagDisableSpectra: boolean;
+  flagDisableDingwords: boolean;
 }
 
 class SetupPageRewrite extends React.Component<SetupPageRewriteProps> {
@@ -1377,6 +1397,7 @@ class SetupPageRewrite extends React.Component<SetupPageRewriteProps> {
           flagDisableApplause={this.props.flagDisableApplause}
           flagDisableWebrtc={this.props.flagDisableWebrtc}
           flagDisableSpectra={this.props.flagDisableSpectra}
+          flagDisableDingwords={this.props.flagDisableDingwords}
         />
       </div>
     );
@@ -1420,6 +1441,7 @@ const tracker = withTracker((): SetupPageRewriteProps => {
   const flagDisableApplause = Flags.active('disable.applause');
   const flagDisableWebrtc = Flags.active('disable.webrtc');
   const flagDisableSpectra = Flags.active('disable.spectra');
+  const flagDisableDingwords = Flags.active('disable.dingwords');
 
   return {
     ready: settingsHandle.ready(),
@@ -1444,6 +1466,7 @@ const tracker = withTracker((): SetupPageRewriteProps => {
     flagDisableApplause,
     flagDisableWebrtc,
     flagDisableSpectra,
+    flagDisableDingwords,
   };
 });
 

--- a/imports/lib/models/chat_notifications.ts
+++ b/imports/lib/models/chat_notifications.ts
@@ -1,0 +1,8 @@
+import ChatNotificationsSchema, { ChatNotificationType } from '../schemas/chat_notifications';
+import Base from './base';
+
+const ChatNotifications = new Base<ChatNotificationType>('chatnotifications');
+ChatNotifications.attachSchema(ChatNotificationsSchema);
+// No publish here -- we do a custom publish for notifications matching the target user.
+
+export default ChatNotifications;

--- a/imports/lib/models/facade.ts
+++ b/imports/lib/models/facade.ts
@@ -1,6 +1,7 @@
 import Announcements from './announcements';
 import CallParticipants from './call_participants';
 import CallSignals from './call_signals';
+import ChatNotifications from './chat_notifications';
 import ChatMessages from './chats';
 import DocumentPermissions from './document_permissions';
 import Documents from './documents';
@@ -18,6 +19,7 @@ const Models = {
   CallParticipants,
   CallSignals,
   ChatMessages,
+  ChatNotifications,
   DocumentPermissions,
   Documents,
   FeatureFlags,

--- a/imports/lib/schemas/chat_notifications.ts
+++ b/imports/lib/schemas/chat_notifications.ts
@@ -1,0 +1,51 @@
+import * as t from 'io-ts';
+import { date } from 'io-ts-types';
+import SimpleSchema from 'simpl-schema';
+import { BaseCodec, BaseOverrides } from './base';
+import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
+
+// A notification triggered by a chat message sent by a user.
+const ChatNotificationFields = t.type({
+  // The userId of the user for whom this notification targets.
+  user: t.string,
+
+  // The sender of the chat message that tripped the user's dingwords.
+  // System messages are forbidden from triggering dingword notifications.
+  sender: t.string,
+
+  // The puzzle to which this chat was sent.
+  puzzle: t.string,
+  // The hunt in which the puzzle resides.
+  hunt: t.string,
+  // The message body. Plain text.
+  text: t.string,
+  // The date this message was sent.  Used for ordering chats in the log.
+  timestamp: date,
+});
+
+const ChatNotificationFieldsOverrides: Overrides<t.TypeOf<typeof ChatNotificationFields>> = {
+  hunt: {
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  puzzle: {
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  user: {
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  sender: {
+    regEx: SimpleSchema.RegEx.Id,
+  },
+};
+
+const [ChatNotificationCodec, ChatNotificationOverrides] = inheritSchema(
+  BaseCodec, ChatNotificationFields,
+  BaseOverrides, ChatNotificationFieldsOverrides,
+);
+export { ChatNotificationCodec };
+export type ChatNotificationType = t.TypeOf<typeof ChatNotificationCodec>;
+
+// A single chat message
+const ChatNotifications = buildSchema(ChatNotificationCodec, ChatNotificationOverrides);
+
+export default ChatNotifications;

--- a/imports/lib/schemas/facade.ts
+++ b/imports/lib/schemas/facade.ts
@@ -1,4 +1,5 @@
 import Announcments from './announcements';
+import ChatNotifications from './chat_notifications';
 import ChatMessages from './chats';
 import DocumentPermissions from './document_permissions';
 import Documents from './documents';
@@ -14,6 +15,7 @@ import User from './users';
 const Schemas = {
   Announcments,
   ChatMessages,
+  ChatNotifications,
   DocumentPermissions,
   Documents,
   FeatureFlags,

--- a/imports/lib/schemas/profiles.ts
+++ b/imports/lib/schemas/profiles.ts
@@ -12,6 +12,7 @@ const ProfileFieldsType = t.type({
   displayName: t.string,
   phoneNumber: t.union([t.string, t.undefined]),
   muteApplause: t.union([t.boolean, t.undefined]),
+  dingwords: t.union([t.array(t.string), t.undefined]),
 });
 
 const ProfileFieldsOverrides: Overrides<t.TypeOf<typeof ProfileFieldsType>> = {

--- a/imports/server/chat-notifications.ts
+++ b/imports/server/chat-notifications.ts
@@ -1,0 +1,100 @@
+import { check } from 'meteor/check';
+import { Meteor, Subscription } from 'meteor/meteor';
+import { Mongo } from 'meteor/mongo';
+import Flags from '../flags';
+import ChatNotifications from '../lib/models/chat_notifications';
+import Hunts from '../lib/models/hunts';
+import Puzzles from '../lib/models/puzzles';
+import { ChatNotificationType } from '../lib/schemas/chat_notifications';
+import { HuntType } from '../lib/schemas/hunts';
+import { PuzzleType } from '../lib/schemas/puzzles';
+import RefCountedObserverMap from './refcounted-observer-map';
+
+class ChatNotificationWatcher {
+  sub: Subscription
+
+  chatNotifCursor: Mongo.Cursor<ChatNotificationType>
+
+  chatNotifWatch: Meteor.LiveQueryHandle
+
+  notifications: Record<string, ChatNotificationType>
+
+  huntRefCounter: RefCountedObserverMap<HuntType>
+
+  puzzleRefCounter: RefCountedObserverMap<PuzzleType>
+
+  constructor(sub: Subscription) {
+    this.sub = sub;
+    this.chatNotifCursor = ChatNotifications.find({
+      user: sub.userId,
+    });
+    this.notifications = {};
+    this.huntRefCounter = new RefCountedObserverMap(sub, Hunts);
+    this.puzzleRefCounter = new RefCountedObserverMap(sub, Puzzles);
+
+    this.chatNotifWatch = this.chatNotifCursor.observeChanges({
+      added: (id, fields) => {
+        this.notifications[id] = { _id: id, ...fields } as ChatNotificationType;
+        this.huntRefCounter.incref(fields.hunt!);
+        this.puzzleRefCounter.incref(fields.puzzle!);
+        this.sub.added(ChatNotifications.tableName, id, fields);
+      },
+
+      changed: (id, fields) => {
+        const huntUpdated = Object.prototype.hasOwnProperty.call(fields, 'hunt');
+        const puzzleUpdated = Object.prototype.hasOwnProperty.call(fields, 'puzzle');
+
+        // Ordering here important to avoid transient inconsistencies.
+        if (huntUpdated) {
+          this.huntRefCounter.incref(fields.hunt!);
+        }
+        if (puzzleUpdated) {
+          this.puzzleRefCounter.incref(fields.puzzle!);
+        }
+        this.sub.changed(ChatNotifications.tableName, id, fields);
+        if (puzzleUpdated) {
+          this.puzzleRefCounter.decref(this.notifications[id].puzzle);
+        }
+        if (huntUpdated) {
+          this.huntRefCounter.decref(this.notifications[id].hunt);
+        }
+
+        this.notifications[id] = { ...this.notifications[id], ...fields };
+      },
+
+      removed: (id) => {
+        this.sub.removed(ChatNotifications.tableName, id);
+        this.puzzleRefCounter.decref(this.notifications[id].puzzle);
+        this.huntRefCounter.decref(this.notifications[id].hunt);
+      },
+    });
+
+    this.sub.ready();
+  }
+
+  shutdown() {
+    this.chatNotifWatch.stop();
+  }
+}
+
+Meteor.publish('chatNotifications', function () {
+  if (!this.userId) {
+    throw new Meteor.Error(401, 'Not logged in');
+  }
+
+  if (Flags.active('disable.dingwords')) {
+    return;
+  }
+
+  const watcher = new ChatNotificationWatcher(this);
+  this.onStop(() => watcher.shutdown());
+});
+
+Meteor.methods({
+  dismissChatNotification(chatNotifId: unknown) {
+    check(this.userId, String);
+    check(chatNotifId, String);
+
+    ChatNotifications.remove(chatNotifId);
+  },
+});

--- a/imports/server/global-hooks.ts
+++ b/imports/server/global-hooks.ts
@@ -1,9 +1,11 @@
+import DingwordHooks from './hooks/dingword-hooks';
 import DiscordHooks from './hooks/discord-hooks';
 import HooksRegistry from './hooks/hooks-registry';
 
 // Instantiate the application-global hookset list.
 const GlobalHooks = new HooksRegistry();
-// Add all hooksets.  Right now that's just Discord.
+// Add all hooksets.
 GlobalHooks.addHookSet(DiscordHooks);
+GlobalHooks.addHookSet(DingwordHooks);
 
 export default GlobalHooks;

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -3,17 +3,16 @@ import { Meteor, Subscription } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import Ansible from '../ansible';
-import Base from '../lib/models/base';
 import Guesses from '../lib/models/guess';
 import Hunts from '../lib/models/hunts';
 import Profiles from '../lib/models/profiles';
 import Puzzles from '../lib/models/puzzles';
-import { BaseType } from '../lib/schemas/base';
 import { GuessType } from '../lib/schemas/guess';
 import { HuntType } from '../lib/schemas/hunts';
 import { PuzzleType } from '../lib/schemas/puzzles';
 import { sendChatMessage } from './chat';
 import GlobalHooks from './global-hooks';
+import RefCountedObserverMap from './refcounted-observer-map';
 
 function addChatMessage(guess: GuessType, newState: GuessType['state']): void {
   const message = `Guess ${guess.guess} was marked ${newState}`;
@@ -52,88 +51,6 @@ function transitionGuess(guess: GuessType, newState: GuessType['state']) {
       },
     });
     GlobalHooks.runPuzzleNoLongerSolvedHooks(guess.puzzle);
-  }
-}
-
-// It's easier to create one observer per object, rather than try and have a
-// single observer with an $in query. It means we don't have to start/stop the
-// observer. Identical queries from different users will get deduped on the
-// server side, and there are relatively few operators, so this should be
-// reasonably safe.
-class RecordUpdateObserver<T extends BaseType> {
-  sub: Subscription;
-
-  tableName: string;
-
-  id: string;
-
-  handle: Meteor.LiveQueryHandle;
-
-  exists: boolean;
-
-  constructor(sub: Subscription, id: string, model: Base<T>) {
-    this.sub = sub;
-    this.tableName = model.tableName;
-    this.id = id;
-    this.exists = false;
-    this.handle = model.find(id).observeChanges({
-      added: (_, fields) => {
-        this.exists = true;
-        this.sub.added(model.tableName, id, fields);
-      },
-      changed: (_, fields) => {
-        this.sub.changed(model.tableName, id, fields);
-      },
-      removed: () => {
-        this.exists = false;
-        this.sub.removed(model.tableName, id);
-      },
-    });
-  }
-
-  destroy() {
-    if (this.exists) {
-      this.sub.removed(this.tableName, this.id);
-    }
-
-    this.handle.stop();
-  }
-}
-
-class RefCountedObserverMap<T extends BaseType> {
-  private sub: Subscription;
-
-  private model: Base<T>;
-
-  private subscribers: Map<string, { refCount: number, subscriber: RecordUpdateObserver<T> }>;
-
-  constructor(sub: Subscription, model: Base<T>) {
-    this.sub = sub;
-    this.model = model;
-    this.subscribers = new Map();
-  }
-
-  incref(id: string) {
-    if (this.subscribers.has(id)) {
-      this.subscribers.get(id)!.refCount += 1;
-    } else {
-      this.subscribers.set(id, {
-        refCount: 1,
-        subscriber: new RecordUpdateObserver(this.sub, id, this.model),
-      });
-    }
-  }
-
-  decref(id: string) {
-    const record = this.subscribers.get(id);
-    if (!record) {
-      return;
-    }
-    record.refCount -= 1;
-    if (record.refCount <= 0) {
-      record.subscriber.destroy();
-      this.subscribers.delete(id);
-    }
   }
 }
 

--- a/imports/server/hooks/dingword-hooks.ts
+++ b/imports/server/hooks/dingword-hooks.ts
@@ -1,0 +1,78 @@
+import { Meteor } from 'meteor/meteor';
+import Flags from '../../flags';
+import ChatNotifications from '../../lib/models/chat_notifications';
+import ChatMessages from '../../lib/models/chats';
+import Profiles from '../../lib/models/profiles';
+import Hookset from './hookset';
+
+const DingwordHooks: Hookset = {
+  onChatMessageCreated(chatMessageId: string) {
+    // Respect feature flag.
+    if (Flags.active('disable.dingwords')) {
+      return;
+    }
+
+    // const start = Date.now();
+    const chatMessage = ChatMessages.findOne(chatMessageId)!;
+
+    if (!chatMessage.sender) {
+      // Don't notify for system messages.
+      return;
+    }
+
+    // Find all users who are in this hunt.
+    const huntMembers = Meteor.users.find({
+      hunts: chatMessage.hunt,
+    }, {
+      fields: { _id: 1 },
+    }).fetch().map((u) => {
+      return u._id;
+    });
+
+    // Fetch the profiles of all those users.
+    const memberProfiles = Profiles.find({
+      _id: {
+        $in: huntMembers,
+      },
+    }, { fields: { dingwords: 1 } });
+
+    // For each user with dingwords, check if this message (normalized to
+    // lower-case) triggers any of their dingwords.
+    const normalizedText = chatMessage.text.trim().toLowerCase();
+    memberProfiles.forEach((p) => {
+      // Avoid making users ding themselves.
+      if (p._id === chatMessage.sender) {
+        return;
+      }
+
+      const dingwords = p.dingwords;
+      if (dingwords) {
+        for (let i = 0; i < dingwords.length; i++) {
+          const dingword = dingwords[i];
+          if (normalizedText.indexOf(dingword) !== -1) {
+            // It matched!  We should notify the user of this message.
+
+            // console.log(`u ${p._id} dingword ${dingword} matched message ${chatMessage.text}`);
+            ChatNotifications.insert({
+              user: p._id,
+              sender: chatMessage.sender,
+              puzzle: chatMessage.puzzle,
+              hunt: chatMessage.hunt,
+              text: chatMessage.text,
+              timestamp: chatMessage.timestamp,
+            });
+
+            // Once we match, we don't need to check any other dingwords.
+            break;
+          }
+        }
+      }
+    });
+
+    // const end = Date.now();
+    // const elapsed = end - start;
+    // console.log(`Dingword hooks ran in ${elapsed} msec`);
+  },
+};
+
+export default DingwordHooks;

--- a/imports/server/hooks/dingword-hooks.ts
+++ b/imports/server/hooks/dingword-hooks.ts
@@ -34,6 +34,7 @@ const DingwordHooks: Hookset = {
       _id: {
         $in: huntMembers,
       },
+      'dingwords.0': { $exists: true },
     }, { fields: { dingwords: 1 } });
 
     // For each user with dingwords, check if this message (normalized to

--- a/imports/server/migrations/32-index-chat-notifications.ts
+++ b/imports/server/migrations/32-index-chat-notifications.ts
@@ -1,0 +1,11 @@
+import { Migrations } from 'meteor/percolate:migrations';
+import ChatNotifications from '../../lib/models/chat_notifications';
+
+Migrations.add({
+  version: 32,
+  name: 'Add indexes on ChatNotifications',
+  up() {
+    // Ensure that the query pattern in chat-notifications.ts is indexed.
+    ChatNotifications._ensureIndex({ deleted: 1, user: 1 });
+  },
+});

--- a/imports/server/migrations/33-index-profile-dingwords.ts
+++ b/imports/server/migrations/33-index-profile-dingwords.ts
@@ -1,0 +1,11 @@
+import { Migrations } from 'meteor/percolate:migrations';
+import Profiles from '../../lib/models/profiles';
+
+Migrations.add({
+  version: 33,
+  name: 'Add dingword index to Profiles',
+  up() {
+    // Ensure that the query pattern used in dingword-hooks.ts is indexed.
+    Profiles._ensureIndex({ deleted: 1, _id: 1, dingwords: 1 });
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -30,3 +30,4 @@ import './28-discord-cache-indexes';
 import './29-fix-guild-setting-id';
 import './30-index-call-participants';
 import './31-index-call-signals';
+import './32-index-chat-notifications';

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -31,3 +31,4 @@ import './29-fix-guild-setting-id';
 import './30-index-call-participants';
 import './31-index-call-signals';
 import './32-index-chat-notifications';
+import './33-index-profile-dingwords';

--- a/imports/server/profile.ts
+++ b/imports/server/profile.ts
@@ -16,6 +16,7 @@ Meteor.methods({
       displayName: String,
       phoneNumber: String,
       muteApplause: Boolean,
+      dingwords: [String],
     });
     const user = Meteor.users.findOne(this.userId)!;
     const primaryEmail = user.emails && user.emails[0].address;
@@ -29,6 +30,7 @@ Meteor.methods({
         primaryEmail,
         phoneNumber: newProfile.phoneNumber,
         muteApplause: newProfile.muteApplause,
+        dingwords: newProfile.dingwords,
         deleted: false,
       },
     }, {

--- a/imports/server/refcounted-observer-map.ts
+++ b/imports/server/refcounted-observer-map.ts
@@ -1,0 +1,87 @@
+import { Meteor, Subscription } from 'meteor/meteor';
+import Base from '../lib/models/base';
+import { BaseType } from '../lib/schemas/base';
+
+// It's easier to create one observer per object, rather than try and have a
+// single observer with an $in query. It means we don't have to start/stop the
+// observer. Identical queries from different users will get deduped on the
+// server side, and there are relatively few operators, so this should be
+// reasonably safe.
+class RecordUpdateObserver<T extends BaseType> {
+  sub: Subscription;
+
+  tableName: string;
+
+  id: string;
+
+  handle: Meteor.LiveQueryHandle;
+
+  exists: boolean;
+
+  constructor(sub: Subscription, id: string, model: Base<T>) {
+    this.sub = sub;
+    this.tableName = model.tableName;
+    this.id = id;
+    this.exists = false;
+    this.handle = model.find(id).observeChanges({
+      added: (_, fields) => {
+        this.exists = true;
+        this.sub.added(model.tableName, id, fields);
+      },
+      changed: (_, fields) => {
+        this.sub.changed(model.tableName, id, fields);
+      },
+      removed: () => {
+        this.exists = false;
+        this.sub.removed(model.tableName, id);
+      },
+    });
+  }
+
+  destroy() {
+    if (this.exists) {
+      this.sub.removed(this.tableName, this.id);
+    }
+
+    this.handle.stop();
+  }
+}
+
+class RefCountedObserverMap<T extends BaseType> {
+  private sub: Subscription;
+
+  private model: Base<T>;
+
+  private subscribers: Map<string, { refCount: number, subscriber: RecordUpdateObserver<T> }>;
+
+  constructor(sub: Subscription, model: Base<T>) {
+    this.sub = sub;
+    this.model = model;
+    this.subscribers = new Map();
+  }
+
+  incref(id: string) {
+    if (this.subscribers.has(id)) {
+      this.subscribers.get(id)!.refCount += 1;
+    } else {
+      this.subscribers.set(id, {
+        refCount: 1,
+        subscriber: new RecordUpdateObserver(this.sub, id, this.model),
+      });
+    }
+  }
+
+  decref(id: string) {
+    const record = this.subscribers.get(id);
+    if (!record) {
+      return;
+    }
+    record.refCount -= 1;
+    if (record.refCount <= 0) {
+      record.subscriber.destroy();
+      this.subscribers.delete(id);
+    }
+  }
+}
+
+export default RefCountedObserverMap;

--- a/server/main.ts
+++ b/server/main.ts
@@ -16,6 +16,7 @@ import '../imports/server/api-init';
 import '../imports/server/api_keys';
 import '../imports/server/calls';
 import '../imports/server/chat';
+import '../imports/server/chat-notifications';
 import '../imports/server/discord';
 import '../imports/server/discord-client-refresher';
 import '../imports/server/feature_flags';


### PR DESCRIPTION
The simplest thing that could work, labeled as experimental, and guarded by a feature flag in the event the naive approach turns out to generate way too much server load.

We add:

* a Profile field `dingwords`, with a list of strings
* a way to edit it in OwnProfilePage
* a circuit breaker `disable.dingwords` on the setup page
* a `DingwordHookset` to, for each chat message sent, check if any users want to get notified, and generate notifications accordingly
* a reactive smart subscription `chatNotifications` which ensures that the puzzle and hunt are available clientside if a chat notification references them
* a new NotificationCenter notification type which links to the puzzle, and shows the sender and the message, and allows the notification to be dismissed

No desktop notifications (permissions and getting them to be interactive from the right tab if multiple tabs are open is more complicated than I want to deal with right now).  No sounds either -- we're likely to have lots of audio usage during hunt anyway, and the less we generate annoying noise the better off we'll be.

Relates to #337 (but only covers basic text, not @-mentions)