### PR TITLE
Fix Discord object selection

### DIFF
--- a/imports/client/components/HuntListPage.tsx
+++ b/imports/client/components/HuntListPage.tsx
@@ -115,7 +115,11 @@ const DiscordChannelSelector = (params: DiscordSelectorParams) => {
       // We want to sort them in the same order they're provided in the Discord UI.
       { sort: { 'object.rawPosition': 1 } },
     )
-      .map((c) => c.object as DiscordChannelType);
+      .map((c) => {
+        // Pick just the fields that we store
+        const { id, name } = c.object as DiscordChannelType;
+        return { id, name };
+      });
 
     return {
       ready: handle.ready(),
@@ -152,6 +156,11 @@ const DiscordRoleSelector = (params: DiscordSelectorParams) => {
         }
 
         return true;
+      })
+      .map((role) => {
+        // Pick just the fields that we store
+        const { id, name } = role;
+        return { id, name };
       });
 
     return {

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -1012,7 +1012,10 @@ const DiscordGuildForm = (props: DiscordGuildFormProps) => {
   const tracker = useTracker<DiscordGuildFormTracker>(() => {
     const guildSub = Meteor.subscribe('discord.guilds');
     const ready = guildSub.ready();
-    const guilds = DiscordCache.find({ type: 'guild' }).fetch().map((c) => c.object as DiscordGuildType);
+    const guilds = DiscordCache.find({ type: 'guild' }).fetch().map((c) => {
+      const { id, name } = c.object as DiscordGuildType;
+      return { id, name };
+    });
     return {
       ready,
       guilds,

--- a/imports/server/setup.ts
+++ b/imports/server/setup.ts
@@ -201,7 +201,7 @@ Meteor.methods({
       throw new Meteor.Error(401, 'Must be admin to configure Discord Bot');
     }
     check(guild, Match.Maybe({
-      _id: String,
+      id: String,
       name: String,
     }));
 


### PR DESCRIPTION
There are a couple of scattered bugs here which mostly come down to
Meteor's check function being strict about object keys and Typescript
being loose. In Meteor, it's an error to pass keys in an object that
aren't part of the checked shape. In Typescript, this is allowed (the
keys just aren't accessible).

We were silently ferrying around all of the keys from the Discord cache
record, which caused an error at check time. Instead, pick off the
specific keys we care about.

(Also fix a small typo in the setup page server logic)

Fixes #470.