### PR TITLE
PuzzleListPage: show number of items visible/total

### DIFF
--- a/client/stylesheets/puzzlelist.scss
+++ b/client/stylesheets/puzzlelist.scss
@@ -3,15 +3,26 @@
 .puzzle-view-controls {
   display: flex;
   flex-wrap: wrap;
+  align-items: flex-end;
   justify-content: space-between;
-  .btn-toolbar:not(:last-child) {
-    margin-right: 0.5em;
+  .expand {
+    flex: 1 1 auto;
   }
-  .puzzle-list-filter-toolbar {
-    flex: 1 1 0;
-    > .input-group {
-      width: 100%;
+  .puzzle-view-controls-section {
+    &:not(:last-child) {
+      margin-right: 0.5em;
     }
+    .puzzle-list-filter-toolbar {
+      flex: 1 1 auto;
+      width: 100%;
+      .input-group {
+        width: 100%;
+      }
+    }
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-end;
   }
 }
 

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -190,15 +190,7 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
     }
   };
 
-  renderList = () => {
-    const matchingSearch = this.puzzlesMatchingSearchString(this.props.puzzles);
-    const matchingSearchAndSolved = this.puzzlesMatchingSolvedFilter(matchingSearch);
-    // Normally, we'll just show matchingSearchAndSolved, but if that produces
-    // no results, and there *is* a solved puzzle that is not being displayed due
-    // to the solved filter, then show that and a note that we're showing solved
-    // puzzles because no unsolved puzzles matched.
-    const solvedOverConstrains = matchingSearch.length > 0 && matchingSearchAndSolved.length === 0;
-    const retainedPuzzles = solvedOverConstrains ? matchingSearch : matchingSearchAndSolved;
+  renderList = (retainedPuzzles: PuzzleType[], solvedOverConstrains: boolean) => {
     const maybeMatchWarning = solvedOverConstrains && (
       <Alert variant="info">
         No matches found in unsolved puzzles; showing matches from solved puzzles
@@ -269,48 +261,65 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
         />
       </>
     );
+
+    const matchingSearch = this.puzzlesMatchingSearchString(this.props.puzzles);
+    const matchingSearchAndSolved = this.puzzlesMatchingSolvedFilter(matchingSearch);
+    // Normally, we'll just show matchingSearchAndSolved, but if that produces
+    // no results, and there *is* a solved puzzle that is not being displayed due
+    // to the solved filter, then show that and a note that we're showing solved
+    // puzzles because no unsolved puzzles matched.
+    const solvedOverConstrains = matchingSearch.length > 0 && matchingSearchAndSolved.length === 0;
+    const retainedPuzzles = solvedOverConstrains ? matchingSearch : matchingSearchAndSolved;
+
     return (
       <div>
         <FormGroup>
-          <FormLabel htmlFor="jr-puzzle-search">View puzzles by:</FormLabel>
           <div className="puzzle-view-controls">
-            <ButtonToolbar>
-              <ToggleButtonGroup type="radio" className="mr-2" name="puzzle-view" defaultValue="group" value={this.state.displayMode} onChange={this.switchView}>
-                <ToggleButton variant="outline-info" value="group">Group</ToggleButton>
-                <ToggleButton variant="outline-info" value="unlock">Unlock</ToggleButton>
-              </ToggleButtonGroup>
-              <ToggleButtonGroup
-                type="checkbox"
-                value={this.state.showSolved ? ['true'] : []}
-                onChange={this.changeShowSolved}
-              >
-                <ToggleButton variant="outline-info" value="true">Show solved</ToggleButton>
-              </ToggleButtonGroup>
-            </ButtonToolbar>
-            <ButtonToolbar className="puzzle-list-filter-toolbar">
-              <InputGroup>
-                <FormControl
-                  id="jr-puzzle-search"
-                  as="input"
-                  type="text"
-                  ref={this.searchBarRef}
-                  placeholder="Filter by title, answer, or tag"
-                  value={this.getSearchString()}
-                  onChange={this.onSearchStringChange}
-                />
-                <InputGroup.Append>
-                  <Button variant="secondary" onClick={this.clearSearch}>
-                    <FontAwesomeIcon icon={faEraser} />
-                  </Button>
-                </InputGroup.Append>
-              </InputGroup>
-            </ButtonToolbar>
+            <div className="puzzle-view-controls-section">
+              <FormLabel>View puzzles by:</FormLabel>
+              <ButtonToolbar className="puzzle-view-buttons">
+                <ToggleButtonGroup type="radio" className="mr-2" name="puzzle-view" defaultValue="group" value={this.state.displayMode} onChange={this.switchView}>
+                  <ToggleButton variant="outline-info" value="group">Group</ToggleButton>
+                  <ToggleButton variant="outline-info" value="unlock">Unlock</ToggleButton>
+                </ToggleButtonGroup>
+                <ToggleButtonGroup
+                  type="checkbox"
+                  value={this.state.showSolved ? ['true'] : []}
+                  onChange={this.changeShowSolved}
+                >
+                  <ToggleButton variant="outline-info" value="true">Show solved</ToggleButton>
+                </ToggleButtonGroup>
+              </ButtonToolbar>
+            </div>
+            <div className="puzzle-view-controls-section expand">
+              <FormLabel htmlFor="jr-puzzle-search">
+                {`Showing ${retainedPuzzles.length}/${this.props.puzzles.length} items`}
+              </FormLabel>
+              <ButtonToolbar className="puzzle-list-filter-toolbar">
+                <InputGroup>
+                  <FormControl
+                    id="jr-puzzle-search"
+                    as="input"
+                    type="text"
+                    ref={this.searchBarRef}
+                    placeholder="Filter by title, answer, or tag"
+                    value={this.getSearchString()}
+                    onChange={this.onSearchStringChange}
+                  />
+                  <InputGroup.Append>
+                    <Button variant="secondary" onClick={this.clearSearch}>
+                      <FontAwesomeIcon icon={faEraser} />
+                    </Button>
+                  </InputGroup.Append>
+                </InputGroup>
+              </ButtonToolbar>
+            </div>
             <ButtonToolbar>
               {addPuzzleContent}
             </ButtonToolbar>
           </div>
         </FormGroup>
-        {this.renderList()}
+        {this.renderList(retainedPuzzles, solvedOverConstrains)}
       </div>
     );
   }


### PR DESCRIPTION
Makes it easy to get a sense of overall hunt progress at a glance.

Text vertically aligns with the "View puzzles by:" label and the search box and is a label for the search box:
![Screenshot_20210311_184538](https://user-images.githubusercontent.com/307325/110884456-fa8bb880-8299-11eb-8e8e-36021d0f2199.png)

Updates to reflect the number of matched items:
![Screenshot_20210311_184602](https://user-images.githubusercontent.com/307325/110884502-0aa39800-829a-11eb-9235-3678ba15c4e9.png)

Counts by puzzles, not by rows shown, since some puzzles may appear multiple times:
![Screenshot_20210311_184628](https://user-images.githubusercontent.com/307325/110884534-17c08700-829a-11eb-8518-f515f2c4d045.png)
