### PR TITLE
Switch to host networking in CloudFormation config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,9 @@ RUN ./build.sh
 ENV PORT 80
 EXPOSE 80
 
+# Mediasoup RTC ports
+EXPOSE 10000-59999/udp
+EXPOSE 10000-59999/tcp
+
 WORKDIR /built_app/bundle
 CMD /built_app/scripts/run_jolly_roger.sh

--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -507,7 +507,6 @@ Resources:
                 - containerd.io
                 - htop
                 - moreutils
-                - nvme-cli
                 - python3-dev
                 - python3-pip
 
@@ -519,22 +518,80 @@ Resources:
                     #!/bin/sh
                     docker volume ls -qf dangling=true | chronic xargs -r docker volume rm
                   permissions: "0755"
-                - path: /etc/nginx-https/cache.conf
+                - path: /etc/nginx/conf.d/default.conf
                   content: |
+                    # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
+                    # scheme used to connect to this server
+                    map $http_x_forwarded_proto $proxy_x_forwarded_proto {
+                      default $http_x_forwarded_proto;
+                      ''      $scheme;
+                    }
+                    # If we receive X-Forwarded-Port, pass it through; otherwise, pass along the
+                    # server port the client connected to
+                    map $http_x_forwarded_port $proxy_x_forwarded_port {
+                      default $http_x_forwarded_port;
+                      ''      $server_port;
+                    }
+                    # Set appropriate X-Forwarded-Ssl header based on $proxy_x_forwarded_proto
+                    map $proxy_x_forwarded_proto $proxy_x_forwarded_ssl {
+                      default off;
+                      https on;
+                    }
+                    # If we receive Upgrade, set Connection to "upgrade"; otherwise, delete any
+                    # Connection header that may have been passed to this server
+                    map $http_upgrade $proxy_connection {
+                      default upgrade;
+                      '' close;
+                    }
+
+                    gzip_types text/plain text/css application/javascript application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+
+                    log_format vhost '$host $remote_addr - $remote_user [$time_local] '
+                                    '"$request" $status $body_bytes_sent '
+                                    '"$http_referer" "$http_user_agent" '
+                                    '"$upstream_addr"';
+                    access_log off;
+
+                    # HTTP 1.1 support
+                    proxy_http_version 1.1;
+                    proxy_buffering off;
+                    proxy_set_header Host $http_host;
+                    proxy_set_header Upgrade $http_upgrade;
+                    proxy_set_header Connection $proxy_connection;
+                    proxy_set_header X-Real-IP $remote_addr;
+                    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+                    proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+                    proxy_set_header X-Forwarded-Ssl $proxy_x_forwarded_ssl;
+                    proxy_set_header X-Forwarded-Port $proxy_x_forwarded_port;
+                    # Mitigate httpoxy attack
+                    proxy_set_header Proxy "";
                     proxy_cache_path /var/cache/nginx/cache levels=1:2 keys_zone=assets:10m;
-                - path: /etc/nginx-https/vhost.d/${AppUrl}
-                  content: |
-                    add_header Strict-Transport-Security "max-age=31536000";
                     proxy_cache assets;
-                    gzip on;
-                    gzip_comp_level 9;
-                    gzip_proxied any;
 
                     set_real_ip_from 10.0.0.0/8;
                     real_ip_header X-Forwarded-For;
 
-                    location /healthcheck {
-                      return 200 "OK\n";
+                    upstream jolly-roger {
+                      server 127.0.0.1:3000;
+                    }
+
+                    server {
+                      server_name ${AppUrl};
+                      listen 8443 default_server;
+                      access_log /var/log/nginx/access.log vhost;
+
+                      add_header Strict-Transport-Security "max-age=31536000";
+                      gzip on;
+                      gzip_comp_level 9;
+                      gzip_proxied any;
+
+                      location /healthcheck {
+                        return 200 "OK\n";
+                      }
+
+                      location / {
+                        proxy_pass http://jolly-roger;
+                      }
                     }
                 - path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
                   content: |
@@ -596,7 +653,7 @@ Resources:
                 - snap remove amazon-ssm-agent
                 - sudo apt-get remove -y snapd
 
-                - pip install 'credstash==1.12.0'
+                - pip3 install 'credstash==1.12.0'
                 - export AWS_DEFAULT_REGION=${AWS::Region}
 
                 # Observability
@@ -607,9 +664,8 @@ Resources:
 
                 ${PapertrailDockerConfig}
 
-                - docker run --name jolly-roger -d --restart=unless-stopped -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION -e VIRTUAL_HOST=${AppUrl} -e ROOT_URL=https://${AppUrl} deathandmayhem/jolly-roger
-
-                - docker run --name nginx-https -d --restart=unless-stopped -p 8443:80 -e DEFAULT_HOST=${AppUrl} -v /var/run/docker.sock:/tmp/docker.sock:ro -v /etc/nginx-https/cache.conf:/etc/nginx/conf.d/cache.conf -v /etc/nginx-https/vhost.d:/etc/nginx/vhost.d jwilder/nginx-proxy
+                - docker run --name jolly-roger -d --network=host --restart=unless-stopped -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION -e PORT=3000 -e ROOT_URL=https://${AppUrl} deathandmayhem/jolly-roger
+                - docker run --name nginx -d --network=host --restart=unless-stopped -v /etc/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf nginx
                 - docker run --name watchtower -d --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --interval 30 --cleanup
             -
               PapertrailRsyslogConfig: !If


### PR DESCRIPTION
Now that we're running RTC traffic directly through the jolly-roger
container, we should move it to host networking to save on overhead. The
easiest way to make this work was to just switch to the standard nginx
container and provide our own nginx config (which is mostly taken from
the config that nginx-proxy was previously rendering).

(Running in production successfully already)