### PR TITLE
Uninstall Amazon SSM and snapd to save memory

### DIFF
--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -758,6 +758,10 @@ Resources:
                 - cleanup() { ret=$?; set +e; cfn-signal -e $ret -r "runcmds complete" --stack=${AWS::StackName} --region=${AWS::Region} --resource=AppAsg; exit $ret; }
                 - trap cleanup EXIT
 
+                # Uninstall Amazon SSM manager and snapd - we don't use them, and they eat memory (and cause swap-thrashing)
+                - snap remove amazon-ssm-agent
+                - sudo apt-get remove -y snapd
+
                 - SWAP_DEV="$(/usr/local/bin/find-swap sdf)"
                 - if [ -n "$SWAP_DEV" ]; then
                 -   SWAP_UUID="$(uuidgen)"


### PR DESCRIPTION
On the smallest instances that Jolly Roger runs on (t3a.nano-ish), we're
very memory-constrained. SSM and snapd both use valuable memory, which
in turn causes swap thrashing. Uninstalling both seems to be enough to
save us.