### PR TITLE
Cleanup main imports

### DIFF
--- a/client/main.ts
+++ b/client/main.ts
@@ -2,9 +2,6 @@
 // things
 import '../imports/lib/config/accounts';
 
-// attach the users schema to Meteor.users
-import '../imports/lib/models/users';
-
 // register actions and roles
 import '../imports/lib/roles';
 

--- a/client/main.ts
+++ b/client/main.ts
@@ -9,16 +9,17 @@ import '../imports/lib/roles';
 import '../imports/client/main';
 import '../imports/client/close';
 
-// Export the schemas and models facades for interaction from the console
-import ModelsFacade from '../imports/lib/models/facade';
-import SchemasFacade from '../imports/lib/schemas/facade';
-
 declare global {
   interface Window {
-    Schemas: typeof SchemasFacade;
-    Models: typeof ModelsFacade;
+    loadFacades: () => void;
   }
 }
 
-window.Schemas = SchemasFacade;
-window.Models = ModelsFacade;
+window.loadFacades = async () => {
+  const [models, schemas] = await Promise.all([
+    import('../imports/lib/models/facade'),
+    import('../imports/lib/schemas/facade'),
+  ]);
+  Object.defineProperty(window, 'Models', { value: models.default });
+  Object.defineProperty(window, 'Schemas', { value: schemas.default });
+};

--- a/client/main.ts
+++ b/client/main.ts
@@ -5,9 +5,6 @@ import '../imports/lib/config/accounts';
 // register actions and roles
 import '../imports/lib/roles';
 
-// Configure marked
-import '../imports/client/marked';
-
 // explicitly import all the stuff from client/
 import '../imports/client/main';
 import '../imports/client/close';

--- a/imports/client/components/AnnouncementsPage.tsx
+++ b/imports/client/components/AnnouncementsPage.tsx
@@ -2,8 +2,6 @@ import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { useTracker } from 'meteor/react-meteor-data';
 import { _ } from 'meteor/underscore';
-import DOMPurify from 'dompurify';
-import marked from 'marked';
 import React, { useCallback, useState } from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
@@ -13,6 +11,7 @@ import Announcements from '../../lib/models/announcements';
 import Profiles from '../../lib/models/profiles';
 import { AnnouncementType } from '../../lib/schemas/announcements';
 import { useBreadcrumb } from '../hooks/breadcrumb';
+import markdown from '../markdown';
 
 /* eslint-disable max-len */
 
@@ -91,7 +90,7 @@ const Announcement = (props: AnnouncementProps) => {
       </div>
       <div
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: marked(DOMPurify.sanitize(ann.message)) }}
+        dangerouslySetInnerHTML={{ __html: markdown(ann.message) }}
       />
     </div>
   );

--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -2,8 +2,6 @@ import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { useTracker } from 'meteor/react-meteor-data';
 import { _ } from 'meteor/underscore';
-import DOMPurify from 'dompurify';
-import marked from 'marked';
 import React, { useCallback, useMemo } from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
@@ -16,6 +14,7 @@ import Hunts from '../../lib/models/hunts';
 import { HuntType } from '../../lib/schemas/hunts';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 import useDocumentTitle from '../hooks/use-document-title';
+import markdown from '../markdown';
 import AnnouncementsPage from './AnnouncementsPage';
 import CelebrationCenter from './CelebrationCenter';
 import GuessQueuePage from './GuessQueuePage';
