### PR TITLE
Add a link to Discord server

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ At its core, it allows tracking puzzles and guesses in an ever-evolving hunt
 structure, and provides a chat room and a Google spreadsheet for each
 puzzle.
 
+Want to help develop Jolly Roger? Join our Discord server
+
+[![Join our Discord server](https://discordapp.com/api/guilds/778431482171490305/widget.png?style=banner3)](https://discord.gg/kdsNjaxmHZ)
 
 ## Features
 


### PR DESCRIPTION
Slightly better discoverability. (To prevent this from being abused, I also set the server to disallow new members from posting until they've been a member for 10 minutes, which hopefully gives us a little opportunity to moderate. If we see someone known-trusted, we can tag them with a role which will bypass. If all of this turns out to be a terrible idea, we can also nuke the invite link)