### PR TITLE
Make debugging in prod slightly more pleasant

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,6 @@
 {
-    "plugins": ["babel-plugin-styled-components"]
+    "plugins": [
+        "babel-plugin-styled-components",
+        "babel-plugin-add-react-displayname"
+    ]
 }
-  

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -27,7 +27,6 @@ meteorhacks:cluster
 meteortesting:browser-tests
 meteortesting:mocha
 standard-minifier-css@1.7.4
-standard-minifier-js@2.7.2
 react-meteor-data@2.1.2
 fourseven:scss@4.15.0
 shell-server@0.5.0
@@ -39,3 +38,4 @@ typescript@4.4.0
 xolvio:cleaner
 deanius:promise
 hot-module-replacement@0.4.0
+zodern:standard-minifier-js

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -51,7 +51,6 @@ meteortesting:browser-tests@1.3.4
 meteortesting:mocha@2.0.3
 meteortesting:mocha-core@8.1.2
 minifier-css@1.6.0
-minifier-js@2.7.2
 minimongo@1.7.0
 mobile-experience@1.1.0
 mobile-status-bar@1.1.0
@@ -84,7 +83,6 @@ sha@1.0.9
 shell-server@0.5.0
 socket-stream-client@0.4.0
 standard-minifier-css@1.7.4
-standard-minifier-js@2.7.2
 tmeasday:check-npm-versions@1.0.2
 tracker@1.2.0
 typescript@4.4.0
@@ -93,3 +91,6 @@ url@1.3.2
 webapp@1.13.0
 webapp-hashing@1.1.0
 xolvio:cleaner@0.4.0
+zodern:caching-minifier@0.4.0
+zodern:minifier-js@4.1.0
+zodern:standard-minifier-js@4.1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1546,6 +1546,12 @@
       "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
       "dev": true
     },
+    "babel-plugin-add-react-displayname": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz",
+      "integrity": "sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=",
+      "dev": true
+    },
     "babel-plugin-emotion": {
       "version": "10.0.33",
       "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@typescript-eslint/eslint-plugin": "^4.9.1",
     "@typescript-eslint/parser": "^4.9.1",
     "assert": "^2.0.0",
+    "babel-plugin-add-react-displayname": "0.0.5",
     "babel-plugin-styled-components": "^1.13.2",
     "chai": "^4.2.0",
     "diff": "^4.0.2",


### PR DESCRIPTION
Switching from Meteor's standard minifier to the zodern packages emits
sourcemaps. The add-react-displayname Babel plugin adds a `displayName`
property to React components, which causes them to show up with
unmangled names in the React dev tools (which apparently can't use
sourcemaps to pierce the minification on its own).

Neither of these are perfect - in particular, some of the libraries we
include seem to not get included in sourcemaps or have their display
names tagged correctly - but I think this is still a meaningful
improvement.