### PR TITLE
Enable dependabot non-security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
We currently get security updates from dependabot automatically. This will additionally start opening PRs for non-security updates to dependencies, which hopefully will reduce the frequency with which I have to do this myself.

(And given our acceptance tests, we have some bare minimum confirmation that the site doesn't totally fail to load)