### PR TITLE
Add FirehosePage for tailing/searching all chat messages

### DIFF
--- a/imports/client/components/FirehosePage.tsx
+++ b/imports/client/components/FirehosePage.tsx
@@ -1,0 +1,266 @@
+import { Meteor } from 'meteor/meteor';
+import { useTracker } from 'meteor/react-meteor-data';
+import { _ } from 'meteor/underscore';
+import { faEraser } from '@fortawesome/free-solid-svg-icons/faEraser';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React, {
+  useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState,
+} from 'react';
+import Button from 'react-bootstrap/Button';
+import FormControl, { FormControlProps } from 'react-bootstrap/FormControl';
+import FormGroup from 'react-bootstrap/FormGroup';
+import InputGroup from 'react-bootstrap/InputGroup';
+import { Link, useParams, useSearchParams } from 'react-router-dom';
+import styled from 'styled-components';
+import { shortCalendarTimeFormat } from '../../lib/calendarTimeFormat';
+import ChatMessages from '../../lib/models/chats';
+import Profiles from '../../lib/models/profiles';
+import Puzzles from '../../lib/models/puzzles';
+import { ChatMessageType } from '../../lib/schemas/chat';
+import { PuzzleType } from '../../lib/schemas/puzzle';
+import { useBreadcrumb } from '../hooks/breadcrumb';
+import FixedLayout from './styling/FixedLayout';
+
+const FirehosePageLayout = styled.div`
+  padding: 8px 15px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  height: 100%;
+  > * {
+    width: 100%;
+  }
+`;
+
+interface MessageProps {
+  msg: ChatMessageType;
+  displayNames: Record<string, string>;
+  puzzles: Record<string, PuzzleType>;
+}
+
+const Message = ({ msg, displayNames, puzzles }: MessageProps) => {
+  const displayName = msg.sender ? displayNames[msg.sender] : 'jolly-roger';
+  const ts = shortCalendarTimeFormat(msg.timestamp);
+  return (
+    <div>
+      [
+      {ts}
+      ] [
+      <Link to={`/hunts/${msg.hunt}/puzzles/${msg.puzzle}`}>{puzzles[msg.puzzle].title}</Link>
+      {'] '}
+      {displayName}
+      {': '}
+      {msg.text}
+    </div>
+  );
+};
+
+const MessagesPane = styled.div`
+  overflow-y: scroll;
+  flex: 1;
+
+  &.live {
+    border-bottom: 1px solid black;
+  }
+`;
+
+const FirehosePage = () => {
+  const huntId = useParams<'huntId'>().huntId!;
+  const [searchParams, setSearchParams] = useSearchParams();
+  const searchString = searchParams.get('q') || '';
+
+  useBreadcrumb({ title: 'Firehose', path: `/hunts/${huntId}/firehose` });
+
+  const profilesTracker = useTracker(() => {
+    const profilesHandle = Profiles.subscribeDisplayNames();
+    const ready = profilesHandle.ready();
+    return {
+      ready,
+      displayNames: ready ? Profiles.displayNames() : {},
+    };
+  }, []);
+  const puzzlesTracker = useTracker(() => {
+    const puzzlesHandle = Meteor.subscribe('mongo.puzzles', {
+      hunt: huntId,
+    });
+    const ready = puzzlesHandle.ready();
+    const puzzles = ready ? Puzzles.find({ hunt: huntId }).fetch() : [];
+    const indexedPuzzles = _.indexBy(puzzles, '_id');
+    return {
+      ready,
+      puzzles: indexedPuzzles,
+    };
+  }, [huntId]);
+  const chatMessagesTracker = useTracker(() => {
+    const chatMessagesHandle = Meteor.subscribe('mongo.chatmessages', {
+      hunt: huntId,
+    });
+    const ready = chatMessagesHandle.ready();
+    const chatMessages = ready ?
+      ChatMessages.find({ hunt: huntId }, { sort: { timestamp: 1 } }).fetch() : [];
+    return {
+      ready,
+      chatMessages,
+    };
+  }, [huntId]);
+
+  const messagesPaneRef = useRef<HTMLDivElement>(null);
+  const searchBarRef = useRef<HTMLInputElement>(null);
+
+  const maybeStealCtrlF = useCallback((e: KeyboardEvent) => {
+    if (e.ctrlKey && e.key === 'f') {
+      e.preventDefault();
+      const node = searchBarRef.current;
+      if (node) {
+        node.focus();
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('keydown', maybeStealCtrlF);
+    return () => {
+      window.removeEventListener('keydown', maybeStealCtrlF);
+    };
+  }, [maybeStealCtrlF]);
+
+  const setSearchString = useCallback((val: string) => {
+    const u = new URLSearchParams(searchParams);
+    if (val) {
+      u.set('q', val);
+    } else {
+      u.delete('q');
+    }
+    setSearchParams(u);
+  }, [searchParams, setSearchParams]);
+
+  const onSearchStringChange: FormControlProps['onChange'] = useCallback((e) => {
+    setSearchString(e.currentTarget.value);
+  }, [setSearchString]);
+
+  const clearSearch = useCallback(() => {
+    setSearchString('');
+  }, [setSearchString]);
+
+  const compileMatcher = useCallback((searchKeys: string[]): (c: ChatMessageType) => boolean => {
+    // Given a list a search keys, compileMatcher returns a function that,
+    // given a chat message, returns true if all search keys match that message in
+    // some way, and false if any of the search keys cannot be found.
+    const lowerSearchKeys = searchKeys.map((key) => key.toLowerCase());
+    return (chatMessage) => {
+      return lowerSearchKeys.every((key) => {
+        return chatMessage.text.toLowerCase().indexOf(key) !== -1;
+      });
+    };
+  }, []);
+
+  const filteredChats = useCallback((chatMessages: ChatMessageType[]) => {
+    const searchKeys = searchString.split(' ');
+    let interestingChatMessages;
+
+    if (searchKeys.length === 1 && searchKeys[0] === '') {
+      interestingChatMessages = chatMessages;
+    } else {
+      const searchKeysWithEmptyKeysRemoved = searchKeys.filter((key) => { return key.length > 0; });
+      const isInteresting = compileMatcher(searchKeysWithEmptyKeysRemoved);
+      interestingChatMessages = chatMessages.filter(isInteresting);
+    }
+
+    return interestingChatMessages;
+  }, [searchString, compileMatcher]);
+
+  const [shouldScrollBottom, setShouldScrollBottom] = useState<boolean>(true);
+
+  const saveShouldScroll = useCallback(() => {
+    const pane = messagesPaneRef.current;
+    if (pane) {
+      const basicallyAtBottom = pane.clientHeight + pane.scrollTop + 5 >= pane.scrollHeight;
+      setShouldScrollBottom(basicallyAtBottom);
+    }
+  }, []);
+
+  const forceScrollBottom = useCallback(() => {
+    const pane = messagesPaneRef.current;
+    if (pane) {
+      pane.scrollTop = pane.scrollHeight;
+    }
+  }, []);
+  const maybeForceScrollBottom = useCallback(() => {
+    if (shouldScrollBottom) {
+      forceScrollBottom();
+    }
+  }, [shouldScrollBottom, forceScrollBottom]);
+
+  const chats = useMemo(() => {
+    return filteredChats(chatMessagesTracker.chatMessages);
+  }, [filteredChats, chatMessagesTracker.chatMessages]);
+
+  const ready = profilesTracker.ready && puzzlesTracker.ready && chatMessagesTracker.ready;
+
+  const onLayoutMaybeChanged = useCallback(() => {
+    // Any time the length of the chat changes, jump to the end if we were already there
+    maybeForceScrollBottom();
+
+    // Any time the contents of the backscroll become shorter than the space
+    // available, stick to the bottom.
+    saveShouldScroll();
+  }, [maybeForceScrollBottom, saveShouldScroll]);
+
+  useEffect(() => {
+    window.addEventListener('resize', onLayoutMaybeChanged);
+
+    return () => {
+      window.removeEventListener('resize', onLayoutMaybeChanged);
+    };
+  }, [onLayoutMaybeChanged]);
+
+  useLayoutEffect(() => {
+    onLayoutMaybeChanged();
+  }, [ready, onLayoutMaybeChanged, chats.length]);
+
+  if (!ready) {
+    return <div>loading...</div>;
+  }
+
+  return (
+    <FixedLayout>
+      <FirehosePageLayout>
+        <h1>Firehose</h1>
+        <p>This log includes all chat messages hunt-wide. Expect some lag.</p>
+        <FormGroup>
+          <InputGroup>
+            <FormControl
+              id="jr-firehose-search"
+              as="input"
+              type="text"
+              ref={searchBarRef}
+              placeholder="Filter by message contents"
+              value={searchString}
+              onChange={onSearchStringChange}
+            />
+            <InputGroup.Append>
+              <Button variant="secondary" onClick={clearSearch}>
+                <FontAwesomeIcon icon={faEraser} />
+              </Button>
+            </InputGroup.Append>
+          </InputGroup>
+        </FormGroup>
+        <MessagesPane ref={messagesPaneRef} onScroll={saveShouldScroll} className={shouldScrollBottom ? 'live' : ''}>
+          {chats.map((msg) => {
+            return (
+              <Message
+                key={msg._id}
+                msg={msg}
+                puzzles={puzzlesTracker.puzzles}
+                displayNames={profilesTracker.displayNames}
+              />
+            );
+          })}
+        </MessagesPane>
+      </FirehosePageLayout>
+    </FixedLayout>
+  );
+};
+
+export default FirehosePage;

--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -15,6 +15,7 @@ import useDocumentTitle from '../hooks/use-document-title';
 import markdown from '../markdown';
 import AnnouncementsPage from './AnnouncementsPage';
 import CelebrationCenter from './CelebrationCenter';
+import FirehosePage from './FirehosePage';
 import GuessQueuePage from './GuessQueuePage';
 import HuntProfileListPage from './HuntProfileListPage';
 import PuzzleListPage from './PuzzleListPage';
@@ -177,6 +178,7 @@ const HuntApp = React.memo(() => {
     return (
       <Routes>
         <Route path="announcements" element={<AnnouncementsPage />} />
+        <Route path="firehose" element={<FirehosePage />} />
         <Route path="guesses" element={<GuessQueuePage />} />
         <Route path="hunters/*" element={<HuntProfileListPage />} />
         <Route path="puzzles/:puzzleId" element={<PuzzlePage />} />

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -3,6 +3,7 @@ import { useTracker } from 'meteor/react-meteor-data';
 import { _ } from 'meteor/underscore';
 import { faBullhorn } from '@fortawesome/free-solid-svg-icons/faBullhorn';
 import { faEraser } from '@fortawesome/free-solid-svg-icons/faEraser';
+import { faFaucet } from '@fortawesome/free-solid-svg-icons/faFaucet';
 import { faMap } from '@fortawesome/free-solid-svg-icons/faMap';
 import { faReceipt } from '@fortawesome/free-solid-svg-icons/faReceipt';
 import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers';
@@ -487,6 +488,15 @@ const PuzzleListPage = () => {
             <StyledPuzzleListLinkLabel>Hunters</StyledPuzzleListLinkLabel>
           </StyledPuzzleListLinkAnchor>
         </StyledPuzzleListLink>
+        {/* Show firehose link only to operators */}
+        {tracker.canUpdate && (
+          <StyledPuzzleListLink>
+            <StyledPuzzleListLinkAnchor to={`/hunts/${huntId}/firehose`}>
+              <FontAwesomeIcon icon={faFaucet} />
+              <StyledPuzzleListLinkLabel>Firehose</StyledPuzzleListLinkLabel>
+            </StyledPuzzleListLinkAnchor>
+          </StyledPuzzleListLink>
+        )}
       </StyledPuzzleListLinkList>
       {puzzleList}
     </div>


### PR DESCRIPTION
This page adds an in-app view of the sort that we historically aimed for
from the firehose in IRC, Slack, or Discord, where we could see all chat
messages on all puzzles in a single interleaved time-series view.

I'm ignoring formatting here for now; this is largely to make searching
over the whole of a hunt's chatlogs easier.

The filter search only looks at the message text; if you wanted to
filter on a single puzzle, just go view the log from the puzzle page.