### PR TITLE
Update Meteor to 2.5.2

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -4,7 +4,7 @@
 # 'meteor add' and 'meteor remove' will edit this file for you,
 # but you can also edit it by hand.
 
-ecmascript@0.16.0
+ecmascript@0.16.1
 ecmascript-collections
 accounts-password@2.2.0
 audit-argument-checks@1.0.7
@@ -34,8 +34,8 @@ google-oauth@1.4.1
 dynamic-import@0.7.2
 underscore@1.0.10
 server-render@0.4.0
-typescript@4.4.0
+typescript@4.4.1
 xolvio:cleaner
 deanius:promise
-hot-module-replacement@0.4.0
+hot-module-replacement@0.5.0
 zodern:standard-minifier-js

--- a/.meteor/release
+++ b/.meteor/release
@@ -1,1 +1,1 @@
-METEOR@2.5.1
+METEOR@2.5.2

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -6,7 +6,7 @@ aldeed:schema-index@3.0.0
 allow-deny@1.1.0
 audit-argument-checks@1.0.7
 autoupdate@1.8.0
-babel-compiler@7.7.0
+babel-compiler@7.8.0
 babel-runtime@1.5.0
 base64@1.0.12
 binary-heap@1.0.11
@@ -24,7 +24,7 @@ ddp-server@2.5.0
 deanius:promise@3.1.3
 diff-sequence@1.1.1
 dynamic-import@0.7.2
-ecmascript@0.16.0
+ecmascript@0.16.1
 ecmascript-collections@0.1.6
 ecmascript-runtime@0.8.0
 ecmascript-runtime-client@0.12.1
@@ -37,7 +37,7 @@ fourseven:scss@4.15.0
 geojson-utils@1.0.10
 google-oauth@1.4.1
 hot-code-push@1.0.4
-hot-module-replacement@0.4.0
+hot-module-replacement@0.5.0
 http@1.4.4
 id-map@1.1.1
 inter-process-messaging@0.1.1
@@ -47,7 +47,7 @@ logging@1.3.1
 meteor@1.10.0
 meteor-base@1.5.1
 meteorhacks:cluster@1.6.9
-meteortesting:browser-tests@1.3.4
+meteortesting:browser-tests@1.3.5
 meteortesting:mocha@2.0.3
 meteortesting:mocha-core@8.1.2
 minifier-css@1.6.0
@@ -55,7 +55,7 @@ minimongo@1.7.0
 mobile-experience@1.1.0
 mobile-status-bar@1.1.0
 modern-browsers@0.1.7
-modules@0.17.0
+modules@0.18.0
 modules-runtime@0.12.0
 modules-runtime-hot@0.14.0
 mongo@1.13.0
@@ -71,7 +71,7 @@ promise@0.12.0
 raix:eventemitter@1.0.0
 random@1.2.0
 rate-limit@1.0.9
-react-fast-refresh@0.2.0
+react-fast-refresh@0.2.2
 react-meteor-data@2.4.0
 reactive-var@1.0.11
 reload@1.3.1
@@ -85,7 +85,7 @@ socket-stream-client@0.4.0
 standard-minifier-css@1.7.4
 tmeasday:check-npm-versions@1.0.2
 tracker@1.2.0
-typescript@4.4.0
+typescript@4.4.1
 underscore@1.0.10
 url@1.3.2
 webapp@1.13.0


### PR DESCRIPTION
Update log:

```
zarvox@minotaur jolly-roger % meteor update

Changes to your project's package version selections from updating the release:

babel-compiler          upgraded from 7.7.0 to 7.8.0
ecmascript              upgraded from 0.16.0 to 0.16.1
hot-module-replacement  upgraded from 0.4.0 to 0.5.0
modules                 upgraded from 0.17.0 to 0.18.0
react-fast-refresh      upgraded from 0.2.0 to 0.2.1
typescript              upgraded from 4.4.0 to 4.4.1

jolly-roger: updated to Meteor 2.5.2.

Changes to your project's package version selections from updating package versions:

meteortesting:browser-tests  upgraded from 1.3.4 to 1.3.5
react-fast-refresh           upgraded from 0.2.1 to 0.2.2

The following top-level dependencies were not updated to the very latest version available:
 * http 1.4.4 (2.0.0 is available)

Newer versions of the following indirect dependencies are available:
 * coffeescript 1.0.17 (2.4.1 is available)
These versions may not be compatible with your project.
To update one or more of these packages to their latest
compatible versions, pass their names to `meteor update`,
or just run `meteor update --all-packages`.
If the packages do not upgrade after this, this could mean
that there is a newer version of Meteor which the package
requires, but it not yet recommended or that some package
dependencies are not up to date and don't allow you to get
the latest package version.
```