### PR TITLE
Clean up shutdown process

### DIFF
--- a/imports/server/discord-client-refresher.ts
+++ b/imports/server/discord-client-refresher.ts
@@ -8,6 +8,7 @@ import Profiles from '../lib/models/profiles';
 import Settings from '../lib/models/settings';
 import { SettingType } from '../lib/schemas/setting';
 import Locks, { PREEMPT_TIMEOUT } from './models/lock';
+import onExit from './onExit';
 
 type DiscordEventsWithArguments<Args> = {
   [K in keyof Discord.ClientEvents]-?: Discord.ClientEvents[K] extends Args ? K : never;
@@ -230,8 +231,7 @@ class DiscordClientRefresher {
 
 const globalClientHolder = new DiscordClientRefresher();
 Meteor.startup(() => {
-  process.on('SIGINT', Meteor.bindEnvironment(() => globalClientHolder.shutdown()));
-  process.on('SIGTERM', Meteor.bindEnvironment(() => globalClientHolder.shutdown()));
+  onExit(Meteor.bindEnvironment(() => globalClientHolder.shutdown()));
 });
 
 export default globalClientHolder;

--- a/imports/server/onExit.ts
+++ b/imports/server/onExit.ts
@@ -1,0 +1,12 @@
+const exitHandlers: (() => void)[] = [];
+
+['SIGINT' as const, 'SIGTERM' as const, 'SIGHUP' as const].forEach((signal) => {
+  process.once(signal, () => {
+    exitHandlers.splice(0).forEach((handler) => handler());
+    process.kill(process.pid, signal);
+  });
+});
+
+export default function onExit(handler: () => void) {
+  exitHandlers.push(handler);
+}


### PR DESCRIPTION
Meteor doesn't set signal handlers by default, so when we set a signal
handler, we were in fact, bypassing the default handling of the signal
(i.e. exiting). Add a helper which runs signal handlers, cleans up after
itself, and then re-signals to actually cause the process to exit.