### PR TITLE
Make "report an issue" link point to GitHub issues

### DIFF
--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -82,7 +82,12 @@ class AppNavbar extends React.Component<AppNavbarProps> {
               <RRBS.LinkContainer to={`/users/${this.props.userId}`}>
                 <DropdownItem eventKey="1">My Profile</DropdownItem>
               </RRBS.LinkContainer>
-              <DropdownItem eventKey="2" href="mailto:dfa-web@mit.edu">
+              <DropdownItem
+                eventKey="2"
+                href="https://github.com/deathandmayhem/jolly-roger/issues"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 Report an issue
               </DropdownItem>
               <DropdownItem eventKey="3" onSelect={this.logout}>Sign out</DropdownItem>


### PR DESCRIPTION
I strongly suspect no one has ever actually clicked this link, but just
in case, since we're running this as an open project, it makes more
sense for the link to point to our public issues tracker than our old
internal mailinglist, and changing the link is ~a free action.

(There's a couple other places we still ref dfa-web@ in email templates; I'm punting on that for now since I'm imagining that as part of a more holistic "branding/whitelabeling" workstream ala #193.)