### PR TITLE
Fix lock preemption

### DIFF
--- a/imports/server/models/lock.ts
+++ b/imports/server/models/lock.ts
@@ -23,7 +23,7 @@ const Locks = new class extends Mongo.Collection<LockType> {
       // any since this is known safe
       return this.insert(<any>{ name });
     } catch (e) {
-      if (!(e instanceof NpmModuleMongodb.MongoError) || e.code !== 11000) {
+      if (e instanceof NpmModuleMongodb.MongoError && e.code === 11000) {
         return undefined;
       }
 


### PR DESCRIPTION
The logic in aa05df90 for lock preemption was backwards (because the
logic is backwards relative to everywhere else we catch a duplicate key
error). This caused us to throw the duplicate key error (and in the
event of any other error, we'd try to preempt the lock 😬)