### PR TITLE
Remove some unnecessary uses of underscore

### DIFF
--- a/imports/client/components/AnnouncementsPage.tsx
+++ b/imports/client/components/AnnouncementsPage.tsx
@@ -1,7 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { useTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import React, { useCallback, useState } from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';

--- a/imports/client/components/AuthenticatedRoute.tsx
+++ b/imports/client/components/AuthenticatedRoute.tsx
@@ -1,6 +1,5 @@
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import React, { useEffect, useState } from 'react';
 import { Redirect, Route, RouteComponentProps } from 'react-router';
 import App from './App';
@@ -50,11 +49,11 @@ const AuthWrapper = React.memo((props: AuthWrapperProps) => {
   }
 
   if (!tracker.userId) {
-    const stateToSave = _.pick(props.location, 'pathname', 'search');
+    const { pathname, search } = props.location;
     return (
       <Redirect to={{
         pathname: '/login',
-        state: stateToSave,
+        state: { pathname, search },
       }}
       />
     );

--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -1,7 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { useTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import React, { useCallback, useMemo } from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
@@ -139,7 +138,7 @@ const HuntApp = React.memo((props: RouteComponentProps<HuntAppParams>) => {
       _id: huntId,
     });
     const user = Meteor.user();
-    const member = !!user && _.contains(user.hunts, huntId);
+    const member = !!user && user.hunts.includes(huntId);
     return {
       ready: userHandle.ready() && huntHandle.ready() && deletedHuntHandle.ready(),
       hunt: Hunts.findOneAllowingDeleted(huntId),

--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -138,7 +138,7 @@ const HuntApp = React.memo((props: RouteComponentProps<HuntAppParams>) => {
       _id: huntId,
     });
     const user = Meteor.user();
-    const member = !!user && user.hunts.includes(huntId);
+    const member = user?.hunts?.includes(huntId) ?? false;
     return {
       ready: userHandle.ready() && huntHandle.ready() && deletedHuntHandle.ready(),
       hunt: Hunts.findOneAllowingDeleted(huntId),

--- a/imports/client/components/HuntListPage.tsx
+++ b/imports/client/components/HuntListPage.tsx
@@ -623,7 +623,7 @@ const HuntListPage = () => {
 
     const myHunts: Record<string, boolean> = {};
     if (ready) {
-      Meteor.user()!.hunts.forEach((hunt) => { myHunts[hunt] = true; });
+      Meteor.user()?.hunts?.forEach((hunt) => { myHunts[hunt] = true; });
     }
 
     return {

--- a/imports/client/components/HuntListPage.tsx
+++ b/imports/client/components/HuntListPage.tsx
@@ -1,7 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { useTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import { faEdit } from '@fortawesome/free-solid-svg-icons/faEdit';
 import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';

--- a/imports/client/components/HuntProfileListPage.tsx
+++ b/imports/client/components/HuntProfileListPage.tsx
@@ -1,7 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/nicolaslopezj:roles';
 import { useTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import React from 'react';
 import { Route, RouteComponentProps, Switch } from 'react-router';
 import MeteorUsers from '../../lib/models/meteor_users';

--- a/imports/client/components/RelatedPuzzleGroup.tsx
+++ b/imports/client/components/RelatedPuzzleGroup.tsx
@@ -1,4 +1,3 @@
-import { _ } from 'meteor/underscore';
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown';
 import { faCaretRight } from '@fortawesome/free-solid-svg-icons/faCaretRight';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/imports/client/components/SplitPanePlus.tsx
+++ b/imports/client/components/SplitPanePlus.tsx
@@ -162,34 +162,36 @@ const SplitPanePlusHook = (props: SplitPanePlusProps) => {
 
   const splitPaneNode = useCallback(() => {
     if (!ref.current || !(ref.current.firstChild instanceof HTMLElement)) {
-      return null;
+      return undefined;
     }
     return ref.current.firstChild;
   }, []);
 
-  const findChildByClass = useCallback((classNameSought: string): HTMLElement | null => {
-    const root = splitPaneNode();
-    return root && _.find(root.children, (n) => {
-      return n.classList.contains(classNameSought);
-    }) as HTMLElement;
-  }, [splitPaneNode]);
+  const findChildByClass = useCallback(
+    (classNameSought: string): Element | undefined => {
+      const root = splitPaneNode();
+      return root && Array.from(root.children).find((n) => {
+        return n.classList.contains(classNameSought);
+      });
+    }, [splitPaneNode]
+  );
 
-  const primaryPaneNode = useCallback((): HTMLElement | null => {
+  const primaryPaneNode = useCallback((): Element | undefined => {
     return findChildByClass(`Pane${primary === 'first' ? 1 : 2}`);
   }, [findChildByClass, primary]);
 
   // Unused.
   /*
-  const secondaryPaneNode = useCallback((): HTMLElement | null => {
+  const secondaryPaneNode = useCallback((): Element | undefined => {
     return findChildByClass(`Pane${primary === 'first' ? 2 : 1}`);
   }, [findChildByClass, primary]);
   */
 
-  const resizerNode = useCallback((): HTMLElement | null => {
+  const resizerNode = useCallback((): Element | undefined => {
     return findChildByClass('Resizer');
   }, [findChildByClass]);
 
-  const measure = useCallback((elem: HTMLElement | null): number => {
+  const measure = useCallback((elem: Element | undefined): number => {
     if (!elem) {
       return NaN;
     }

--- a/imports/client/components/TagList.tsx
+++ b/imports/client/components/TagList.tsx
@@ -1,4 +1,3 @@
-import { _ } from 'meteor/underscore';
 import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';

--- a/imports/client/components/UnauthenticatedRoute.tsx
+++ b/imports/client/components/UnauthenticatedRoute.tsx
@@ -1,6 +1,5 @@
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import React, { useEffect, useState } from 'react';
 import { Redirect, Route, RouteComponentProps } from 'react-router';
 import SplashPage from './SplashPage';
@@ -50,7 +49,7 @@ const UnauthWrapper = React.memo((props: UnauthWrapperProps) => {
   }
 
   if (tracker.userId) {
-    const state = _.extend({ pathname: '/', search: undefined }, props.location.state);
+    const state = { pathname: '/', search: undefined, ...(props.location.state as any) };
     return (
       <Redirect to={{
         pathname: state.pathname,

--- a/imports/lib/models/base.ts
+++ b/imports/lib/models/base.ts
@@ -97,28 +97,28 @@ class Base<T extends BaseType> extends Mongo.Collection<T> {
 
   find(selector: FindSelector<T> = {}, options: FindOptions = {}) {
     return super.find(
-      { deleted: false as any, ...this[formatQuery](selector) },
+      { ...this[formatQuery](selector), deleted: false as any },
       this[formatOptions](options)
     );
   }
 
   findOne(selector: FindSelector<T> = {}, options: FindOneOptions = {}) {
     return super.findOne(
-      { deleted: false as any, ...this[formatQuery](selector) },
+      { ...this[formatQuery](selector), deleted: false as any },
       this[formatOptions](options)
     );
   }
 
   findDeleted(selector: FindSelector<T> = {}, options: FindOptions = {}) {
     return super.find(
-      { deleted: true as any, ...this[formatQuery](selector) },
+      { ...this[formatQuery](selector), deleted: true as any },
       this[formatOptions](options)
     );
   }
 
   findOneDeleted(selector: FindSelector<T> = {}, options: FindOneOptions = {}) {
     return super.findOne(
-      { deleted: true as any, ...this[formatQuery](selector) },
+      { ...this[formatQuery](selector), deleted: true as any },
       this[formatOptions](options)
     );
   }

--- a/imports/lib/models/base.ts
+++ b/imports/lib/models/base.ts
@@ -1,7 +1,6 @@
 import { check, Match } from 'meteor/check';
 import { Meteor, Subscription } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
-import { _ } from 'meteor/underscore';
 import { BaseType } from '../schemas/base';
 
 const formatQuery = Symbol('formatQuery');
@@ -98,28 +97,28 @@ class Base<T extends BaseType> extends Mongo.Collection<T> {
 
   find(selector: FindSelector<T> = {}, options: FindOptions = {}) {
     return super.find(
-      _.extend({ deleted: false }, this[formatQuery](selector)),
+      { deleted: false as any, ...this[formatQuery](selector) },
       this[formatOptions](options)
     );
   }
 
   findOne(selector: FindSelector<T> = {}, options: FindOneOptions = {}) {
     return super.findOne(
-      _.extend({ deleted: false }, this[formatQuery](selector)),
+      { deleted: false as any, ...this[formatQuery](selector) },
       this[formatOptions](options)
     );
   }
 
   findDeleted(selector: FindSelector<T> = {}, options: FindOptions = {}) {
     return super.find(
-      _.extend({ deleted: true }, this[formatQuery](selector)),
+      { deleted: true as any, ...this[formatQuery](selector) },
       this[formatOptions](options)
     );
   }
 
   findOneDeleted(selector: FindSelector<T> = {}, options: FindOneOptions = {}) {
     return super.findOne(
-      _.extend({ deleted: true }, this[formatQuery](selector)),
+      { deleted: true as any, ...this[formatQuery](selector) },
       this[formatOptions](options)
     );
   }

--- a/imports/lib/schemas/typedSchemas.ts
+++ b/imports/lib/schemas/typedSchemas.ts
@@ -1,5 +1,4 @@
 import { Meteor } from 'meteor/meteor';
-import { _ } from 'meteor/underscore';
 import * as t from 'io-ts';
 import { date } from 'io-ts-types';
 import SimpleSchema from 'simpl-schema';
@@ -186,15 +185,13 @@ const buildField = function <T> (
   } else if (<any>fieldCodec === date) {
     return [[fieldName, { ...overrides, type: Date, optional }]];
   } else if (fieldCodec instanceof t.ArrayType) {
-    const schemaOverrides = _.omit(overrides, 'array');
-    const arrayOverrides = overrides && (<ArrayOverrides<any[]>>overrides).array;
+    const { array: arrayOverrides = undefined, ...schemaOverrides } = (overrides || {}) as any;
     return [
       [fieldName, { ...schemaOverrides, type: Array, optional }],
       ...buildField(`${fieldName}.$`, fieldCodec.type, arrayOverrides),
     ];
   } else if (fieldCodec instanceof t.InterfaceType) {
-    const schemaOverrides = _.omit(overrides, 'nested');
-    const nestedOverrides = overrides && (<ObjectOverrides<Record<string, any>>>overrides).nested;
+    const { nested: nestedOverrides = undefined, ...schemaOverrides } = (overrides || {}) as any;
     return [[fieldName, {
       ...schemaOverrides,
       // eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/imports/lib/schemas/users.ts
+++ b/imports/lib/schemas/users.ts
@@ -13,7 +13,7 @@ const UserCodec = t.type({
   lastLogin: t.union([date, t.undefined]),
   services: t.union([t.object, t.undefined]),
   roles: t.union([t.array(t.string), t.undefined]),
-  hunts: t.array(t.string),
+  hunts: t.union([t.array(t.string), t.undefined]),
   profile: t.type({
     operating: t.boolean,
   }),

--- a/imports/model-helpers.ts
+++ b/imports/model-helpers.ts
@@ -37,16 +37,16 @@ const huntsMatchingCurrentUser = function <T extends HuntModel> (
   if (q.hunt) {
     if (q.hunt instanceof RegExp) {
       // stop your shenanigans
-      huntList = u.hunts;
+      huntList = u.hunts || [];
     } else if (typeof q.hunt === 'object') {
       // if q.hunt is still an object, then it must be a FieldExpression
-      huntList = _.intersection(u.hunts, q.hunt.$in || []);
+      huntList = _.intersection(u.hunts || [], q.hunt.$in || []);
     } else {
       // otherwise it's a string
-      huntList = _.intersection(u.hunts, [q.hunt]);
+      huntList = _.intersection(u.hunts || [], [q.hunt]);
     }
   } else {
-    huntList = u.hunts;
+    huntList = u.hunts || [];
   }
 
   // typescript comes so close to being able to infer this, but seems to

--- a/imports/server/blanche.ts
+++ b/imports/server/blanche.ts
@@ -1,6 +1,5 @@
 import child from 'child_process';
 import { Meteor } from 'meteor/meteor';
-import { _ } from 'meteor/underscore';
 import Ansible from '../ansible';
 
 const execFile = Meteor.wrapAsync(child.execFile);
@@ -27,27 +26,29 @@ class List {
 
   members(): string[] {
     const out = blanche([this.name]);
-    return _.compact(_.map(out.trim().split('\n'), (line) => {
-      // Technically some of these are probably type STRING, but the
-      // distinction isn't important here
-      let type = 'USER';
-      let member = line;
-      if (line.indexOf(':') !== -1) {
-        [type, member] = line.split(':');
-      }
+    return out.trim().split('\n')
+      .map((line) => {
+        // Technically some of these are probably type STRING, but the
+        // distinction isn't important here
+        let type = 'USER';
+        let member = line;
+        if (line.indexOf(':') !== -1) {
+          [type, member] = line.split(':');
+        }
 
-      if (member.indexOf('@') === -1) {
-        member += '@mit.edu';
-      }
+        if (member.indexOf('@') === -1) {
+          member += '@mit.edu';
+        }
 
-      switch (type) {
-        case 'USER':
-        case 'LIST':
-          return member;
-        default:
-          return undefined;
-      }
-    }));
+        switch (type) {
+          case 'USER':
+          case 'LIST':
+            return member;
+          default:
+            return undefined;
+        }
+      })
+      .filter<string>((v): v is string => v !== undefined);
   }
 
   add(member: string): boolean {

--- a/imports/server/hunts.ts
+++ b/imports/server/hunts.ts
@@ -95,7 +95,7 @@ Meteor.methods({
     }
     if (!joineeUser._id) throw new Meteor.Error(500, 'Something has gone terribly wrong');
 
-    if (joineeUser.hunts.includes(huntId)) {
+    if (joineeUser.hunts?.includes(huntId)) {
       Ansible.log('Tried to add user to hunt but they were already a member', {
         joiner: this.userId,
         joinee: joineeUser._id,

--- a/imports/server/profile.ts
+++ b/imports/server/profile.ts
@@ -121,8 +121,7 @@ Meteor.methods({
       }
     }
 
-    const hunts = Meteor.user()!.hunts;
-    hunts.forEach((h) => {
+    Meteor.user()!.hunts?.forEach((h) => {
       addUserToDiscordRole(this.userId!, h);
     });
   },

--- a/imports/server/puzzle.ts
+++ b/imports/server/puzzle.ts
@@ -201,7 +201,7 @@ Meteor.methods({
 
     const user = MeteorUsers.findOne(this.userId)!;
     const puzzle = Puzzles.findOne(puzzleId);
-    if (!puzzle || !user.hunts.includes(puzzle.hunt)) {
+    if (!puzzle || !user.hunts?.includes(puzzle.hunt)) {
       throw new Meteor.Error(404, 'Unknown puzzle');
     }
 

--- a/imports/server/users.ts
+++ b/imports/server/users.ts
@@ -21,7 +21,7 @@ Meteor.publish('huntMembers', function (huntId: string) {
   const u = MeteorUsers.findOne(this.userId)!;
   // Note: this is not reactive, so if hunt membership changes, this
   // behavior will change
-  if (!u.hunts.includes(huntId)) {
+  if (!u.hunts?.includes(huntId)) {
     return [];
   }
 

--- a/types/user.d.ts
+++ b/types/user.d.ts
@@ -2,7 +2,7 @@ declare module 'meteor/meteor' {
   module Meteor {
     interface User {
       lastLogin?: Date;
-      hunts: string[];
+      hunts?: string[];
     }
   }
 }


### PR DESCRIPTION
Three main types of changes here:

* Removing the underscore import from files where it wasn't used at all. Typescript makes it an error to have unused variables, but I think it misses this because it starts with (is) an underscore.
* Replacing underscore with native equivalents. I think in the early days of working on jolly-roger, I used underscore more heavily because I assumed that it new something about, like, weird Javascript prototypical inheritance that I didn't, but in practice there's really no reason to use `_.map` or `_.filter`.
* Replacing underscore where it obfuscates typing information. The type annotations on underscore are mostly pretty good, but a few of them are quite bad - `_.extend` and `_.omit` in particular have a tendency to just return `any`. Plus the spread operator and destructuring assignment in modern JS are basically equivalent anyway.

I thought about introducing a lint rule (I've been using https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore as my goto for "when are there easy native equivalents") but decided not to for the time being. I also looked into whether we could eliminate underscore entirely, but `_.indexBy`, `_.groupBy`, and `_.throttle` are hard to replace (and `_.sortBy` is a little awkward). Since it's only 14K of bundle, it didn't seem worth it.