@@ -89,7 +88,7 @@ const HuntMemberError = React.memo((props: HuntMemberErrorProps) => {
 
   const history = useHistory();
 
-  const msg = marked(DOMPurify.sanitize(props.hunt.signupMessage || ''));
+  const msg = markdown(props.hunt.signupMessage || '');
   return (
     <div>
       <Alert variant="warning">

--- a/imports/client/components/HuntProfileListPage.tsx
+++ b/imports/client/components/HuntProfileListPage.tsx
@@ -4,6 +4,7 @@ import { useTracker } from 'meteor/react-meteor-data';
 import { _ } from 'meteor/underscore';
 import React from 'react';
 import { Route, RouteComponentProps, Switch } from 'react-router';
+import MeteorUsers from '../../lib/models/meteor_users';
 import Profiles from '../../lib/models/profiles';
 import { ProfileType } from '../../lib/schemas/profiles';
 import { useBreadcrumb } from '../hooks/breadcrumb';
@@ -46,7 +47,7 @@ const HuntProfileListPage = (props: HuntProfileListPageWithRouterParams) => {
       Meteor.userId(), 'hunt.join', huntId
     );
 
-    const hunters = Meteor.users.find({ hunts: huntId }).map((u) => u._id) as string[];
+    const hunters = MeteorUsers.find({ hunts: huntId }).map((u) => u._id) as string[];
     const profiles = Profiles.find(
       { _id: { $in: hunters } },
       { sort: { displayName: 1 } },

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -8,8 +8,6 @@ import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
 import { faSkullCrossbones } from '@fortawesome/free-solid-svg-icons/faSkullCrossbones';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
-import DOMPurify from 'dompurify';
-import marked from 'marked';
 import React, { useCallback, useState } from 'react';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
@@ -32,6 +30,7 @@ import { PendingAnnouncementType } from '../../lib/schemas/pending_announcements
 import { PuzzleType } from '../../lib/schemas/puzzles';
 import { guessURL } from '../../model-helpers';
 import { requestDiscordCredential } from '../discord';
+import markdown from '../markdown';
 
 /* eslint-disable max-len */
 
@@ -271,7 +270,7 @@ const AnnouncementMessage = React.memo((props: AnnouncementMessageProps) => {
       <MessengerContent dismissable>
         <div
           // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: marked(DOMPurify.sanitize(props.announcement.message)) }}
+          dangerouslySetInnerHTML={{ __html: markdown(props.announcement.message) }}
         />
         <footer>
           {'- '}

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -8,8 +8,6 @@ import { faPaperPlane } from '@fortawesome/free-solid-svg-icons/faPaperPlane';
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
-import DOMPurify from 'dompurify';
-import marked from 'marked';
 import React, {
   useCallback, useEffect, useImperativeHandle, useRef, useState,
 } from 'react';
@@ -43,6 +41,7 @@ import { PuzzleType } from '../../lib/schemas/puzzles';
 import { TagType } from '../../lib/schemas/tags';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 import useDocumentTitle from '../hooks/use-document-title';
+import markdown from '../markdown';
 import ChatPeople from './ChatPeople';
 import DocumentDisplay from './Documents';
 import ModalForm, { ModalFormHandle } from './ModalForm';
@@ -122,7 +121,7 @@ const ChatMessage = React.memo((props: ChatMessageProps) => {
       {!props.suppressSender && <strong>{props.senderDisplayName}</strong>}
       <span
         // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: marked(DOMPurify.sanitize(props.message.text)) }}
+        dangerouslySetInnerHTML={{ __html: markdown(props.message.text) }}
       />
     </div>
   );

--- a/imports/client/markdown.ts
+++ b/imports/client/markdown.ts
@@ -1,3 +1,4 @@
+import DOMPurify from 'dompurify';
 import marked from 'marked';
 
 (marked.InlineLexer.rules.gfm as marked.Rules).em = /^\b_((?:__|[^_])+?)_\b/;
@@ -11,4 +12,6 @@ const renderer = new class extends marked.Renderer {
   }
 }();
 
-marked.setOptions({ renderer });
+export default function markdown(text: string) {
+  return marked(DOMPurify.sanitize(text), { renderer });
+}

--- a/imports/lib/models/meteor_users.ts
+++ b/imports/lib/models/meteor_users.ts
@@ -8,3 +8,7 @@ import UserSchema from '../schemas/users';
 // extension, and by casting we switch from the non-extended type to the
 // extended one. This seemed a little better than just casting to any.
 (<Mongo.Collection<Meteor.User>>Meteor.users).attachSchema(UserSchema);
+
+// Re-export Meteor.users. We should require this instead of using Meteor.users
+// directly to ensure that the schema has always been attached.
+export default Meteor.users;

--- a/imports/model-helpers.ts
+++ b/imports/model-helpers.ts
@@ -2,6 +2,7 @@ import { Meteor, Subscription } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import { _ } from 'meteor/underscore';
 import Mustache from 'mustache';
+import MeteorUsers from './lib/models/meteor_users';
 import { HuntType } from './lib/schemas/hunts';
 import { PuzzleType } from './lib/schemas/puzzles';
 
@@ -26,7 +27,7 @@ const huntsMatchingCurrentUser = function <T extends HuntModel> (
   // As a note: this will not re-publish if the user's hunt membership
   // changes, so use it carefully (basically, use it when you already
   // know the user is a member of the hunt in question).
-  const u = Meteor.users.findOne(this.userId);
+  const u = MeteorUsers.findOne(this.userId);
   if (!u) {
     throw new Meteor.Error(401, 'Unauthenticated');
   }

--- a/imports/server/accounts.ts
+++ b/imports/server/accounts.ts
@@ -4,6 +4,7 @@ import logfmt from 'logfmt';
 import Mustache from 'mustache';
 import Ansible from '../ansible';
 import Hunts from '../lib/models/hunts';
+import MeteorUsers from '../lib/models/meteor_users';
 import Settings from '../lib/models/settings';
 import { SettingType } from '../lib/schemas/settings';
 
@@ -49,7 +50,7 @@ const summaryFromLoginInfo = function (info: LoginInfo) {
 Accounts.onLogin((info: LoginInfo) => {
   if (!info.user || !info.user._id) throw new Meteor.Error(500, 'Something has gone horribly wrong');
   // Capture login time
-  Meteor.users.update(info.user._id, { $set: { lastLogin: new Date() } });
+  MeteorUsers.update(info.user._id, { $set: { lastLogin: new Date() } });
 
   if (info.type === 'resume') {
     return;

--- a/imports/server/announcements.ts
+++ b/imports/server/announcements.ts
@@ -3,6 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import Ansible from '../ansible';
 import Announcements from '../lib/models/announcements';
+import MeteorUsers from '../lib/models/meteor_users';
 import PendingAnnouncements from '../lib/models/pending_announcements';
 
 Meteor.methods({
@@ -19,7 +20,7 @@ Meteor.methods({
       message,
     });
 
-    Meteor.users.find({ hunts: huntId }).forEach((user) => {
+    MeteorUsers.find({ hunts: huntId }).forEach((user) => {
       PendingAnnouncements.insert({
         hunt: huntId,
         announcement: id,

--- a/imports/server/api/resources/users.ts
+++ b/imports/server/api/resources/users.ts
@@ -3,6 +3,7 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import express from 'express';
+import MeteorUsers from '../../../lib/models/meteor_users';
 import Profiles from '../../../lib/models/profiles';
 import { ProfileType } from '../../../lib/schemas/profiles';
 
@@ -19,7 +20,7 @@ function findUserByEmail(email: string): {
 
   const profile = Profiles.findOne({ googleAccount: email });
   if (profile) {
-    return { profile, user: Meteor.users.findOne(profile._id) };
+    return { profile, user: MeteorUsers.findOne(profile._id) };
   }
 
   const user = <Meteor.User | undefined>Accounts.findUserByEmail(email);

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -5,6 +5,7 @@ import { Roles } from 'meteor/nicolaslopezj:roles';
 import Ansible from '../ansible';
 import Guesses from '../lib/models/guess';
 import Hunts from '../lib/models/hunts';
+import MeteorUsers from '../lib/models/meteor_users';
 import Profiles from '../lib/models/profiles';
 import Puzzles from '../lib/models/puzzles';
 import { GuessType } from '../lib/schemas/guess';
@@ -70,7 +71,7 @@ class PendingGuessWatcher {
   constructor(sub: Subscription) {
     this.sub = sub;
 
-    const user = Meteor.users.findOne(sub.userId)!;
+    const user = MeteorUsers.findOne(sub.userId)!;
 
     this.guessCursor = Guesses.find({ state: 'pending', hunt: { $in: user.hunts } });
     this.guesses = {};

--- a/imports/server/hooks/dingword-hooks.ts
+++ b/imports/server/hooks/dingword-hooks.ts
@@ -1,7 +1,7 @@
-import { Meteor } from 'meteor/meteor';
 import Flags from '../../flags';
 import ChatNotifications from '../../lib/models/chat_notifications';
 import ChatMessages from '../../lib/models/chats';
+import MeteorUsers from '../../lib/models/meteor_users';
 import Profiles from '../../lib/models/profiles';
 import Hookset from './hookset';
 
@@ -21,7 +21,7 @@ const DingwordHooks: Hookset = {
     }
 
     // Find all users who are in this hunt.
-    const huntMembers = Meteor.users.find({
+    const huntMembers = MeteorUsers.find({
       hunts: chatMessage.hunt,
     }, {
       fields: { _id: 1 },

--- a/imports/server/hunts.ts
+++ b/imports/server/hunts.ts
@@ -6,6 +6,7 @@ import { Roles } from 'meteor/nicolaslopezj:roles';
 import Mustache from 'mustache';
 import Ansible from '../ansible';
 import Hunts from '../lib/models/hunts';
+import MeteorUsers from '../lib/models/meteor_users';
 import Profiles from '../lib/models/profiles';
 import Settings from '../lib/models/settings';
 import { HuntType } from '../lib/schemas/hunts';
@@ -90,7 +91,7 @@ Meteor.methods({
     const newUser = joineeUser === undefined;
     if (!joineeUser) {
       const joineeUserId = Accounts.createUser({ email });
-      joineeUser = Meteor.users.findOne(joineeUserId)!;
+      joineeUser = MeteorUsers.findOne(joineeUserId)!;
     }
     if (!joineeUser._id) throw new Meteor.Error(500, 'Something has gone terribly wrong');
 
@@ -108,7 +109,7 @@ Meteor.methods({
       joinee: joineeUser._id,
       hunt: huntId,
     });
-    Meteor.users.update(joineeUser._id, { $addToSet: { hunts: { $each: [huntId] } } });
+    MeteorUsers.update(joineeUser._id, { $addToSet: { hunts: { $each: [huntId] } } });
     const joineeEmails = (joineeUser.emails || []).map((e) => e.address);
 
     hunt.mailingLists.forEach((listName) => {
@@ -181,7 +182,7 @@ Meteor.methods({
 
     Roles.checkPermission(this.userId, 'discord.useBotAPIs', huntId);
 
-    Meteor.users.find({ hunts: huntId })
+    MeteorUsers.find({ hunts: huntId })
       .forEach((u) => {
         addUserToDiscordRole(u._id, huntId);
       });

--- a/imports/server/migrations/7-more-indexes.ts
+++ b/imports/server/migrations/7-more-indexes.ts
@@ -1,7 +1,7 @@
-import { Meteor } from 'meteor/meteor';
 import { Migrations } from 'meteor/percolate:migrations';
 import Documents from '../../lib/models/documents';
 import Guesses from '../../lib/models/guess';
+import MeteorUsers from '../../lib/models/meteor_users';
 import Tags from '../../lib/models/tags';
 import dropIndex from './drop-index';
 
@@ -9,7 +9,7 @@ Migrations.add({
   version: 7,
   name: 'Add more missing indexes',
   up() {
-    Meteor.users._ensureIndex({ hunts: 1 });
+    MeteorUsers._ensureIndex({ hunts: 1 });
 
     Tags._ensureIndex({ deleted: 1, hunt: 1, name: 1 });
 

--- a/imports/server/profile.ts
+++ b/imports/server/profile.ts
@@ -3,6 +3,7 @@ import { Google } from 'meteor/google-oauth';
 import { Meteor } from 'meteor/meteor';
 import { OAuth } from 'meteor/oauth';
 import Ansible from '../ansible';
+import MeteorUsers from '../lib/models/meteor_users';
 import Profiles from '../lib/models/profiles';
 import Settings from '../lib/models/settings';
 import addUserToDiscordRole from './addUserToDiscordRole';
@@ -18,7 +19,7 @@ Meteor.methods({
       muteApplause: Boolean,
       dingwords: [String],
     });
-    const user = Meteor.users.findOne(this.userId)!;
+    const user = MeteorUsers.findOne(this.userId)!;
     const primaryEmail = user.emails && user.emails[0].address;
 
     Ansible.log('Updating profile for user', { user: this.userId });
@@ -74,7 +75,7 @@ Meteor.methods({
     });
 
     // Save the user's credentials to their User object, under services.discord.
-    Meteor.users.update(this.userId, {
+    MeteorUsers.update(this.userId, {
       $set: {
         'services.discord': credential.serviceData,
       },
@@ -132,7 +133,7 @@ Meteor.methods({
     // TODO: tell Discord to revoke the token?
 
     // Remove token (secret) from the user object in the database.
-    Meteor.users.update(this.userId, {
+    MeteorUsers.update(this.userId, {
       $unset: { 'services.discord': '' },
     });
 

--- a/imports/server/puzzle.ts
+++ b/imports/server/puzzle.ts
@@ -5,6 +5,7 @@ import { Random } from 'meteor/random';
 import Ansible from '../ansible';
 import Flags from '../flags';
 import DocumentPermissions from '../lib/models/document_permissions';
+import MeteorUsers from '../lib/models/meteor_users';
 import Profiles from '../lib/models/profiles';
 import Puzzles from '../lib/models/puzzles';
 import Tags from '../lib/models/tags';
@@ -198,7 +199,7 @@ Meteor.methods({
     check(this.userId, String);
     check(puzzleId, String);
 
-    const user = Meteor.users.findOne(this.userId)!;
+    const user = MeteorUsers.findOne(this.userId)!;
     const puzzle = Puzzles.findOne(puzzleId);
     if (!puzzle || !user.hunts.includes(puzzle.hunt)) {
       throw new Meteor.Error(404, 'Unknown puzzle');

--- a/imports/server/setup.ts
+++ b/imports/server/setup.ts
@@ -8,6 +8,7 @@ import { Random } from 'meteor/random';
 import { ServiceConfiguration } from 'meteor/service-configuration';
 import Ansible from '../ansible';
 import { API_BASE } from '../lib/discord';
+import MeteorUsers from '../lib/models/meteor_users';
 import Settings from '../lib/models/settings';
 import UploadTokens from './models/upload_tokens';
 
@@ -33,7 +34,7 @@ Meteor.methods({
 
     // Refuse to create the user if any users already exist
     // This is theoretically racy but is probably fine in practice
-    const existingUser = Meteor.users.findOne({});
+    const existingUser = MeteorUsers.findOne({});
     if (existingUser) {
       throw new Meteor.Error(403, 'The first user already exists.');
     }
@@ -268,7 +269,7 @@ Meteor.publish('hasUsers', function () {
   // Publish a pseudo-collection which just communicates if there are any users
   // at all, so we can either guide users through the server setup flow or just
   // point them at the login page.
-  const cursor = Meteor.users.find();
+  const cursor = MeteorUsers.find();
   if (cursor.count() > 0) {
     this.added('hasUsers', 'hasUsers', { hasUsers: true });
   } else {

--- a/imports/server/users.ts
+++ b/imports/server/users.ts
@@ -1,13 +1,14 @@
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
+import MeteorUsers from '../lib/models/meteor_users';
 
 Meteor.publish('selfHuntMembership', function () {
   if (!this.userId) {
     return [];
   }
 
-  return Meteor.users.find(this.userId, { fields: { hunts: 1 } });
+  return MeteorUsers.find(this.userId, { fields: { hunts: 1 } });
 });
 
 Meteor.publish('huntMembers', function (huntId: string) {
@@ -17,14 +18,14 @@ Meteor.publish('huntMembers', function (huntId: string) {
     return [];
   }
 
-  const u = Meteor.users.findOne(this.userId)!;
+  const u = MeteorUsers.findOne(this.userId)!;
   // Note: this is not reactive, so if hunt membership changes, this
   // behavior will change
   if (!u.hunts.includes(huntId)) {
     return [];
   }
 
-  return Meteor.users.find({ hunts: huntId }, { fields: { hunts: 1 } });
+  return MeteorUsers.find({ hunts: huntId }, { fields: { hunts: 1 } });
 });
 
 Meteor.publish('userRoles', function (targetUserId: string) {
@@ -35,5 +36,5 @@ Meteor.publish('userRoles', function (targetUserId: string) {
     return [];
   }
 
-  return Meteor.users.find(targetUserId, { fields: { roles: 1 } });
+  return MeteorUsers.find(targetUserId, { fields: { roles: 1 } });
 });

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,7 +1,6 @@
 // explicitly import all the stuff from lib/ since mainModule skips autoloading
 // things
 import '../imports/lib/config/accounts';
-import '../imports/lib/models/users';
 import '../imports/lib/roles';
 
 // Register migrations


### PR DESCRIPTION
This trims down the set of things that we import in `client/main.ts`, in favor of pulling things in as they're actually used. This makes it potentially more feasible to trim out unused dependencies in the future.

I think the dependency pruning of the `loadFacades` change is worth it, since it's only used by admins doing sketchy things in the console, but I'm open to pushback. (Note that `await loadFacades()` will do the right thing and block until `Models` and `Schemas` are populated)