### PR TITLE
Spacing options for PuzzleAnswer

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -122,6 +122,10 @@ table.puzzle-list {
   text-transform: uppercase;
   font-family: $font-family-monospace;
   font-weight: 300;
+
+  .answer-segment + .answer-segment {
+    margin-left: .4em;
+  }
 }
 
 // Tags
@@ -567,6 +571,10 @@ table.puzzle-list {
     align-self: start;
     margin-left: 8px;
     flex: 0 0 auto;
+
+    > * {
+      margin-left: 8px;
+    }
   }
 }
 

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -26,6 +26,7 @@ interface PuzzleProps {
   layout: 'grid' | 'table';
   canUpdate: boolean;
   suppressTags?: string[];
+  segmentAnswers?: boolean;
 }
 
 const Puzzle = React.memo((props: PuzzleProps) => {
@@ -81,7 +82,7 @@ const Puzzle = React.memo((props: PuzzleProps) => {
   const answers = props.puzzle.answers.map((answer, i) => {
     return (
       // eslint-disable-next-line react/no-array-index-key
-      <PuzzleAnswer key={`${i}-${answer}`} answer={answer} />
+      <PuzzleAnswer key={`${i}-${answer}`} answer={answer} respace={props.segmentAnswers} />
     );
   });
 

--- a/imports/client/components/PuzzleAnswer.tsx
+++ b/imports/client/components/PuzzleAnswer.tsx
@@ -2,14 +2,31 @@ import React from 'react';
 
 interface PuzzleAnswerProps {
   answer: string;
+  // If respace is set, answers are formatted without spaces and grouped into segments of length
+  // segmentSize. If segmentSize is zero or negative, the effect is simply to strip spaces.
+  respace?: boolean;
+  segmentSize?: number;
 }
 
-const PuzzleAnswer = (props: PuzzleAnswerProps) => {
+const PuzzleAnswer = React.memo((props: PuzzleAnswerProps) => {
+  const respace = props.respace ?? false;
+  const segmentSize = Math.floor(props.segmentSize ?? 5);
+  const respacedAnswer = respace ? props.answer.replace(/\s+/g, '') : props.answer;
+  let formattedAnswer : React.ReactNode = respacedAnswer;
+  if (respace && segmentSize > 0) {
+    const segments = respacedAnswer.match(new RegExp(`.{1,${segmentSize}}`, 'g')) || [];
+    formattedAnswer = segments.map((segment, i) => (
+      // eslint-disable-next-line react/no-array-index-key
+      <span key={`segment-${i}`} className="answer-segment">
+        {segment}
+      </span>
+    ));
+  }
   return (
     <span className="answer">
-      {props.answer}
+      {formattedAnswer}
     </span>
   );
-};
+});
 
-export default React.memo(PuzzleAnswer);
+export default PuzzleAnswer;

--- a/imports/client/components/PuzzleList.tsx
+++ b/imports/client/components/PuzzleList.tsx
@@ -13,6 +13,7 @@ interface PuzzleListProps {
   layout: 'grid' | 'table';
   canUpdate: boolean;
   suppressTags?: string[];
+  segmentAnswers?: boolean;
 }
 
 const PuzzleList = React.memo((props: PuzzleListProps) => {
@@ -29,6 +30,7 @@ const PuzzleList = React.memo((props: PuzzleListProps) => {
       layout={props.layout}
       canUpdate={props.canUpdate}
       suppressTags={props.suppressTags}
+      segmentAnswers={props.segmentAnswers}
     />);
   }
 

--- a/imports/client/components/RelatedPuzzleList.tsx
+++ b/imports/client/components/RelatedPuzzleList.tsx
@@ -35,6 +35,7 @@ interface RelatedPuzzleListProps {
   canUpdate: boolean;
   sharedTag: TagType | undefined;
   suppressedTagIds: string[];
+  segmentAnswers?: boolean;
 }
 
 const RelatedPuzzleList = React.memo((props: RelatedPuzzleListProps) => {
@@ -54,6 +55,7 @@ const RelatedPuzzleList = React.memo((props: RelatedPuzzleListProps) => {
       layout={props.layout}
       canUpdate={props.canUpdate}
       suppressTags={props.suppressedTagIds}
+      segmentAnswers={props.segmentAnswers}
     />
   );
 });

--- a/imports/client/components/Tag.tsx
+++ b/imports/client/components/Tag.tsx
@@ -1,4 +1,5 @@
 import { _ } from 'meteor/underscore';
+import { faAlignJustify } from '@fortawesome/free-solid-svg-icons/faAlignJustify';
 import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -83,6 +84,7 @@ type TagProps = BaseTagProps & (DoNotPopoverRelatedProps | PopoverRelatedProps);
 
 const Tag = (props: TagProps) => {
   const [showPopover, setShowPopover] = useState<boolean>(false);
+  const [segmentAnswers, setSegmentAnswers] = useState<boolean>(false);
 
   const onOverlayTriggerToggle = useCallback((nextShow: boolean) => {
     setShowPopover(nextShow);
@@ -95,6 +97,10 @@ const Tag = (props: TagProps) => {
   const doHidePopover = useCallback(() => {
     setShowPopover(false);
   }, []);
+
+  const toggleSegmentAnswers = useCallback(() => {
+    setSegmentAnswers(!segmentAnswers);
+  }, [segmentAnswers]);
 
   useEffect(() => {
     // Necessary to ensure the popover closes when entering the iframe on
@@ -147,7 +153,9 @@ const Tag = (props: TagProps) => {
       const missingCnt = minRowCnt > puzzle.answers.length ? minRowCnt - puzzle.answers.length : 0;
       const answers = puzzle.answers.concat(Array(missingCnt).fill(''));
       return answers.map((answer) => {
-        return `${puzzle.title}\t${answer.toUpperCase()}`;
+        let formattedAnswer = answer.toUpperCase();
+        formattedAnswer = segmentAnswers ? formattedAnswer.replace(/\s+/g, '') : formattedAnswer;
+        return `${puzzle.title}\t${formattedAnswer}`;
       }).join('\n');
     }).join('\n');
     navigator.clipboard.writeText(clipboardData);
@@ -156,6 +164,7 @@ const Tag = (props: TagProps) => {
     props.tag.name,
     allTagsIfPresent,
     getRelatedPuzzles,
+    segmentAnswers,
   ]);
 
   const name = props.tag.name;
@@ -219,6 +228,7 @@ const Tag = (props: TagProps) => {
   if (props.popoverRelated) {
     const sharedTagName = getRelatedPuzzlesSharedTagName(props.tag.name);
     const relatedPuzzles = getRelatedPuzzles();
+    const respaceButtonVariant = segmentAnswers ? 'secondary' : 'outline-secondary';
     const popover = (
       <Popover
         id={`tag-${props.tag._id}`}
@@ -230,6 +240,16 @@ const Tag = (props: TagProps) => {
           <div className="related-puzzle-popover-header-inner">
             {sharedTagName}
             <div className="related-puzzle-popover-controls">
+              <Button
+                className="tag-respace-button"
+                variant={respaceButtonVariant}
+                size="sm"
+                onClick={toggleSegmentAnswers}
+              >
+                <FontAwesomeIcon icon={faAlignJustify} />
+                {'    '}
+                Respace
+              </Button>
               <Button
                 className="tag-copy-button"
                 variant="secondary"
@@ -251,6 +271,7 @@ const Tag = (props: TagProps) => {
             canUpdate={false}
             sharedTag={props.tag}
             suppressedTagIds={[]}
+            segmentAnswers={segmentAnswers}
           />
         </Popover.Content>
       </Popover>


### PR DESCRIPTION
Adds a convenience feature which standardizes spacing in related puzzle answers for spotting patterns. A toggle on the related puzzle popover switches between preserving original spacing and removing all spaces (displayed segmented into groups of five characters for easy indexing). The copy button is aware of the spacing setting and copies answers to the clipboard without spaces as appropriate. (Whether using the copy button or highlighting and copying, the gaps between segments are for display only and do not add space characters in the copied text.)

Historically, hunters and operators have been inconsistent about spaces in answers. Hopefully, display flexibility will encourage us to standardize on preserving natural spaces.

Respace off:
<img width="317" alt="original" src="https://user-images.githubusercontent.com/2136874/148629621-60c5c29c-b804-4647-849e-6b3d8fd70fae.png">

Respace on:
<img width="309" alt="segmented" src="https://user-images.githubusercontent.com/2136874/148629634-d4d02221-23d1-4b8e-b725-b88b90f026fb.png">
