### PR TITLE
Make email configurable via a new Setting with templates

### DIFF
--- a/imports/lib/roles.ts
+++ b/imports/lib/roles.ts
@@ -10,6 +10,7 @@ Roles.registerAction('discord.useBotAPIs', true);
 Roles.registerAction('discord.updateRole', true);
 Roles.registerAction('users.makeOperator', true);
 Roles.registerAction('webrtc.configureServers', true);
+Roles.registerAction('email.configureBranding', true);
 
 const InactiveOperatorRole = new Roles.Role('inactiveOperator');
 InactiveOperatorRole.allow('users.makeOperator', () => true);

--- a/imports/lib/schemas/settings.ts
+++ b/imports/lib/schemas/settings.ts
@@ -45,6 +45,16 @@ export const SettingCodec = t.intersection([
         urls: t.array(t.string),
       }),
     }),
+    t.type({
+      name: t.literal('email.branding'),
+      value: t.type({
+        from: t.union([t.string, t.undefined]),
+        enrollAccountMessageSubjectTemplate: t.union([t.string, t.undefined]),
+        enrollAccountMessageTemplate: t.union([t.string, t.undefined]),
+        existingJoinMessageSubjectTemplate: t.union([t.string, t.undefined]),
+        existingJoinMessageTemplate: t.union([t.string, t.undefined]),
+      }),
+    }),
   ]),
 ]);
 export type SettingType = t.TypeOf<typeof SettingCodec>;

--- a/imports/server/setup.ts
+++ b/imports/server/setup.ts
@@ -197,6 +197,32 @@ Meteor.methods({
       Settings.remove({ name: 'webrtc.turnserver' });
     }
   },
+
+  setupEmailBranding(from: unknown, enrollSubject: unknown, enrollMessage: unknown,
+    joinSubject: unknown, joinMessage: unknown) {
+    check(this.userId, String);
+    Roles.checkPermission(this.userId, 'email.configureBranding');
+    check(from, Match.Optional(String));
+    check(enrollSubject, Match.Optional(String));
+    check(enrollMessage, Match.Optional(String));
+    check(joinSubject, Match.Optional(String));
+    check(joinMessage, Match.Optional(String));
+
+    const value = {
+      from: from || undefined,
+      enrollAccountMessageSubjectTemplate: enrollSubject || undefined,
+      enrollAccountMessageTemplate: enrollMessage || undefined,
+      existingJoinMessageSubjectTemplate: joinSubject || undefined,
+      existingJoinMessageTemplate: joinMessage || undefined,
+    };
+
+    Settings.upsert({ name: 'email.branding' }, {
+      $set: {
+        name: 'email.branding',
+        value,
+      },
+    });
+  },
 });
 
 Meteor.publish('hasUsers', function () {


### PR DESCRIPTION
This change:

* adds a new Setting type for email configuration which covers all the
  deployment-specific configuration that was previously hardcoded in the
  jolly-roger source
* adds a Meteor method in setup.ts to save this configuration to the DB
* adds UI in SetupPage to edit the From: address and email templates,
  along with an explanation of what variables are available at
  email-rendering time, and to call the method to save the config values
* adds code in imports/server/accounts.ts to monitor that setting for changes and update
  `Accounts.emailTemplates` accordingly when changes are observed, so that the Meteor
  accounts system will use the templates and `From:` as desired.
* adds code to render Mustache templates to produce email contents when
  we want to send email

Related to #193.

Once we merge this, we should update the configuration on our production instance to explicitly specify appropriate values for each of these fields.