### PR TITLE
Slim down dd-agent's footprint

### DIFF
--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -663,6 +663,15 @@ Resources:
                     location /healthcheck {
                       return 200 "OK\n";
                     }
+                - path: /etc/datadog-agent/datadog.yaml
+                  content: |
+                    apm_config:
+                      enabled: false
+                    compliance_config:
+                      enabled: false
+                    runtime_security_config:
+                      enabled: false
+                    use_dogstatsd: false
 
               runcmd:
                 - set -eux
@@ -704,7 +713,11 @@ Resources:
                 - ''
               DatadogDockerConfig: !If
                 - HaveDatadog
-                - !Sub '- docker run --name dd-agent -d --restart=unless-stopped -h `hostname` -v /var/run/docker.sock:/var/run/docker.sock -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=${DatadogApiKey} datadog/agent:latest'
+                - !Sub |
+                  - docker run --name dd-agent -d --restart=unless-stopped -h `hostname` -v /etc/datadog-agent/datadog.yaml:/etc/datadog-agent/datadog.yaml -v /var/run/docker.sock:/var/run/docker.sock -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=${DatadogApiKey} datadog/agent:latest
+                  # this is a hack to stop the security agent, which doesn't seem to want to stop on its own, and free up some memory
+                  - sleep 5
+                  - docker exec dd-agent s6-svc -d /var/run/s6/services/security/ || true
                 - ''
     DependsOn:
       - InternetGatewayAttachment


### PR DESCRIPTION
This disables the tracing, dogstatsd, and security agents, none of which we use. It's still a memory hog, but this seems to make it better.

I'm undecided if this is actually a good idea or not, but we are pretty memory constrained on t3a.nano and we're about to add the Mediasoup logic.

Note that the shenanigans around the security agent are related to what seems to be a bug. This logic seems designed to cause the security agent to quit if it isn't enabled:

https://github.com/DataDog/datadog-agent/blob/f4cbdd633850263e8aab363c008087ab8b2ed72d/cmd/security-agent/app/app.go#L211-L219

But if that function returns `nil`, then the main function just blocks until it gets a signal on stopCh (which fires on Unix signal):

https://github.com/DataDog/datadog-agent/blob/f4cbdd633850263e8aab363c008087ab8b2ed72d/cmd/security-agent/app/app.go#L162-L168

So instead it just sits in a sleep loop, which should be harmless, but seems to wake up frequently enough to keep itself in resident memory.

(And yes, the Datadog container does seem to use daemontools to manage daemons :sob:)