### PR TITLE
Rework chat scroll position behavior

### DIFF
--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -6,7 +6,7 @@ import { faCaretRight } from '@fortawesome/free-solid-svg-icons/faCaretRight';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 import React, {
-  ReactChild, useCallback, useEffect, useState,
+  ReactChild, useCallback, useEffect, useLayoutEffect, useState,
 } from 'react';
 import Button from 'react-bootstrap/Button';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
@@ -65,6 +65,7 @@ const ViewerPersonBox = ({
 interface ChatPeopleProps {
   huntId: string;
   puzzleId: string;
+  onHeightChange: () => void;
 }
 
 interface ChatPeopleTracker {
@@ -146,7 +147,7 @@ const ChatPeople = (props: ChatPeopleProps) => {
     leveledStreamSource: undefined,
   });
 
-  const { huntId, puzzleId } = props;
+  const { huntId, puzzleId, onHeightChange } = props;
 
   const tracker: ChatPeopleTracker = useTracker(() => {
     // A note on this feature flag: we still do the subs for call *metadata* for
@@ -416,6 +417,16 @@ const ChatPeople = (props: ChatPeopleProps) => {
     };
   }, [audioState.rawMediaSource]);
 
+  useLayoutEffect(() => {
+    // Notify parent whenever we might have changed size:
+    // * on viewers or rtcViewers counts change
+    // * on expand/collapse of the callers or viewers
+    // * when joining the audiocall
+    onHeightChange();
+  }, [
+    onHeightChange, rtcViewers.length, viewers.length, callersExpanded, viewersExpanded, callState,
+  ]);
+
   if (!ready) {
     return null;
   }
@@ -459,6 +470,7 @@ const ChatPeople = (props: ChatPeopleProps) => {
             localStream={audioState.leveledStreamSource!}
             callersExpanded={callersExpanded}
             onToggleCallersExpanded={toggleCallersExpanded}
+            onHeightChange={onHeightChange}
           />
         );
       case CallState.STREAM_ERROR:

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -215,7 +215,7 @@ const ChatHistory = React.forwardRef((props: ChatHistoryProps, forwardedRef: Rea
     if (scrollBottomTarget.current > 10) {
       saveScrollBottomTarget();
     } else {
-      scrollToTarget();
+      snapToBottom();
     }
   }, [props.chatMessages.length, saveScrollBottomTarget, scrollToTarget]);
 

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -8,7 +8,7 @@ import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import classnames from 'classnames';
 import React, {
-  useCallback, useEffect, useImperativeHandle, useRef, useState,
+  useCallback, useEffect, useImperativeHandle, useLayoutEffect, useRef, useState,
 } from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Badge from 'react-bootstrap/Badge';
@@ -134,78 +134,93 @@ interface ChatHistoryProps {
 }
 
 type ChatHistoryHandle = {
-  forceScrollBottom: () => void;
-  maybeForceScrollBottom: () => void;
+  saveScrollBottomTarget: () => void,
+  snapToBottom: () => void,
+  scrollToTarget: () => void;
 }
 
-// TODO: chat scrolling is still kinda broken -- on initial pageload, it seems that we render, then only after the viewers data loads,
-// we draw boxes for viewers, which results in ChatHistory getting placed in a smaller area, but it doesn't get any event/callback for this.
-// The solution is probably to make sure that when ChatPeople rerenders, we find some way to trigger a maybeForceScrollBottom() here.
 const ChatHistory = React.forwardRef((props: ChatHistoryProps, forwardedRef: React.Ref<ChatHistoryHandle>) => {
   const ref = useRef<HTMLDivElement>(null);
-  const shouldScroll = useRef<boolean>(true);
+  const scrollBottomTarget = useRef<number>(0);
+  const shouldIgnoreNextScrollEvent = useRef<boolean>(false);
 
-  const saveShouldScroll = useCallback(() => {
-    // Save whether the current scrollTop is equal to the ~maximum scrollTop.
-    // If so, then we should make the log "stick" to the bottom, by manually scrolling to the bottom
-    // when needed.
-    const messagePane = ref.current;
-    if (!messagePane) {
-      return;
-    }
-
-    // Include a 5 px fudge factor to account for bad scrolling and
-    // fractional pixels
-    shouldScroll.current = (messagePane.clientHeight + messagePane.scrollTop + 5 >= messagePane.scrollHeight);
-    console.log(`shouldScroll: ${shouldScroll.current}`);
-  }, []);
-
-  const forceScrollBottom = useCallback(() => {
-    console.log('forceScrollBottom called');
-    const messagePane = ref.current;
-    if (messagePane) {
-      messagePane.scrollTop = messagePane.scrollHeight;
-      shouldScroll.current = true;
+  const saveScrollBottomTarget = useCallback(() => {
+    if (ref.current) {
+      const rect = ref.current.getClientRects()[0];
+      const hiddenHeight = ref.current.scrollHeight - rect.height;
+      const distanceFromBottom = hiddenHeight - ref.current.scrollTop;
+      scrollBottomTarget.current = distanceFromBottom;
     }
   }, []);
 
-  const maybeForceScrollBottom = useCallback(() => {
-    console.log('maybeForceScrollBottom called');
-    if (shouldScroll.current) {
-      forceScrollBottom();
+  const onScrollObserved = useCallback(() => {
+    // When we call scrollToTarget and it actually changes scrollTop, this triggers a scroll event.
+    // If the element's scrollHeight or clientHeight changed after scrollToTarget was called, we'd
+    // mistakenly save an incorrect scrollBottomTarget.  So skip one scroll event when we self-induce
+    // this callback, so we only update the target distance from bottom when the user is actually
+    // scrolling.
+    if (shouldIgnoreNextScrollEvent.current) {
+      shouldIgnoreNextScrollEvent.current = false;
+    } else {
+      saveScrollBottomTarget();
     }
-  }, [forceScrollBottom]);
+  }, [saveScrollBottomTarget]);
+
+  const scrollToTarget = useCallback(() => {
+    if (ref.current) {
+      const rect = ref.current.getClientRects()[0];
+      const hiddenHeight = ref.current.scrollHeight - rect.height;
+      // if distanceFromBottom is hiddenHeight - scrollTop, then
+      // our desired scrollTop is hiddenHeight - distanceFromBottom
+      const scrollTopTarget = hiddenHeight - scrollBottomTarget.current;
+      if (ref.current.scrollTop !== scrollTopTarget) {
+        shouldIgnoreNextScrollEvent.current = true;
+        ref.current.scrollTop = scrollTopTarget;
+      }
+    }
+  }, []);
+
+  const snapToBottom = useCallback(() => {
+    scrollBottomTarget.current = 0;
+    scrollToTarget();
+  }, [scrollToTarget]);
 
   useImperativeHandle(forwardedRef, () => ({
-    forceScrollBottom,
-    maybeForceScrollBottom,
+    saveScrollBottomTarget,
+    snapToBottom,
+    scrollToTarget,
   }));
-
-  const resizeHandler = useCallback(() => {
-    maybeForceScrollBottom();
-  }, [maybeForceScrollBottom]);
 
   useEffect(() => {
     // Scroll to end of chat on initial mount.
-    forceScrollBottom();
-  }, [forceScrollBottom]);
+    scrollToTarget();
+  }, [scrollToTarget]);
 
   useEffect(() => {
-    // Add resize handler
-    window.addEventListener('resize', resizeHandler);
+    // Add resize handler that scrolls to target
+    window.addEventListener('resize', scrollToTarget);
 
     return () => {
-      window.removeEventListener('resize', resizeHandler);
+      window.removeEventListener('resize', scrollToTarget);
     };
-  }, [resizeHandler]);
+  }, [scrollToTarget]);
 
-  useEffect(() => {
-    // Whenever we rerender, check if we should be scrolling to the bottom.
-    maybeForceScrollBottom();
-  });
+  useLayoutEffect(() => {
+    // Whenever we rerender due to new messages arriving, make our
+    // distance-from-bottom match the previous one, if it's larger than some
+    // small fudge factor.  But if the user has actually scrolled into the backlog,
+    // don't move the backlog while they're reading it -- instead, assume they want
+    // to see the same messages in the same position, and adapt the target bottom
+    // distance instead.
+    if (scrollBottomTarget.current > 10) {
+      saveScrollBottomTarget();
+    } else {
+      scrollToTarget();
+    }
+  }, [props.chatMessages.length, saveScrollBottomTarget, scrollToTarget]);
 
   return (
-    <div ref={ref} className="chat-history" onScroll={saveShouldScroll}>
+    <div ref={ref} className="chat-history" onScroll={onScrollObserved}>
       {props.chatMessages.length === 0 ? (
         <div className="chat-placeholder" key="no-message">
           <span>No chatter yet. Say something?</span>
@@ -332,34 +347,43 @@ interface ChatSectionProps {
   huntId: string;
 }
 
-const ChatSection = React.memo((props: ChatSectionProps) => {
+interface ChatSectionHandle {
+  scrollHistoryToTarget: () => void;
+}
+
+const ChatSection = React.forwardRef((props: ChatSectionProps, forwardedRef: React.Ref<ChatSectionHandle>) => {
   const historyRef = useRef<React.ElementRef<typeof ChatHistoryMemo>>(null);
 
-  const onInputHeightChange = useCallback(() => {
+  const scrollHistoryToTarget = useCallback(() => {
     if (historyRef.current) {
-      historyRef.current.maybeForceScrollBottom();
+      historyRef.current.scrollToTarget();
     }
   }, []);
 
   const onMessageSent = useCallback(() => {
     if (historyRef.current) {
-      historyRef.current.forceScrollBottom();
+      historyRef.current.snapToBottom();
     }
   }, []);
+
+  useImperativeHandle(forwardedRef, () => ({
+    scrollHistoryToTarget,
+  }));
 
   return (
     <div className="chat-section">
       {props.chatReady ? null : <span>loading...</span>}
-      <ChatPeople huntId={props.huntId} puzzleId={props.puzzleId} />
+      <ChatPeople huntId={props.huntId} puzzleId={props.puzzleId} onHeightChange={scrollHistoryToTarget} />
       <ChatHistoryMemo ref={historyRef} chatMessages={props.chatMessages} displayNames={props.displayNames} />
       <ChatInput
         puzzleId={props.puzzleId}
-        onHeightChange={onInputHeightChange}
+        onHeightChange={scrollHistoryToTarget}
         onMessageSent={onMessageSent}
       />
     </div>
   );
 });
+const ChatSectionMemo = React.memo(ChatSection);
 
 interface PuzzlePageMetadataProps {
   puzzle: PuzzleType;
@@ -917,6 +941,7 @@ interface PuzzlePageTracker {
 
 const PuzzlePage = React.memo((props: PuzzlePageWithRouterParams) => {
   const puzzlePageDivRef = useRef<HTMLDivElement | null>(null);
+  const chatSectionRef = useRef<ChatSectionHandle | null>(null);
   const [sidebarWidth, setSidebarWidth] = useState<number>(DefaultSidebarWidth);
   const [isDesktop, setIsDesktop] = useState<boolean>(window.innerWidth >= MinimumDesktopWidth);
 
@@ -1017,11 +1042,27 @@ const PuzzlePage = React.memo((props: PuzzlePageWithRouterParams) => {
 
   const onResize = useCallback(() => {
     setIsDesktop(window.innerWidth >= MinimumDesktopWidth);
+    if (chatSectionRef.current) {
+      chatSectionRef.current.scrollHistoryToTarget();
+    }
   }, []);
 
-  const onChangeSideBarSize = useCallback((newSidebarWidth: number) => {
+  const onCommitSideBarSize = useCallback((newSidebarWidth: number) => {
     setSidebarWidth(newSidebarWidth);
   }, []);
+
+  const onChangeSideBarSize = useCallback(() => {
+    if (chatSectionRef.current) {
+      chatSectionRef.current.scrollHistoryToTarget();
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    // When sidebarWidth is updated, scroll history to the target
+    if (chatSectionRef.current) {
+      chatSectionRef.current.scrollHistoryToTarget();
+    }
+  }, [sidebarWidth]);
 
   useEffect(() => {
     // Populate sidebar width on mount
@@ -1055,7 +1096,8 @@ const PuzzlePage = React.memo((props: PuzzlePageWithRouterParams) => {
     />
   );
   const chat = (
-    <ChatSection
+    <ChatSectionMemo
+      ref={chatSectionRef}
       chatReady={tracker.chatReady}
       chatMessages={tracker.chatMessages}
       displayNames={tracker.displayNames}
@@ -1075,7 +1117,8 @@ const PuzzlePage = React.memo((props: PuzzlePageWithRouterParams) => {
           autoCollapse1={-1}
           autoCollapse2={-1}
           size={sidebarWidth}
-          onPaneChanged={onChangeSideBarSize}
+          onChanged={onChangeSideBarSize}
+          onPaneChanged={onCommitSideBarSize}
         >
           {chat}
           <div className="puzzle-content">

--- a/imports/client/components/SplitPanePlus.tsx
+++ b/imports/client/components/SplitPanePlus.tsx
@@ -54,6 +54,8 @@ import SplitPane, { SplitPaneProps } from 'react-split-pane';
       If 'relative', primary and secondary panes will retain their proportions during resize.
     step?: number
       Step size when dragging
+    onChanged?: (size: number, collapsed: 0 | 1 | 2) => void
+      Callback triggered per-frame to indicate a change in pane size during a drag.
     onPaneChanged?: (size: number, collapsed: 0 | 1 | 2, cause: 'drag' | 'resize') => void
       Callback triggered to request a change to size or collapsed state. Drag events will call
       this once, at the end of the event. Resize events will call this whenever the currently
@@ -98,6 +100,7 @@ interface SplitPanePlusProps {
   autoCollapse1: number,
   autoCollapse2: number,
   scaling?: 'absolute' | 'relative',
+  onChanged?: (size: number, collapsed: 0 | 1 | 2) => void,
   onPaneChanged?: (size: number, collapsed: 0 | 1 | 2, cause: 'drag' | 'resize') => void,
   step?: number,
   className?: string,
@@ -136,6 +139,7 @@ const SplitPanePlusHook = (props: SplitPanePlusProps) => {
     autoCollapse1 = 50,
     autoCollapse2 = 50,
     scaling = 'absolute',
+    onChanged,
     onPaneChanged,
     step,
     className,
@@ -262,11 +266,15 @@ const SplitPanePlusHook = (props: SplitPanePlusProps) => {
 
   const onChange = useCallback((newSize: number) => {
     // Setting dragInProgress in onDragStarted creates a frame of strangeness
+    const nextCollapse = calculateCollapse(newSize);
     setState({
       dragInProgress: true,
-      collapseWarning: calculateCollapse(newSize),
+      collapseWarning: nextCollapse,
     });
-  }, [calculateCollapse]);
+    if (onChanged) {
+      onChanged(newSize, nextCollapse);
+    }
+  }, [calculateCollapse, onChanged]);
 
   const onDragFinished = useCallback((rawSize: number | string) => {
     setState({


### PR DESCRIPTION
Most of the time, users are interested in the most recent chunk of chat
history, and think of the backlog as being pinned to the bottom, rather
than the top.  However, in the web APIs, overflow definitely defaults to
considering space from the top-left corner of a rectangle.

To approximate the "fixed distance from bottom of scrollback" behavior,
we save the distance from the bottom that we're aiming for, and have a
function which jumps to the appropriate scrollTop value to maintain that
distance-from-bottom which we call in response to a number of possible
ways that might cause the space available to the chat history pane (or
the space demanded by the contents to be displayed) to change:

* Callers or viewers are collapsed or expanded
* New callers or viewers join or leave, causing their boxes to take up a
  different number of rows
* Other transient RTC warnings are displayed
* The sidebar is resized (via the SplitPanePlus drag)
* The browser window as a whole is resized
* The chat input box grows or shrinks due to multiline input
* A new chat message arrives

There's one noteworthy exception: if you scroll partway back in the chat
backlog, you probably don't actually want the chat jumping around as the
scroll height of the chat history grows in response to new messages
coming in, since that makes it hard to read.  So when the message log
changes, if we were scrolled away from the bottom, we instead update the
target distance from bottom.  (When we send a chat message, we do wish
to show it in the backscroll to avoid user confusion, so we jump to the
bottom.)

We were missing a number of possible "size available has changed" event
sources -- nearly every render change in ChatPeople can cause its height
to change, and we also failed to keep the history pinned on sidebar
resize.  This change attempts to rectify these omissions.  Because we
operate on refs and wish to make DOM mutations, we should make use of
`useLayoutEffect` rather than `useEffect` anywhere we'd want to react
before the browser makes the changes visible to the user, since
otherwise we'd see flicker as `scrollTop` jumps around between frames.

<strike>There is one last situation that I have been unable to reliably fix:
when quickly shrinking the chat sidebar from a size where the chat
history does not yet overflow its container to a size where (after
reflow) it does, sometimes we will wind up failing to scroll far enough
down.  However, since the target remains "at the bottom", when any other
event comes in that affects the sidebar height, we correctly converge to
the expected behavior.  I consider this a small enough wart that I will
accept it to get the rest of the behavioral improvement.</strike> Update: this seems to be fixed after converting one more `useEffect` -> `useLayoutEffect` and splitting out the "changes happening during drag" from "committing change after drag completion" for `SplitPanePlus`.

Fixes #427.
Fixes #428.