### PR TITLE
Lint fixups

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,9 +54,6 @@
     "react/no-multi-comp": ["off"],
     "max-classes-per-file": ["off"],
 
-    // Specifying explicit propTypes is worthwhile
-    "react/prefer-stateless-function": ["off"],
-
     // Absolute imports work with Meteor, but aren't well-understood by IDEs, like VS Code
     "import/no-absolute-path": ["error"],
 
@@ -76,22 +73,9 @@
       "newlines-between": "never"
     }],
 
-    // This seems incompatible with React.createClass
-    "react/no-this-in-sfc": ["off"],
-
-    // We should really fix this if we can
-    "react/forbid-prop-types": ["off"],
-
     // This is complaining a lot and I don't really want to write dozens of lines of
     // default prop values of `undefined`
     "react/require-default-props": ["off"],
-
-    // This rule seems to be failing to detect that accessing this.props inside
-    // fat-arrow functions in fact use the prop
-    "react/no-unused-prop-types": ["off"],
-
-    // TypeScript doesn't support setting the property assignment style
-    "react/static-property-placement": ["error", "static public field"],
 
     // We use spread props a lot for HOCs or other wrapper-type components
     "react/jsx-props-no-spreading": ["off"],
@@ -106,6 +90,9 @@
 
     // "name" is a useful variable
     "no-restricted-globals": ["off"],
+
+    // Detect missing deps for non-standard hooks
+    "react-hooks/exhaustive-deps": ["warn", { "additionalHooks": "useTracker" }],
 
     // Match existing style
     "operator-linebreak": ["error", "after"],

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -837,8 +837,6 @@ const EmailConfigSection = (props: EmailConfigSectionProps) => {
 };
 
 interface DiscordOAuthFormProps {
-  configured: boolean;
-  enabled: boolean;
   oauthSettings: any;
 }
 
@@ -1095,7 +1093,6 @@ const DiscordGuildForm = (props: DiscordGuildFormProps) => {
 };
 
 interface DiscordIntegrationSectionProps {
-  configured: boolean;
   enabled: boolean;
   oauthSettings?: Configuration;
   botToken?: string;
@@ -1195,11 +1192,7 @@ const DiscordIntegrationSection = (props: DiscordIntegrationSectionProps) => {
           <li>Click the save button below.</li>
           <li>Then, after you have successfully saved the client secret and bot token: as the guild (&quot;server&quot;) owner, <a href={addGuildLink}>add the bot to your Discord guild here</a>.</li>
         </ol>
-        <DiscordOAuthForm
-          configured={props.configured}
-          enabled={props.enabled}
-          oauthSettings={props.oauthSettings}
-        />
+        <DiscordOAuthForm oauthSettings={props.oauthSettings} />
       </Subsection>
 
       <Subsection>
@@ -1983,7 +1976,6 @@ const SetupPage = () => {
     );
   }
 
-  const discordConfigured = !!tracker.discordOAuthConfig;
   const discordEnabled = !tracker.flagDisableDiscord;
   return (
     <div>
@@ -1999,7 +1991,6 @@ const SetupPage = () => {
       />
       <DiscordIntegrationSection
         oauthSettings={tracker.discordOAuthConfig}
-        configured={discordConfigured}
         enabled={discordEnabled}
         botToken={tracker.discordBotToken}
         guild={tracker.discordGuild}


### PR DESCRIPTION
Some of our eslint config dated from before we switched to using
functional components and are no longer problematic. Re-enabling
`react/no-unused-prop-types` didn't seem to flag any false-positives,
but did find some props in SetupPage that weren't being used.

This also enables exhaustive dep checks for `useTracker`, which aren't
enabled by default. This found one false-positive in PuzzlePage which
was easily addressed by restructuring the variable usage. My general
philosophy is that it's worth working around slightly overzealous
linters, so long as it's not hard to do so (I don't think it is in this
case), if those linters would catch real bugs (I think this one would).