### PR TITLE
Add copy-to-clipboard button to related puzzles

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -582,6 +582,20 @@ table.puzzle-list {
   .popover-body {
     overflow: auto;
   }
+
+  // Applying display:flex directly to popover-header leads to incorrect vertical sizing when the
+  // popover's height is constrained by the viewport. Use an inner div to avoid this.
+  .related-puzzle-popover-header-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .related-puzzle-popover-controls {
+    align-self: start;
+    margin-left: 8px;
+    flex: 0 0 auto;
+  }
 }
 
 .SplitPane > .Pane.collapsing:before {

--- a/imports/client/components/RelatedPuzzleList.tsx
+++ b/imports/client/components/RelatedPuzzleList.tsx
@@ -66,3 +66,4 @@ class RelatedPuzzleList extends React.PureComponent<RelatedPuzzleListProps> {
 }
 
 export default RelatedPuzzleList;
+export { RelatedPuzzleList, sortPuzzlesByRelevanceWithinPuzzleGroup };


### PR DESCRIPTION
Adds a button to copy related puzzles and answers to clipboard.

Format is tab delimited for pasting into spreadsheets. Each answer has its own line (with puzzle name repeated). If fewer answers are present than expected, rows with blank answers are appended. Exports at least 1 line even for puzzles with 0 expected answers (which is currently not allowed).