### PR TITLE
Switch to using CloudWatch agent for host metrics

### DIFF
--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -100,15 +100,9 @@ Parameters:
     Type: String
     Default: ''
     NoEcho: true
-  DatadogApiKey:
-    Description: API key for DataDog
-    Type: String
-    Default: ''
-    NoEcho: true
 
 Conditions:
   HavePapertrail: !Not [!Equals [!Ref PapertrailHost, '']]
-  HaveDatadog: !Not [!Equals [!Ref DatadogApiKey, '']]
 
 Resources:
 
@@ -380,6 +374,8 @@ Resources:
             Principal:
               Service: [ec2.amazonaws.com]
             Action: ["sts:AssumeRole"]
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
       Policies:
         - PolicyName: credstash-download
           PolicyDocument:
@@ -663,15 +659,53 @@ Resources:
                     location /healthcheck {
                       return 200 "OK\n";
                     }
-                - path: /etc/datadog-agent/datadog.yaml
+                - path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
                   content: |
-                    apm_config:
-                      enabled: false
-                    compliance_config:
-                      enabled: false
-                    runtime_security_config:
-                      enabled: false
-                    use_dogstatsd: false
+                    {
+                      "metrics": {
+                        "append_dimensions": {
+                          "AutoScalingGroupName": "${!aws:AutoScalingGroupName}",
+                          "ImageId": "${!aws:ImageId}",
+                          "InstanceId": "${!aws:InstanceId}",
+                          "InstanceType": "${!aws:InstanceType}"
+                        },
+                        "metrics_collected": {
+                          "cpu": {
+                            "measurement": [
+                              "cpu_usage_idle",
+                              "cpu_usage_iowait",
+                              "cpu_usage_user",
+                              "cpu_usage_system"
+                            ]
+                          },
+                          "mem": {
+                            "measurement": [
+                              "mem_used_percent"
+                            ]
+                          },
+                          "diskio": {
+                            "measurement": [
+                              "io_time",
+                              "write_bytes",
+                              "read_bytes",
+                              "writes",
+                              "reads"
+                            ]
+                          },
+                          "netstat": {
+                            "measurement": [
+                              "tcp_established",
+                              "tcp_time_wait"
+                            ]
+                          },
+                          "swap": {
+                            "measurement": [
+                              "swap_used_percent"
+                            ]
+                          }
+                        }
+                      }
+                    }
 
               runcmd:
                 - set -eux
@@ -689,8 +723,12 @@ Resources:
                 - export AWS_DEFAULT_REGION=${AWS::Region}
 
                 # Observability
+                - curl -O https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+                - dpkg -i ./amazon-cloudwatch-agent.deb
+                - rm amazon-cloudwatch-agent.deb
+                - sudo systemctl start amazon-cloudwatch-agent
+
                 ${PapertrailDockerConfig}
-                ${DatadogDockerConfig}
 
                 # Use host networking for better performance
                 - docker run --name coturn -d --restart=unless-stopped --network=host instrumentisto/coturn --log-file=stdout --external-ip='$(detect-external-ip)' --realm=${DirectUrl} --use-auth-secret --static-auth-secret=${TurnSecret}
@@ -710,14 +748,6 @@ Resources:
               PapertrailDockerConfig: !If
                 - HavePapertrail
                 - !Sub '- docker run --name logspout -d --restart=unless-stopped -v /var/run/docker.sock:/tmp/docker.sock -e "SYSLOG_HOSTNAME=$(hostname){{.Container.Name}}" gliderlabs/logspout:master syslog://${PapertrailHost}'
-                - ''
-              DatadogDockerConfig: !If
-                - HaveDatadog
-                - !Sub |
-                  - docker run --name dd-agent -d --restart=unless-stopped -h `hostname` -v /etc/datadog-agent/datadog.yaml:/etc/datadog-agent/datadog.yaml -v /var/run/docker.sock:/var/run/docker.sock -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=${DatadogApiKey} datadog/agent:latest
-                  # this is a hack to stop the security agent, which doesn't seem to want to stop on its own, and free up some memory
-                  - sleep 5
-                  - docker exec dd-agent s6-svc -d /var/run/s6/services/security/ || true
                 - ''
     DependsOn:
       - InternetGatewayAttachment


### PR DESCRIPTION
I'm not wild about CloudWatch in general as a service, and this does
theoretically cost us some metrics that the Datadog agent is capable of
capturing, but we don't make that much use of those metrics today, and
the CloudWatch agent uses significantly less memory than Datadog.