### PR TITLE
Clean up peer join logging

### DIFF
--- a/imports/server/mediasoup-api.ts
+++ b/imports/server/mediasoup-api.ts
@@ -1,6 +1,7 @@
 import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { NpmModuleMongodb } from 'meteor/npm-mongo';
+import Ansible from '../ansible';
 import Flags from '../flags';
 import ConnectAcks from '../lib/models/mediasoup/connect_acks';
 import ConnectRequests from '../lib/models/mediasoup/connect_requests';
@@ -145,6 +146,8 @@ Meteor.publish('mediasoup:join', function (hunt, call, tab) {
       muted: false,
       deafened: false,
     });
+
+    Ansible.log('Peer joined call', { peer: peerId, call, createdBy: this.userId });
   });
 
   this.onStop(() => {

--- a/imports/server/mediasoup.ts
+++ b/imports/server/mediasoup.ts
@@ -21,7 +21,6 @@ import TransportStates from '../lib/models/mediasoup/transport_states';
 import Transports from '../lib/models/mediasoup/transports';
 import { ConnectRequestType } from '../lib/schemas/mediasoup/connect_request';
 import { ConsumerAckType } from '../lib/schemas/mediasoup/consumer_ack';
-import { PeerType } from '../lib/schemas/mediasoup/peer';
 import { ProducerClientType } from '../lib/schemas/mediasoup/producer_client';
 import { RoomType } from '../lib/schemas/mediasoup/room';
 import { TransportRequestType } from '../lib/schemas/mediasoup/transport_request';
@@ -83,7 +82,8 @@ class SFU {
     this.onWorkerCreated(this.worker);
 
     this.peersHandle = Peers.find({}).observeChanges({
-      added: (id, fields) => this.peerCreated({ _id: id, ...fields } as PeerType),
+      // Use this as an opportunity to cleanup data created as part of the
+      // transport negotiation
       removed: (id) => this.peerRemoved(id),
     });
 
@@ -382,10 +382,6 @@ class SFU {
   }
 
   // Mongo callbacks
-
-  peerCreated(peer: PeerType) {
-    Ansible.log('Peer joined call', { peer: peer._id, call: peer.call, createdBy: peer.createdBy });
-  }
 
   peerRemoved(id: string) {
     this.peerToRtpCapabilities.delete(id);


### PR DESCRIPTION
We listen for all peers being deleted because that's our best
opportunity to clean up any cached RTP parameters we have for that peer,
but because it runs on all servers, we don't want each of them to emit a
log line telling us that a new peer joined.