### PR TITLE
Save last "Show solved" state per Hunt in localStorage

### DIFF
--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -46,6 +46,10 @@ interface PuzzleListViewState {
   showSolved: boolean;
 }
 
+function showSolvedStorageKey(huntId: string): string {
+  return `showsolved-${huntId}`;
+}
+
 class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListViewState> {
   addModalRef: React.RefObject<PuzzleModalForm>
 
@@ -55,9 +59,12 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
 
   constructor(props: PuzzleListViewProps) {
     super(props);
+    const showSolvedKey = showSolvedStorageKey(props.huntId);
+    const localStorageShowSolved = localStorage.getItem(showSolvedKey);
+    const showSolved = !(localStorageShowSolved === 'false');
     this.state = {
       displayMode: 'group',
-      showSolved: true,
+      showSolved,
     };
     this.addModalRef = React.createRef();
     this.searchBarRef = React.createRef();
@@ -179,9 +186,21 @@ class PuzzleListView extends React.Component<PuzzleListViewProps, PuzzleListView
   };
 
   changeShowSolved = () => {
-    this.setState((oldState) => ({
-      showSolved: !oldState.showSolved,
-    }));
+    this.setState((oldState) => {
+      const newState = !oldState.showSolved;
+      // Try to save the new state in localStorage, so that we'll use the
+      // last-set value again the next time we load up this view.
+      try {
+        // Note: localStorage serialization converts booleans to strings anyway
+        localStorage.setItem(showSolvedStorageKey(this.props.huntId), `${newState}`);
+      } catch (e) {
+        // Ignore failure to set value in storage; this is best-effort and if
+        // localStorage isn't available then whatever
+      }
+      return {
+        showSolved: newState,
+      };
+    });
   };
 
   showAddModal = () => {


### PR DESCRIPTION
And use that value as the default value on PuzzleListPage for that Hunt.
This has the effect of making the toggle "sticky", which makes the "hide
solved" view more useful, especially later on in hunts when there are
many solved puzzles and we're trying to see the ones that remain more
clearly.

Now that we have UI that indicates that we're hiding some subset of
puzzles when applying either a search or an unsolved filter, I'm less
concerned about folks accidentally hiding solved puzzles and being
confused when they can't find the puzzle they're looking for, so I'm
more comfortable with the idea of hiding solved puzzles more of the
time.

Fixes #423.