### PR TITLE
Small test improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ RUN <<EOF bash
   curl -sL https://install.meteor.com?release=\$METEOR_RELEASE | sh
 EOF
 
+# Install meteor deps (list is sufficient to do this)
+COPY .meteor /app/.meteor
+RUN METEOR_ALLOW_SUPERUSER=1 meteor list
 # Install app deps
 COPY package.json package-lock.json /app
 RUN --mount=type=cache,target=/root/.npm meteor npm ci

--- a/tests/acceptance/authentication.tsx
+++ b/tests/acceptance/authentication.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { Accounts } from 'meteor/accounts-base';
 import { DDP } from 'meteor/ddp';
 import { Meteor } from 'meteor/meteor';
@@ -26,6 +27,7 @@ Meteor.methods({
       email: USER_EMAIL,
       password: USER_PASSWORD,
     });
+    console.log('Created test user', { email: USER_EMAIL });
   },
 });
 
@@ -121,7 +123,7 @@ if (Meteor.isClient) {
 
         // Attempt to go to a specific authenticated page
         await act(async () => {
-          navigate.current?.('/hunts');
+          (navigate.current!)('/hunts');
           await stabilize();
         });
         assert.equal(location.current?.pathname, '/login', 'redirects to login from authenticated page');
@@ -139,7 +141,7 @@ if (Meteor.isClient) {
         await act(async () => {
           render(<TestApp />, container);
           await stabilize();
-          navigate.current?.('/login');
+          (navigate.current!)('/login');
           await stabilize();
         });
         assert.equal(location.current?.pathname, '/hunts');
@@ -149,7 +151,7 @@ if (Meteor.isClient) {
         await act(async () => {
           render(<TestApp />, container);
           await stabilize();
-          navigate.current?.('/hunts');
+          (navigate.current!)('/hunts');
           await stabilize();
         });
         assert.equal(location.current?.pathname, '/hunts');

--- a/tests/acceptance/lib.ts
+++ b/tests/acceptance/lib.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { Meteor } from 'meteor/meteor';
 import { Migrations } from 'meteor/percolate:migrations';
 import { resetDatabase } from 'meteor/xolvio:cleaner';
@@ -7,6 +8,7 @@ if (Meteor.isServer) {
     'test.resetDatabase': function () {
       resetDatabase();
       Migrations.migrateTo('latest');
+      console.log('Reset database');
     },
   });
 }


### PR DESCRIPTION
Fetch meteor packages when we handle dependencies. This enables better caching across builds and eliminates some duplicated time spent between the parallel test and build phases.

Add some additional logging. We've seen intermittent test timeouts in the acceptance test setup phase (deleting the database, creating a test user, logging in as that test user). I haven't been able to reproduce it on demand, but hopefully this will give us better information about where the timeouts are occurring.

(I originally opened this PR to try and reproduce some test flakiness we saw after re-enabling the test suite, but I haven't been able to reproduce, so I'm settling for small test improvements to improve our chance of catching it next time)