### PR TITLE
Fix bug where saving profile during onboarding was broken by missing dingwords

### DIFF
--- a/imports/client/components/AccountForm.tsx
+++ b/imports/client/components/AccountForm.tsx
@@ -142,6 +142,7 @@ class AccountForm extends React.Component<AccountFormProps, AccountFormState> {
       displayName: this.state.displayName,
       phoneNumber: this.state.phoneNumber,
       muteApplause: false,
+      dingwords: [],
     };
 
     this.setState({


### PR DESCRIPTION
There's two sites we call the `saveProfile` Meteor method; the one in
the enrollment flow was broken because we did not include a `dingwords`
parameter, which the server checks.