### PR TITLE
Allow `expectedAnswerCount` to be zero

### DIFF
--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -68,13 +68,13 @@ const Puzzle = React.memo((props: PuzzleProps) => {
   const tagIndex = _.indexBy(props.allTags, '_id');
   const shownTags = _.difference(props.puzzle.tags, props.suppressTags || []);
   const ownTags = shownTags.map((tagId) => { return tagIndex[tagId]; }).filter(Boolean);
-  const isAdministrivia = props.puzzle.tags.find((t) => { return tagIndex[t] && tagIndex[t].name === 'administrivia'; });
 
   const puzzleClasses = classnames('puzzle',
-    props.puzzle.answers.length >= props.puzzle.expectedAnswerCount ? 'solved' : 'unsolved',
+    props.puzzle.expectedAnswerCount === 0 ? 'administrivia' : null,
+    props.puzzle.expectedAnswerCount > 0 && props.puzzle.answers.length >= props.puzzle.expectedAnswerCount ? 'solved' : null,
+    props.puzzle.expectedAnswerCount > 0 && props.puzzle.answers.length < props.puzzle.expectedAnswerCount ? 'unsolved' : null,
     props.layout === 'grid' ? 'puzzle-grid' : null,
-    props.layout === 'table' ? 'puzzle-table-row' : null,
-    isAdministrivia ? 'administrivia' : null);
+    props.layout === 'table' ? 'puzzle-table-row' : null);
 
   const answers = props.puzzle.answers.map((answer, i) => {
     return (
@@ -120,7 +120,7 @@ const Puzzle = React.memo((props: PuzzleProps) => {
         <Link to={linkTarget}>{props.puzzle.title}</Link>
       </div>
       <div className="puzzle-column puzzle-view-count">
-        {!(props.puzzle.answers.length >= props.puzzle.expectedAnswerCount) && !isAdministrivia && <SubscriberCount puzzleId={props.puzzle._id} />}
+        {!(props.puzzle.answers.length >= props.puzzle.expectedAnswerCount) && <SubscriberCount puzzleId={props.puzzle._id} />}
       </div>
       <div className="puzzle-column puzzle-link">
         {props.puzzle.url ? (

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -205,7 +205,10 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
       return puzzles;
     } else {
       return puzzles.filter((puzzle) => {
-        return (puzzle.answers.length < puzzle.expectedAnswerCount);
+        // Items with no expected answer are always shown, since they're
+        // generally pinned administrivia.
+        return (puzzle.expectedAnswerCount === 0 ||
+          puzzle.answers.length < puzzle.expectedAnswerCount);
       });
     }
   }, [showSolved]);

--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -300,7 +300,7 @@ const PuzzleModalForm = React.forwardRef((
               disabled={disableForm}
               onChange={onExpectedAnswerCountChange}
               value={currentExpectedAnswerCount}
-              min={1}
+              min={0}
               step={1}
             />
           </Col>

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -446,7 +446,6 @@ const PuzzlePageMetadata = (props: PuzzlePageMetadataProps) => {
 
   const tagsById = _.indexBy(props.allTags, '_id');
   const tags = props.puzzle.tags.map((tagId) => { return tagsById[tagId]; }).filter(Boolean);
-  const isAdministrivia = tags.find((t) => t.name === 'administrivia');
   const correctGuesses = props.guesses.filter((guess) => guess.state === 'correct');
   const numGuesses = props.guesses.length;
 
@@ -493,7 +492,7 @@ const PuzzlePageMetadata = (props: PuzzlePageMetadataProps) => {
   ) : null;
 
   let guessButton = null;
-  if (!isAdministrivia) {
+  if (props.puzzle.expectedAnswerCount > 0) {
     guessButton = tracker.hasGuessQueue ? (
       <>
         <Button variant="primary" size="sm" className="puzzle-metadata-guess-button" onClick={showGuessModal}>


### PR DESCRIPTION
For puzzles where expected answer count is exactly zero:

* On the puzzle page, don't show the answer submission/guess queue
  submission button or modal
* On the puzzle list page, consider the item eligible to be shown
  alongside unsolved puzzles, since these are usually pinned
  administrivia that we don't want to disappear.
* On the puzzle list page, don't show viewer counts
* On the puzzle list page, style the puzzle row in light purple (as we
  currently do for administrivia)

We retain the sort order behavior of the `administrivia` tag (sorts
above all other groups).

I audited the remaining references to the string `administrivia` as well
as the `expectedAnswerCount` field; they all look good.

Fixes #512.