### PR TITLE
Make react-select dynamically imported

### DIFF
--- a/client/stylesheets/loading.scss
+++ b/client/stylesheets/loading.scss
@@ -1,8 +1,11 @@
-.loading {
-  position: fixed;
+.loading-fullsize {
+  position: absolute;
+  top: 0;
+  left: 0;
   height: 100%;
   width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
+  background: rgba(255, 255, 255, 0.5);
 }

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -51,7 +51,7 @@ $administrivia-puzzle-background-color: #dfdfff;
   padding: 4px 2px;
   margin-bottom: 4px;
 
-  > * {
+  .puzzle-column {
     padding: 0 2px;
     display: inline-block;
     flex: none;

--- a/imports/client/components/Loading.tsx
+++ b/imports/client/components/Loading.tsx
@@ -1,11 +1,12 @@
 import { faSpinner } from '@fortawesome/free-solid-svg-icons/faSpinner';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import classNames from 'classnames';
 import React from 'react';
 
-export default React.memo(() => {
+export default React.memo(({ inline = false }: { inline?: boolean }) => {
   return (
-    <div className="loading">
-      <FontAwesomeIcon icon={faSpinner} color="#aaa" size="3x" pulse />
+    <div className={classNames('loading', inline ? 'loading-inline' : 'loading-fullsize')}>
+      <FontAwesomeIcon icon={faSpinner} color="#aaa" size={inline ? undefined : '3x'} pulse />
     </div>
   );
 });

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -112,17 +112,17 @@ const Puzzle = React.memo((props: PuzzleProps) => {
         />
       ) : null}
       {props.canUpdate && (
-        <div className="puzzle-edit-button">
+        <div className="puzzle-column puzzle-edit-button">
           {editButton}
         </div>
       )}
-      <div className="puzzle-title">
+      <div className="puzzle-column puzzle-title">
         <Link to={linkTarget}>{props.puzzle.title}</Link>
       </div>
-      <div className="puzzle-view-count">
+      <div className="puzzle-column puzzle-view-count">
         {!(props.puzzle.answers.length >= props.puzzle.expectedAnswerCount) && !isAdministrivia && <SubscriberCount puzzleId={props.puzzle._id} />}
       </div>
-      <div className="puzzle-link">
+      <div className="puzzle-column puzzle-link">
         {props.puzzle.url ? (
           <span>
             <a href={props.puzzle.url} target="_blank" rel="noopener noreferrer" title="Open the puzzle">
@@ -131,10 +131,10 @@ const Puzzle = React.memo((props: PuzzleProps) => {
           </span>
         ) : null}
       </div>
-      <div className="puzzle-answer">
+      <div className="puzzle-column puzzle-answer">
         {answers}
       </div>
-      <TagList puzzle={props.puzzle} tags={ownTags} linkToSearch={props.layout === 'grid'} popoverRelated={false} />
+      <TagList className="puzzle-column" puzzle={props.puzzle} tags={ownTags} linkToSearch={props.layout === 'grid'} popoverRelated={false} />
     </div>
   );
 });

--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -1,4 +1,5 @@
 import React, {
+  Suspense,
   useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState,
 } from 'react';
 import Alert from 'react-bootstrap/Alert';
@@ -7,11 +8,13 @@ import FormControl, { FormControlProps } from 'react-bootstrap/FormControl';
 import FormGroup from 'react-bootstrap/FormGroup';
 import FormLabel from 'react-bootstrap/FormLabel';
 import Row from 'react-bootstrap/Row';
-import Creatable from 'react-select/creatable';
 import { PuzzleType } from '../../lib/schemas/puzzles';
 import { TagType } from '../../lib/schemas/tags';
 import LabelledRadioGroup from './LabelledRadioGroup';
+import Loading from './Loading';
 import ModalForm, { ModalFormHandle } from './ModalForm';
+
+const Creatable = React.lazy(() => import('react-select/creatable'));
 
 /* eslint-disable max-len */
 
@@ -230,80 +233,82 @@ const PuzzleModalForm = React.forwardRef((
   ) : null;
 
   return (
-    <ModalForm
-      ref={formRef}
-      title={props.puzzle ? 'Edit puzzle' : 'Add puzzle'}
-      onSubmit={onFormSubmit}
-      submitDisabled={disableForm}
-    >
-      <FormGroup as={Row}>
-        <FormLabel column xs={3} htmlFor="jr-new-puzzle-title">
-          Title
-        </FormLabel>
-        <Col xs={9}>
-          <FormControl
-            id="jr-new-puzzle-title"
-            type="text"
-            autoFocus
-            disabled={disableForm}
-            onChange={onTitleChange}
-            value={currentTitle}
-          />
-        </Col>
-      </FormGroup>
+    <Suspense fallback={<div><Loading /></div>}>
+      <ModalForm
+        ref={formRef}
+        title={props.puzzle ? 'Edit puzzle' : 'Add puzzle'}
+        onSubmit={onFormSubmit}
+        submitDisabled={disableForm}
+      >
+        <FormGroup as={Row}>
+          <FormLabel column xs={3} htmlFor="jr-new-puzzle-title">
+            Title
+          </FormLabel>
+          <Col xs={9}>
+            <FormControl
+              id="jr-new-puzzle-title"
+              type="text"
+              autoFocus
+              disabled={disableForm}
+              onChange={onTitleChange}
+              value={currentTitle}
+            />
+          </Col>
+        </FormGroup>
 
-      <FormGroup as={Row}>
-        <FormLabel column xs={3} htmlFor="jr-new-puzzle-url">
-          URL
-        </FormLabel>
-        <Col xs={9}>
-          <FormControl
-            id="jr-new-puzzle-url"
-            type="text"
-            disabled={disableForm}
-            onChange={onUrlChange}
-            value={currentUrl}
-          />
-        </Col>
-      </FormGroup>
+        <FormGroup as={Row}>
+          <FormLabel column xs={3} htmlFor="jr-new-puzzle-url">
+            URL
+          </FormLabel>
+          <Col xs={9}>
+            <FormControl
+              id="jr-new-puzzle-url"
+              type="text"
+              disabled={disableForm}
+              onChange={onUrlChange}
+              value={currentUrl}
+            />
+          </Col>
+        </FormGroup>
 
-      <FormGroup as={Row}>
-        <FormLabel column xs={3} htmlFor="jr-new-puzzle-tags">
-          Tags
-        </FormLabel>
-        <Col xs={9}>
-          <Creatable
-            id="jr-new-puzzle-tags"
-            options={selectOptions}
-            isMulti
-            disabled={disableForm}
-            onChange={onTagsChange as any /* onChange type declaration doesn't understand isMulti */}
-            value={currentTags.map((t) => { return { label: t, value: t }; })}
-          />
-        </Col>
-      </FormGroup>
+        <FormGroup as={Row}>
+          <FormLabel column xs={3} htmlFor="jr-new-puzzle-tags">
+            Tags
+          </FormLabel>
+          <Col xs={9}>
+            <Creatable
+              id="jr-new-puzzle-tags"
+              options={selectOptions}
+              isMulti
+              disabled={disableForm}
+              onChange={onTagsChange as any /* onChange type declaration doesn't understand isMulti */}
+              value={currentTags.map((t) => { return { label: t, value: t }; })}
+            />
+          </Col>
+        </FormGroup>
 
-      {docTypeSelector}
+        {docTypeSelector}
 
-      <FormGroup as={Row}>
-        <FormLabel column xs={3} htmlFor="jr-new-puzzle-expected-answer-count">
-          Expected # of answers
-        </FormLabel>
-        <Col xs={9}>
-          <FormControl
-            id="jr-new-puzzle-expected-answer-count"
-            type="number"
-            disabled={disableForm}
-            onChange={onExpectedAnswerCountChange}
-            value={currentExpectedAnswerCount}
-            min={1}
-            step={1}
-          />
-        </Col>
-      </FormGroup>
+        <FormGroup as={Row}>
+          <FormLabel column xs={3} htmlFor="jr-new-puzzle-expected-answer-count">
+            Expected # of answers
+          </FormLabel>
+          <Col xs={9}>
+            <FormControl
+              id="jr-new-puzzle-expected-answer-count"
+              type="number"
+              disabled={disableForm}
+              onChange={onExpectedAnswerCountChange}
+              value={currentExpectedAnswerCount}
+              min={1}
+              step={1}
+            />
+          </Col>
+        </FormGroup>
 
-      {submitState === PuzzleModalFormSubmitState.FAILED && <Alert variant="danger">{errorMessage}</Alert>}
-    </ModalForm>
+        {submitState === PuzzleModalFormSubmitState.FAILED && <Alert variant="danger">{errorMessage}</Alert>}
+      </ModalForm>
+    </Suspense>
   );
 });
 

--- a/imports/client/components/TagEditor.tsx
+++ b/imports/client/components/TagEditor.tsx
@@ -1,9 +1,11 @@
 import { useTracker } from 'meteor/react-meteor-data';
-import React, { useCallback } from 'react';
-import Creatable from 'react-select/creatable';
+import React, { Suspense, useCallback } from 'react';
 import Tags from '../../lib/models/tags';
 import { PuzzleType } from '../../lib/schemas/puzzles';
 import { TagType } from '../../lib/schemas/tags';
+import Loading from './Loading';
+
+const Creatable = React.lazy(() => import('react-select/creatable'));
 
 interface TagEditorProps {
   puzzle: PuzzleType;
@@ -37,15 +39,17 @@ const TagEditor = (props: TagEditorProps) => {
     });
 
   return (
-    <span className="tag-editor">
-      <Creatable
-        options={options}
-        autoFocus
-        openMenuOnFocus
-        onChange={(v) => props.onSubmit((v as {value: string}).value)}
-        onBlur={onBlur}
-      />
-    </span>
+    <Suspense fallback={<Loading inline />}>
+      <span className="tag-editor">
+        <Creatable
+          options={options}
+          autoFocus
+          openMenuOnFocus
+          onChange={(v: typeof options[0]) => props.onSubmit((v as {value: string}).value)}
+          onBlur={onBlur}
+        />
+      </span>
+    </Suspense>
   );
 };
 

--- a/imports/client/components/TagList.tsx
+++ b/imports/client/components/TagList.tsx
@@ -11,6 +11,7 @@ import Tag from './Tag';
 import TagEditor from './TagEditor';
 
 interface BaseTagListProps {
+  className?: string;
   puzzle: PuzzleType;
   tags: TagType[];
   onCreateTag?: (tagName: string) => void; // if provided, will show UI for adding a new tag
@@ -182,7 +183,7 @@ const TagList = React.memo((props: TagListProps) => {
   }
 
   return (
-    <div className="tag-list">
+    <div className={`tag-list ${props.className}`}>
       {components}
     </div>
   );


### PR DESCRIPTION
The puzzle edit modal and the tag editor are the only 2 places where we use react-select, which is an otherwise fairly expensive require (about 60K in the final bundle). By pushing the react-select usages to use dynamic-import we can slim down the default fetch.

I tested this using the Chrome dev tools with a custom throttling profile that added 2 seconds of latency.

Here's what the tag selector looks like:

![suspense-tag-editor](https://user-images.githubusercontent.com/28167/128620932-53b74832-7b5c-4def-9bcd-b153bd49a2b0.gif)

And here's what the puzzle edit modal looks like:

![suspense-puzzle-modal](https://user-images.githubusercontent.com/28167/128620943-275277a4-3b67-4cd3-abf5-d61fa5074272.gif)
