### PR TITLE
Fix Discord error when creating untagged puzzle

### DIFF
--- a/imports/server/hooks/discord-hooks.ts
+++ b/imports/server/hooks/discord-hooks.ts
@@ -45,13 +45,12 @@ const DiscordHooks: Hookset = {
         return t ? t.name : '';
       }).filter((t) => t.length > 0);
       const tags = tagNameList.map((tagName) => `\`${tagName}\``).join(', ');
+      const fields = tags.length > 0 ? [{ name: 'Tags', value: tags, inline: true }] : undefined;
       const messageObj = {
         embed: {
           title,
           url,
-          fields: [
-            { name: 'Tags', value: tags, inline: true },
-          ],
+          fields,
         },
       };
       bot.postMessageToChannel(hunt.puzzleHooksDiscordChannel.id, messageObj);


### PR DESCRIPTION
It is apparently an error to submit an embedded fields record with the
empty string as its value.

Fixes #473.