### PR TITLE
Add async loading for SetupPage and RTCDebugPage

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -33,7 +33,7 @@ react-meteor-data@2.1.2
 fourseven:scss
 shell-server@0.5.0
 google-oauth@1.3.0
-dynamic-import@0.6.0
+dynamic-import
 underscore@1.0.10
 server-render@0.3.1
 typescript@4.2.2

--- a/client/stylesheets/loading.scss
+++ b/client/stylesheets/loading.scss
@@ -1,0 +1,8 @@
+.loading {
+  position: fixed;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/imports/client/components/Loading.tsx
+++ b/imports/client/components/Loading.tsx
@@ -1,0 +1,11 @@
+import { faSpinner } from '@fortawesome/free-solid-svg-icons/faSpinner';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React from 'react';
+
+export default React.memo(() => {
+  return (
+    <div className="loading">
+      <FontAwesomeIcon icon={faSpinner} color="#aaa" size="3x" pulse />
+    </div>
+  );
+});

--- a/imports/client/components/Routes.tsx
+++ b/imports/client/components/Routes.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { Route, Switch } from 'react-router';
 import { BreadcrumbsProvider } from '../hooks/breadcrumb';
 import useDocumentTitle from '../hooks/use-document-title';
@@ -8,37 +8,41 @@ import EnrollForm from './EnrollForm';
 import FirstUserForm from './FirstUserForm';
 import HuntApp from './HuntApp';
 import HuntListPage from './HuntListPage';
+import Loading from './Loading';
 import LoginForm from './LoginForm';
 import PasswordResetForm from './PasswordResetForm';
 import ProfilePage from './ProfilePage';
-import RTCDebugPage from './RTCDebugPage';
 import RootRedirector from './RootRedirector';
-import SetupPage from './SetupPage';
 import UnauthenticatedRoute from './UnauthenticatedRoute';
+
+const SetupPage = React.lazy(() => import('./SetupPage'));
+const RTCDebugPage = React.lazy(() => import('./RTCDebugPage'));
 
 const Routes = React.memo(() => {
   useDocumentTitle('Jolly Roger');
 
   return (
     <BreadcrumbsProvider>
-      <Switch>
-        {/* Index redirect */}
-        <Route exact path="/" component={RootRedirector} />
+      <Suspense fallback={<Loading />}>
+        <Switch>
+          {/* Index redirect */}
+          <Route exact path="/" component={RootRedirector} />
 
-        {/* Authenticated routes - if user not logged in, get redirected to /login */}
-        <AuthenticatedRoute path="/hunts/:huntId" component={HuntApp} />
-        <AuthenticatedRoute path="/hunts" component={HuntListPage} />
-        <AuthenticatedRoute path="/users/:userId" component={ProfilePage} />
-        <AuthenticatedRoute path="/users" component={AllProfileListPage} />
-        <AuthenticatedRoute path="/setup" component={SetupPage} />
-        <AuthenticatedRoute path="/rtcdebug" component={RTCDebugPage} />
+          {/* Authenticated routes - if user not logged in, get redirected to /login */}
+          <AuthenticatedRoute path="/hunts/:huntId" component={HuntApp} />
+          <AuthenticatedRoute path="/hunts" component={HuntListPage} />
+          <AuthenticatedRoute path="/users/:userId" component={ProfilePage} />
+          <AuthenticatedRoute path="/users" component={AllProfileListPage} />
+          <AuthenticatedRoute path="/setup" component={SetupPage} />
+          <AuthenticatedRoute path="/rtcdebug" component={RTCDebugPage} />
 
-        {/* Unauthenticated routes - if user already logged in, get redirected to /hunts */}
-        <UnauthenticatedRoute path="/login" component={LoginForm} />
-        <UnauthenticatedRoute path="/reset-password/:token" component={PasswordResetForm} />
-        <UnauthenticatedRoute path="/enroll/:token" component={EnrollForm} />
-        <UnauthenticatedRoute path="/create-first-user" component={FirstUserForm} />
-      </Switch>
+          {/* Unauthenticated routes - if user already logged in, get redirected to /hunts */}
+          <UnauthenticatedRoute path="/login" component={LoginForm} />
+          <UnauthenticatedRoute path="/reset-password/:token" component={PasswordResetForm} />
+          <UnauthenticatedRoute path="/enroll/:token" component={EnrollForm} />
+          <UnauthenticatedRoute path="/create-first-user" component={FirstUserForm} />
+        </Switch>
+      </Suspense>
     </BreadcrumbsProvider>
   );
 });


### PR DESCRIPTION
This is made pretty straightforward with the introduction of React.lazy and the Suspense component. The only thing we really need to provide is a placeholder component to use as a loading indicator.

This doesn't seem to make much of a dent in the bundle size, likely because most of the bundle is dependencies, and I don't think removing these pages allows for pruning many dependencies, but it still seems like good hygiene and a good leaping off point for more code splitting later.

Here's what the loading component looks like for reference:

![Screenshot from 2021-08-06 11-29-33](https://user-images.githubusercontent.com/28167/128557822-543a3662-85b9-4a91-b76f-946af4fc93bd.png)

For what it's worth, I'm somewhat tempted to switch some of the "loading..." text placeholders to use the spinner instead, since I think the UI is a little cleaner. I'll probably play with it some and see if it works.

I'm going to say this fixes #111, although there is more work to do if we want.