### PR TITLE
Tracker updates

### DIFF
--- a/imports/client/components/AccountForm.tsx
+++ b/imports/client/components/AccountForm.tsx
@@ -1,6 +1,6 @@
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
-import { useTracker } from 'meteor/react-meteor-data';
+import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import React, { useCallback, useState } from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
@@ -64,12 +64,11 @@ enum AccountFormSubmitState {
 }
 
 const AccountForm = (props: AccountFormProps) => {
+  const loading = useSubscribe('teamName');
   const tracker = useTracker(() => {
-    const teamNameSub = Meteor.subscribe('teamName');
     const teamNameObj = TeamName.findOne('teamName');
     const teamName = teamNameObj ? teamNameObj.name : 'Default Team Name';
     return {
-      ready: teamNameSub.ready(),
       teamName,
     };
   }, []);
@@ -187,7 +186,7 @@ const AccountForm = (props: AccountFormProps) => {
     }
   }, [tryLogin, tryPasswordReset, tryEnroll, tryCompletePasswordReset, props]);
 
-  if (!tracker.ready) {
+  if (loading()) {
     return <div>loading...</div>;
   }
 

--- a/imports/client/components/AccountForm.tsx
+++ b/imports/client/components/AccountForm.tsx
@@ -65,12 +65,8 @@ enum AccountFormSubmitState {
 
 const AccountForm = (props: AccountFormProps) => {
   const loading = useSubscribe('teamName');
-  const tracker = useTracker(() => {
-    const teamNameObj = TeamName.findOne('teamName');
-    const teamName = teamNameObj ? teamNameObj.name : 'Default Team Name';
-    return {
-      teamName,
-    };
+  const teamName = useTracker(() => {
+    return TeamName.findOne('teamName')?.name ?? 'Default Team Name';
   }, []);
 
   const [submitState, setSubmitState] = useState<AccountFormSubmitState>(AccountFormSubmitState.IDLE);
@@ -195,7 +191,7 @@ const AccountForm = (props: AccountFormProps) => {
   // drop AccountTemplates entirely.
   const submitting = submitState === AccountFormSubmitState.SUBMITTING;
   const title = {
-    [AccountFormFormat.LOGIN]: `Jolly Roger: ${tracker.teamName} Virtual HQ`,
+    [AccountFormFormat.LOGIN]: `Jolly Roger: ${teamName} Virtual HQ`,
     [AccountFormFormat.ENROLL]: 'Create an Account',
     [AccountFormFormat.REQUEST_PW_RESET]: 'Reset your password',
     [AccountFormFormat.RESET_PWD]: 'Reset your password',

--- a/imports/client/components/AllProfileListPage.tsx
+++ b/imports/client/components/AllProfileListPage.tsx
@@ -1,5 +1,4 @@
-import { Meteor } from 'meteor/meteor';
-import { useTracker } from 'meteor/react-meteor-data';
+import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import React from 'react';
 import Profiles from '../../lib/models/profiles';
 import { ProfileType } from '../../lib/schemas/profile';
@@ -7,24 +6,22 @@ import { useBreadcrumb } from '../hooks/breadcrumb';
 import ProfileList from './ProfileList';
 
 interface AllProfileListPageTracker {
-  ready: boolean;
   profiles: ProfileType[];
 }
 
 const AllProfileListPage = () => {
   useBreadcrumb({ title: 'Users', path: '/users' });
+  const profilesLoading = useSubscribe('mongo.profiles');
+  const loading = profilesLoading();
 
   const tracker: AllProfileListPageTracker = useTracker(() => {
-    const profilesHandle = Meteor.subscribe('mongo.profiles');
-    const ready = profilesHandle.ready();
-    const profiles = ready ? Profiles.find({}, { sort: { displayName: 1 } }).fetch() : [];
+    const profiles = loading ? [] : Profiles.find({}, { sort: { displayName: 1 } }).fetch();
     return {
-      ready,
       profiles,
     };
-  }, []);
+  }, [loading]);
 
-  if (!tracker.ready) {
+  if (loading) {
     return <div>loading...</div>;
   }
   return <ProfileList profiles={tracker.profiles} />;

--- a/imports/client/components/AllProfileListPage.tsx
+++ b/imports/client/components/AllProfileListPage.tsx
@@ -1,30 +1,22 @@
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import React from 'react';
 import Profiles from '../../lib/models/profiles';
-import { ProfileType } from '../../lib/schemas/profile';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 import ProfileList from './ProfileList';
-
-interface AllProfileListPageTracker {
-  profiles: ProfileType[];
-}
 
 const AllProfileListPage = () => {
   useBreadcrumb({ title: 'Users', path: '/users' });
   const profilesLoading = useSubscribe('mongo.profiles');
   const loading = profilesLoading();
 
-  const tracker: AllProfileListPageTracker = useTracker(() => {
-    const profiles = loading ? [] : Profiles.find({}, { sort: { displayName: 1 } }).fetch();
-    return {
-      profiles,
-    };
+  const profiles = useTracker(() => {
+    return loading ? [] : Profiles.find({}, { sort: { displayName: 1 } }).fetch();
   }, [loading]);
 
   if (loading) {
     return <div>loading...</div>;
   }
-  return <ProfileList profiles={tracker.profiles} />;
+  return <ProfileList profiles={profiles} />;
 };
 
 export default AllProfileListPage;

--- a/imports/client/components/AnnouncementsPage.tsx
+++ b/imports/client/components/AnnouncementsPage.tsx
@@ -95,7 +95,7 @@ const AnnouncementForm = (props: AnnouncementFormProps) => {
 
 interface AnnouncementProps {
   announcement: AnnouncementType;
-  displayNames: Record<string, string>;
+  displayName: string;
 }
 
 const AnnouncementContainer = styled.div`
@@ -122,7 +122,7 @@ const Announcement = (props: AnnouncementProps) => {
     <AnnouncementContainer>
       <AnnouncementOrigin>
         <AnnouncementTimestamp>{calendarTimeFormat(ann.createdAt)}</AnnouncementTimestamp>
-        <div>{props.displayNames[ann.createdBy]}</div>
+        <div>{props.displayName}</div>
       </AnnouncementOrigin>
       <div
         // eslint-disable-next-line react/no-danger
@@ -165,7 +165,7 @@ const AnnouncementsPage = () => {
             <Announcement
               key={announcement._id}
               announcement={announcement}
-              displayNames={displayNames}
+              displayName={displayNames[announcement.createdBy]}
             />
           );
         })}

--- a/imports/client/components/AnnouncementsPage.tsx
+++ b/imports/client/components/AnnouncementsPage.tsx
@@ -143,13 +143,11 @@ const AnnouncementsPage = () => {
   const displayNamesLoading = useSubscribeDisplayNames();
   const loading = announcementsLoading() || displayNamesLoading();
 
-  const { announcements, canCreateAnnouncements, displayNames } = useTracker(() => {
-    return {
-      announcements: loading ? [] : Announcements.find({ hunt: huntId }, { sort: { createdAt: 1 } }).fetch(),
-      canCreateAnnouncements: userMayAddAnnouncementToHunt(Meteor.userId(), huntId),
-      displayNames: loading ? {} : Profiles.displayNames(),
-    };
-  }, [loading, huntId]);
+  const announcements = useTracker(() => (
+    loading ? [] : Announcements.find({ hunt: huntId }, { sort: { createdAt: 1 } }).fetch()
+  ), [loading, huntId]);
+  const displayNames = useTracker(() => (loading ? {} : Profiles.displayNames()), [loading]);
+  const canCreateAnnouncements = useTracker(() => userMayAddAnnouncementToHunt(Meteor.userId(), huntId), [huntId]);
 
   if (loading) {
     return <div>loading...</div>;

--- a/imports/client/components/AnnouncementsPage.tsx
+++ b/imports/client/components/AnnouncementsPage.tsx
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor';
-import { useTracker } from 'meteor/react-meteor-data';
+import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import React, { useCallback, useState } from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
@@ -11,6 +11,7 @@ import Profiles from '../../lib/models/profiles';
 import { userMayAddAnnouncementToHunt } from '../../lib/permission_stubs';
 import { AnnouncementType } from '../../lib/schemas/announcement';
 import { useBreadcrumb } from '../hooks/breadcrumb';
+import useSubscribeDisplayNames from '../hooks/use-subscribe-display-names';
 import markdown from '../markdown';
 
 /* eslint-disable max-len */
@@ -132,7 +133,6 @@ const Announcement = (props: AnnouncementProps) => {
 };
 
 interface AnnouncementsPageTracker {
-  ready: boolean;
   canCreateAnnouncements: boolean;
   announcements: AnnouncementType[];
   displayNames: Record<string, string>;
@@ -141,17 +141,18 @@ interface AnnouncementsPageTracker {
 const AnnouncementsPage = () => {
   const huntId = useParams<'huntId'>().huntId!;
   useBreadcrumb({ title: 'Announcements', path: `/hunts/${huntId}/announcements` });
-  const tracker = useTracker<AnnouncementsPageTracker>(() => {
-    // We already have subscribed to mongo.announcements on the main page, since we want to be able
-    // to show them on any page.  So we don't *need* to make the subscription here...
-    // ...except that we might want to wait to render until we've received all of them?  IDK.
-    const announcementsHandle = Meteor.subscribe('mongo.announcements', { hunt: huntId });
-    const displayNamesHandle = Profiles.subscribeDisplayNames();
-    const ready = announcementsHandle.ready() && displayNamesHandle.ready();
 
+  // We already have subscribed to mongo.announcements on the main page, since we want to be able
+  // to show them on any page.  So we don't *need* to make the subscription here...
+  // ...except that we might want to wait to render until we've received all of them?  IDK.
+  const announcementsLoading = useSubscribe('mongo.announcements', { hunt: huntId });
+  const displayNamesLoading = useSubscribeDisplayNames();
+  const loading = announcementsLoading() || displayNamesLoading();
+
+  const tracker = useTracker<AnnouncementsPageTracker>(() => {
     let announcements: AnnouncementType[];
     let displayNames: Record<string, string>;
-    if (!ready) {
+    if (loading) {
       announcements = [];
       displayNames = {};
     } else {
@@ -161,14 +162,13 @@ const AnnouncementsPage = () => {
     const canCreateAnnouncements = userMayAddAnnouncementToHunt(Meteor.userId(), huntId);
 
     return {
-      ready,
       announcements,
       canCreateAnnouncements,
       displayNames,
     };
-  }, [huntId]);
+  }, [loading, huntId]);
 
-  if (!tracker.ready) {
+  if (loading) {
     return <div>loading...</div>;
   }
 

--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -73,17 +73,19 @@ const AppNavbar = () => {
   const profileLoading = useSubscribe('mongo.profiles', { _id: userId });
   const loading = profileLoading();
 
-  const { displayName, brandSrc, brandSrc2x } = useTracker(() => {
+  const displayName = useTracker(() => {
     const profile = Profiles.findOne(Meteor.userId()!);
 
+    return loading ?
+      'loading...' :
+      ((profile && profile.displayName) || '<no name given>');
+  }, [loading]);
+  const { brandSrc, brandSrc2x } = useTracker(() => {
     return {
-      displayName: loading ?
-        'loading...' :
-        ((profile && profile.displayName) || '<no name given>'),
       brandSrc: lookupUrl('brand.png'),
       brandSrc2x: lookupUrl('brand@2x.png'),
     };
-  }, [loading]);
+  }, []);
 
   const navigate = useNavigate();
   const logout = useCallback(() => {

--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -23,12 +23,6 @@ import NotificationCenter from './NotificationCenter';
 import { NavBarHeight } from './styling/constants';
 import { mediaBreakpointDown } from './styling/responsive';
 
-interface AppNavbarTracker {
-  displayName: string;
-  brandSrc: string;
-  brandSrc2x: string;
-}
-
 const Breadcrumb = styled.nav`
   display: flex;
   align-items: center;
@@ -79,18 +73,15 @@ const AppNavbar = () => {
   const profileLoading = useSubscribe('mongo.profiles', { _id: userId });
   const loading = profileLoading();
 
-  const tracker = useTracker<AppNavbarTracker>(() => {
+  const { displayName, brandSrc, brandSrc2x } = useTracker(() => {
     const profile = Profiles.findOne(Meteor.userId()!);
-    const displayName = loading ?
-      'loading...' :
-      ((profile && profile.displayName) || '<no name given>');
 
-    const brandSrc = lookupUrl('brand.png');
-    const brandSrc2x = lookupUrl('brand@2x.png');
     return {
-      displayName,
-      brandSrc,
-      brandSrc2x,
+      displayName: loading ?
+        'loading...' :
+        ((profile && profile.displayName) || '<no name given>'),
+      brandSrc: lookupUrl('brand.png'),
+      brandSrc2x: lookupUrl('brand@2x.png'),
     };
   }, [loading]);
 
@@ -138,9 +129,9 @@ const AppNavbar = () => {
       <NavbarBrand className="p-0">
         <Link to="/">
           <Brand
-            src={tracker.brandSrc}
+            src={brandSrc}
             alt="Jolly Roger logo"
-            srcSet={`${tracker.brandSrc} 1x, ${tracker.brandSrc2x} 2x`}
+            srcSet={`${brandSrc} 1x, ${brandSrc2x} 2x`}
           />
         </Link>
       </NavbarBrand>
@@ -150,7 +141,7 @@ const AppNavbar = () => {
           <DropdownToggle id="profileDropdown" as={NavLink}>
             <FontAwesomeIcon icon={faUser} />
             {' '}
-            <NavUsername>{tracker.displayName}</NavUsername>
+            <NavUsername>{displayName}</NavUsername>
           </DropdownToggle>
           <DropdownMenu alignRight>
             <RRBS.LinkContainer to={`/users/${userId}`}>

--- a/imports/client/components/CelebrationCenter.tsx
+++ b/imports/client/components/CelebrationCenter.tsx
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor';
-import { useTracker } from 'meteor/react-meteor-data';
+import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import { Tracker } from 'meteor/tracker';
 import React, { useCallback, useEffect, useState } from 'react';
 import Flags from '../../flags';
@@ -22,10 +22,10 @@ interface CelebrationCenterQueueItem {
 const CelebrationCenter = (props: CelebrationCenterProps) => {
   const [playbackQueue, setPlaybackQueue] = useState<CelebrationCenterQueueItem[]>([]);
 
-  const tracker = useTracker(() => {
-    // This should be effectively a noop, since we're already fetching it for every hunt
-    Meteor.subscribe('mongo.puzzles', { hunt: props.huntId });
+  // This should be effectively a noop, since we're already fetching it for every hunt
+  useSubscribe('mongo.puzzles', { hunt: props.huntId });
 
+  const tracker = useTracker(() => {
     const profile = Profiles.findOne({ _id: Meteor.userId()! });
     const muted = !!(profile && profile.muteApplause);
 
@@ -33,7 +33,7 @@ const CelebrationCenter = (props: CelebrationCenterProps) => {
       disabled: Flags.active('disable.applause'),
       muted,
     };
-  }, [props.huntId]);
+  }, []);
 
   const onPuzzleSolved = useCallback((puzzle: PuzzleType, newAnswer: string) => {
     // Only celebrate if:

--- a/imports/client/components/CelebrationCenter.tsx
+++ b/imports/client/components/CelebrationCenter.tsx
@@ -25,13 +25,10 @@ const CelebrationCenter = (props: CelebrationCenterProps) => {
   // This should be effectively a noop, since we're already fetching it for every hunt
   useSubscribe('mongo.puzzles', { hunt: props.huntId });
 
-  const tracker = useTracker(() => {
-    const profile = Profiles.findOne({ _id: Meteor.userId()! });
-    const muted = !!(profile && profile.muteApplause);
-
+  const { disabled, muted } = useTracker(() => {
     return {
       disabled: Flags.active('disable.applause'),
-      muted,
+      muted: !!(Profiles.findOne({ _id: Meteor.userId()! })?.muteApplause),
     };
   }, []);
 
@@ -42,7 +39,7 @@ const CelebrationCenter = (props: CelebrationCenterProps) => {
     // 3) TODO: the user has not disabled it in their profile settings
     // Hack: disabled celebrations because I don't want to think about it right now
     // eslint-disable-next-line no-constant-condition
-    if ((window.orientation === undefined) && !tracker.disabled && false) {
+    if ((window.orientation === undefined) && !disabled && false) {
       setPlaybackQueue((prevPlaybackQueue) => {
         const newQueue = prevPlaybackQueue.concat([{
           puzzleId: puzzle._id,
@@ -54,7 +51,7 @@ const CelebrationCenter = (props: CelebrationCenterProps) => {
         return newQueue;
       });
     }
-  }, [tracker.disabled]);
+  }, [disabled]);
 
   useEffect(() => {
     const puzzleWatcher = Tracker.autorun(() => {
@@ -92,7 +89,7 @@ const CelebrationCenter = (props: CelebrationCenterProps) => {
         url={celebration.url}
         title={celebration.title}
         answer={celebration.answer}
-        playAudio={!tracker.muted}
+        playAudio={!muted}
         onClose={dismissCurrentCelebration}
       />
     );

--- a/imports/client/components/CelebrationCenter.tsx
+++ b/imports/client/components/CelebrationCenter.tsx
@@ -25,12 +25,8 @@ const CelebrationCenter = (props: CelebrationCenterProps) => {
   // This should be effectively a noop, since we're already fetching it for every hunt
   useSubscribe('mongo.puzzles', { hunt: props.huntId });
 
-  const { disabled, muted } = useTracker(() => {
-    return {
-      disabled: Flags.active('disable.applause'),
-      muted: !!(Profiles.findOne({ _id: Meteor.userId()! })?.muteApplause),
-    };
-  }, []);
+  const disabled = useTracker(() => Flags.active('disable.applause'), []);
+  const muted = useTracker(() => !!(Profiles.findOne({ _id: Meteor.userId()! })?.muteApplause), []);
 
   const onPuzzleSolved = useCallback((puzzle: PuzzleType, newAnswer: string) => {
     // Only celebrate if:

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -148,12 +148,17 @@ const ChatPeople = (props: ChatPeopleProps) => {
 
   const loading = subscribersLoading() || callMembersLoading() || avatarsLoading();
 
+  // A note on this feature flag: we still do the subs for call *metadata* for
+  // simplicity even when webrtc is flagged off; we simply avoid rendering
+  // anything in the UI (which prevents clients from subbing to 'mediasoup:join'
+  // or doing signalling).
+  const rtcDisabled = useTracker(() => Flags.active('disable.webrtc'), []);
+
   const {
     unknown,
     viewers,
     rtcViewers,
     selfPeer,
-    rtcDisabled,
   } = useTracker(() => {
     if (loading) {
       return {
@@ -161,7 +166,6 @@ const ChatPeople = (props: ChatPeopleProps) => {
         viewers: [],
         rtcViewers: [],
         selfPeer: undefined,
-        rtcDisabled: false,
       };
     }
 
@@ -228,11 +232,6 @@ const ChatPeople = (props: ChatPeopleProps) => {
       viewers: viewersAcc,
       rtcViewers: rtcViewersAcc,
       selfPeer: self,
-      // A note on this feature flag: we still do the subs for call *metadata* for
-      // simplicity even when webrtc is flagged off; we simply avoid rendering
-      // anything in the UI (which prevents clients from subbing to 'mediasoup:join' or
-      // doing signalling).
-      rtcDisabled: Flags.active('disable.webrtc'),
     };
   }, [loading, subscriberTopic, huntId, puzzleId]);
 

--- a/imports/client/components/FirehosePage.tsx
+++ b/imports/client/components/FirehosePage.tsx
@@ -35,19 +35,18 @@ const FirehosePageLayout = styled.div`
 
 interface MessageProps {
   msg: ChatMessageType;
-  displayNames: Record<string, string>;
-  puzzles: Record<string, PuzzleType>;
+  displayName: string;
+  puzzle: PuzzleType;
 }
 
-const Message = ({ msg, displayNames, puzzles }: MessageProps) => {
-  const displayName = msg.sender ? displayNames[msg.sender] : 'jolly-roger';
+const Message = ({ msg, displayName, puzzle }: MessageProps) => {
   const ts = shortCalendarTimeFormat(msg.timestamp);
   return (
     <div>
       [
       {ts}
       ] [
-      <Link to={`/hunts/${msg.hunt}/puzzles/${msg.puzzle}`}>{puzzles[msg.puzzle].title}</Link>
+      <Link to={`/hunts/${msg.hunt}/puzzles/${msg.puzzle}`}>{puzzle.title}</Link>
       {'] '}
       {displayName}
       {': '}
@@ -234,8 +233,8 @@ const FirehosePage = () => {
               <Message
                 key={msg._id}
                 msg={msg}
-                puzzles={puzzles}
-                displayNames={displayNames}
+                puzzle={puzzles[msg.puzzle]}
+                displayName={msg.sender ? displayNames[msg.sender] : 'jolly-roger'}
               />
             );
           })}

--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -210,17 +210,11 @@ const GuessQueuePage = () => {
     puzzlesLoading() ||
     displayNamesLoading();
 
-  const {
-    hunt, guesses, puzzles, displayNames, canEdit,
-  } = useTracker(() => {
-    return {
-      hunt: Hunts.findOne({ _id: huntId }),
-      guesses: loading ? [] : Guesses.find({ hunt: huntId }, { sort: { createdAt: -1 } }).fetch(),
-      puzzles: loading ? {} : _.indexBy(Puzzles.find({ hunt: huntId }).fetch(), '_id'),
-      displayNames: loading ? {} : Profiles.displayNames(),
-      canEdit: userMayUpdateGuessesForHunt(Meteor.userId(), huntId),
-    };
-  }, [loading, huntId]);
+  const hunt = useTracker(() => Hunts.findOne({ _id: huntId }), [huntId]);
+  const guesses = useTracker(() => (loading ? [] : Guesses.find({ hunt: huntId }, { sort: { createdAt: -1 } }).fetch()), [huntId, loading]);
+  const puzzles = useTracker(() => (loading ? {} : _.indexBy(Puzzles.find({ hunt: huntId }).fetch(), '_id')), [huntId, loading]);
+  const displayNames = useTracker(() => (loading ? {} : Profiles.displayNames()), [loading]);
+  const canEdit = useTracker(() => userMayUpdateGuessesForHunt(Meteor.userId(), huntId), [huntId]);
 
   const searchBarRef = useRef<HTMLInputElement>(null);
 

--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -124,11 +124,12 @@ const HuntApp = React.memo(() => {
   const huntLoading = useSubscribe('mongo.hunts', { _id: huntId });
   const deletedHuntLoading = useSubscribe('mongo.hunts.deleted', { _id: huntId });
   const loading = userLoading() || huntLoading() || deletedHuntLoading();
+
+  const hunt = useTracker(() => Hunts.findOneAllowingDeleted(huntId), [huntId]);
   const {
-    hunt, member, canUndestroy, canJoin,
+    member, canUndestroy, canJoin,
   } = useTracker(() => {
     return {
-      hunt: Hunts.findOneAllowingDeleted(huntId),
       member: Meteor.user()?.hunts?.includes(huntId) ?? false,
       canUndestroy: userMayUpdateHunt(Meteor.userId(), huntId),
       canJoin: userMayAddUsersToHunt(Meteor.userId(), huntId),

--- a/imports/client/components/HuntProfileListPage.tsx
+++ b/imports/client/components/HuntProfileListPage.tsx
@@ -19,19 +19,21 @@ const HuntProfileListPage = () => {
   const profilesLoading = useSubscribe('mongo.profiles');
   const loading = usersLoading() || profilesLoading();
 
-  const { canInvite, canSyncDiscord, profiles } = useTracker(() => {
+  const profiles = useTracker(() => (
+    loading ?
+      [] :
+      Profiles.find(
+        { _id: { $in: MeteorUsers.find({ hunts: huntId }).map((u) => u._id) } },
+        { sort: { displayName: 1 } },
+      ).fetch()
+  ), [huntId, loading]);
+
+  const { canInvite, canSyncDiscord } = useTracker(() => {
     return {
       canInvite: userMayAddUsersToHunt(Meteor.userId(), huntId),
       canSyncDiscord: userMayUseDiscordBotAPIs(Meteor.userId()),
-      profiles:
-        loading ?
-          [] :
-          Profiles.find(
-            { _id: { $in: MeteorUsers.find({ hunts: huntId }).map((u) => u._id) } },
-            { sort: { displayName: 1 } },
-          ).fetch(),
     };
-  }, [huntId, loading]);
+  }, [huntId]);
 
   if (loading) {
     return <div>loading...</div>;

--- a/imports/client/components/LabelledRadioGroup.tsx
+++ b/imports/client/components/LabelledRadioGroup.tsx
@@ -1,16 +1,20 @@
 import React, { useCallback, useState } from 'react';
+import styled from 'styled-components';
 
 /* eslint-disable max-len */
 
-const labelledRadioStyles: Record<string, React.CSSProperties> = {
-  radiolabel: {
-    display: 'block',
-    fontWeight: 'normal',
-  },
-  radio: {
-    margin: '8px',
-  },
-};
+const RadioHeader = styled.span`
+  font-weight: bold;
+`;
+
+const RadioLabel = styled.label`
+  display: block;
+  fontWeight: normal;
+`;
+
+const Radio = styled.input`
+  margin: 8px;
+`;
 
 interface LabelledRadioProps {
   id: string;
@@ -28,10 +32,9 @@ interface LabelledRadioProps {
 // instead.  Uses some bootstrap styles.
 const LabelledRadio = (props: LabelledRadioProps) => {
   return (
-    <label style={labelledRadioStyles.radiolabel} htmlFor={props.id}>
-      <input
+    <RadioLabel htmlFor={props.id}>
+      <Radio
         id={props.id}
-        style={labelledRadioStyles.radio}
         type="radio"
         name={props.name}
         onChange={props.onChange}
@@ -39,14 +42,8 @@ const LabelledRadio = (props: LabelledRadioProps) => {
         defaultChecked={!!props.defaultChecked}
       />
       {props.label}
-    </label>
+    </RadioLabel>
   );
-};
-
-const labelledRadioGroupStyles: Record<string, React.CSSProperties> = {
-  radioheader: {
-    fontWeight: 'bold',
-  },
 };
 
 interface LabelledRadioGroupProps {
@@ -85,7 +82,7 @@ const LabelledRadioGroup = (props: LabelledRadioGroupProps) => {
   });
   return (
     <div className="radio-group">
-      <span style={labelledRadioGroupStyles.radioheader}>{props.header}</span>
+      <RadioHeader>{props.header}</RadioHeader>
       <fieldset>
         {buttons}
       </fieldset>

--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -1,7 +1,7 @@
 import { Google } from 'meteor/google-oauth';
 import { Meteor } from 'meteor/meteor';
 import { OAuth } from 'meteor/oauth';
-import { useTracker } from 'meteor/react-meteor-data';
+import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import { ServiceConfiguration, Configuration } from 'meteor/service-configuration';
 import React, { useCallback, useMemo, useState } from 'react';
 import Alert from 'react-bootstrap/Alert';
@@ -180,10 +180,11 @@ const DiscordLinkBlock = (props: DiscordLinkBlockProps) => {
   const [state, setState] =
     useState<DiscordLinkBlockState>({ state: DiscordLinkBlockLinkState.IDLE });
 
+  useSubscribe('teamName');
+
   const tracker = useTracker<DiscordLinkBlockTracker>(() => {
     const config = ServiceConfiguration.configurations.findOne({ service: 'discord' });
     const discordDisabled = Flags.active('disable.discord');
-    Meteor.subscribe('teamName');
     const teamNameObj = TeamName.findOne('teamName');
     const teamName = teamNameObj ? teamNameObj.name : 'Default Team Name';
     return {

--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -39,14 +39,8 @@ const GoogleLinkBlock = (props: GoogleLinkBlockProps) => {
   const [state, setState] =
     useState<GoogleLinkBlockState>({ state: GoogleLinkBlockLinkState.IDLE });
 
-  const { config, googleDisabled } = useTracker(() => {
-    return {
-      config: ServiceConfiguration.configurations.findOne({
-        service: 'google',
-      }),
-      googleDisabled: Flags.active('disable.google'),
-    };
-  }, []);
+  const config = useTracker(() => ServiceConfiguration.configurations.findOne({ service: 'google' }), []);
+  const googleDisabled = useTracker(() => Flags.active('disable.google'), []);
 
   const requestComplete = useCallback((token: string) => {
     const secret = OAuth._retrieveCredentialSecret(token);
@@ -172,13 +166,9 @@ const DiscordLinkBlock = (props: DiscordLinkBlockProps) => {
 
   useSubscribe('teamName');
 
-  const { config, discordDisabled, teamName } = useTracker(() => {
-    return {
-      config: ServiceConfiguration.configurations.findOne({ service: 'discord' }),
-      discordDisabled: Flags.active('disable.discord'),
-      teamName: TeamName.findOne('teamName')?.name ?? 'Default Team Name',
-    };
-  }, []);
+  const config = useTracker(() => ServiceConfiguration.configurations.findOne({ service: 'discord' }), []);
+  const discordDisabled = useTracker(() => Flags.active('disable.discord'), []);
+  const teamName = useTracker(() => TeamName.findOne('teamName')?.name ?? 'Default Team Name', []);
 
   const requestComplete = useCallback((token: string) => {
     const secret = OAuth._retrieveCredentialSecret(token);

--- a/imports/client/components/ProfilePage.tsx
+++ b/imports/client/components/ProfilePage.tsx
@@ -18,27 +18,27 @@ const ProfilePage = ({ userId, isSelf }: { userId: string, isSelf: boolean }) =>
   const userRolesLoading = useSubscribe('userRoles', userId);
   const loading = profileLoading() || userRolesLoading();
 
-  const {
-    profile, viewerCanMakeOperator, viewerIsOperator, targetIsOperator,
-  } = useTracker(() => {
+  const profile = useTracker(() => {
     const user = Meteor.user()!;
     const defaultEmail = user.emails![0].address!;
+    return Profiles.findOne(userId) || {
+      _id: userId,
+      displayName: '',
+      primaryEmail: defaultEmail,
+      phoneNumber: '',
+      dingwords: [],
+      deleted: false,
+      createdAt: new Date(),
+      createdBy: user._id,
+      updatedAt: undefined,
+      updatedBy: undefined,
+      googleAccount: undefined,
+      discordAccount: undefined,
+      muteApplause: undefined,
+    };
+  }, [userId]);
+  const { viewerCanMakeOperator, viewerIsOperator, targetIsOperator } = useTracker(() => {
     return {
-      profile: Profiles.findOne(userId) || {
-        _id: userId,
-        displayName: '',
-        primaryEmail: defaultEmail,
-        phoneNumber: '',
-        dingwords: [],
-        deleted: false,
-        createdAt: new Date(),
-        createdBy: user._id,
-        updatedAt: undefined,
-        updatedBy: undefined,
-        googleAccount: undefined,
-        discordAccount: undefined,
-        muteApplause: undefined,
-      },
       viewerCanMakeOperator: deprecatedUserMayMakeOperator(Meteor.userId()),
       viewerIsOperator: deprecatedIsActiveOperator(Meteor.userId()),
       targetIsOperator: deprecatedUserMayMakeOperator(userId),

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -425,18 +425,25 @@ const PuzzleListPage = () => {
 
   // Don't bother including this in loading - it's ok if it trickles in
   useSubscribe('subscribers.counts', { hunt: huntId });
-  const {
-    canAdd, canUpdate, allPuzzles, allTags, hunt,
-  } = useTracker(() => {
+
+  // Assertion is safe because hunt is already subscribed and checked by HuntApp
+  const hunt = useTracker(() => Hunts.findOne(huntId)!, [huntId]);
+  const allPuzzles = useTracker(() => (
+    loading ?
+      [] :
+      Puzzles.find({ hunt: huntId }).fetch()
+  ), [loading, huntId]);
+  const allTags = useTracker(() => (
+    loading ?
+      [] :
+      Tags.find({ hunt: huntId }).fetch()
+  ), [loading, huntId]);
+  const { canAdd, canUpdate } = useTracker(() => {
     return {
-      // Assertion is safe because hunt is already subscribed and checked by HuntApp
-      hunt: Hunts.findOne({ _id: huntId })!,
-      canAdd: loading ? false : userMayWritePuzzlesForHunt(Meteor.userId(), huntId),
-      canUpdate: loading ? false : userMayWritePuzzlesForHunt(Meteor.userId(), huntId),
-      allPuzzles: loading ? [] : Puzzles.find({ hunt: huntId }).fetch(),
-      allTags: loading ? [] : Tags.find({ hunt: huntId }).fetch(),
+      canAdd: userMayWritePuzzlesForHunt(Meteor.userId(), huntId),
+      canUpdate: userMayWritePuzzlesForHunt(Meteor.userId(), huntId),
     };
-  }, [loading, huntId]);
+  }, [huntId]);
 
   const huntLink = hunt.homepageUrl && (
     <StyledPuzzleListExternalLink>

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -27,7 +27,6 @@ import Puzzles from '../../lib/models/puzzles';
 import Tags from '../../lib/models/tags';
 import { userMayWritePuzzlesForHunt } from '../../lib/permission_stubs';
 import { PuzzleType } from '../../lib/schemas/puzzle';
-import { TagType } from '../../lib/schemas/tag';
 import PuzzleList from './PuzzleList';
 import PuzzleModalForm, {
   PuzzleModalFormHandle, PuzzleModalFormSubmitPayload,
@@ -40,8 +39,6 @@ interface PuzzleListViewProps {
   huntId: string
   canAdd: boolean;
   canUpdate: boolean;
-  puzzles: PuzzleType[];
-  allTags: TagType[];
 }
 
 const ViewControls = styled.div`
@@ -90,6 +87,9 @@ function showSolvedStorageKey(huntId: string): string {
 }
 
 const PuzzleListView = (props: PuzzleListViewProps) => {
+  const allPuzzles = useTracker(() => Puzzles.find({ hunt: props.huntId }).fetch(), [props.huntId]);
+  const allTags = useTracker(() => Tags.find({ hunt: props.huntId }).fetch(), [props.huntId]);
+
   const [searchParams, setSearchParams] = useSearchParams();
   const searchString = searchParams.get('q') || '';
   const addModalRef = useRef<PuzzleModalFormHandle>(null);
@@ -147,7 +147,7 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
 
   const compileMatcher = useCallback((searchKeys: string[]): (p: PuzzleType) => boolean => {
     const tagNames: Record<string, string> = {};
-    props.allTags.forEach((t) => {
+    allTags.forEach((t) => {
       tagNames[t._id] = t.name.toLowerCase();
     });
     const lowerSearchKeys = searchKeys.map((key) => key.toLowerCase());
@@ -178,7 +178,7 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
         return false;
       });
     };
-  }, [props.allTags]);
+  }, [allTags]);
 
   const puzzlesMatchingSearchString = useCallback((puzzles: PuzzleType[]): PuzzleType[] => {
     const searchKeys = searchString.split(' ');
@@ -249,7 +249,7 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
         // We group and sort first, and only filter afterward, to avoid losing the
         // relative group structure as a result of removing some puzzles from
         // consideration.
-        const unfilteredGroups = puzzleGroupsByRelevance(props.puzzles, props.allTags);
+        const unfilteredGroups = puzzleGroupsByRelevance(allPuzzles, allTags);
         const puzzleGroups = filteredPuzzleGroups(unfilteredGroups, retainedIds);
         const groupComponents = puzzleGroups.map((g) => {
           const suppressedTagIds = [];
@@ -261,7 +261,7 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
               key={g.sharedTag ? g.sharedTag._id : 'ungrouped'}
               group={g}
               noSharedTagLabel="(no group specified)"
-              allTags={props.allTags}
+              allTags={allTags}
               includeCount={false}
               layout="grid"
               canUpdate={props.canUpdate}
@@ -273,12 +273,12 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
         break;
       }
       case 'unlock': {
-        const puzzlesByUnlock = _.sortBy(props.puzzles, (p) => { return p.createdAt; });
+        const puzzlesByUnlock = _.sortBy(allPuzzles, (p) => { return p.createdAt; });
         const retainedPuzzlesByUnlock = puzzlesByUnlock.filter((p) => retainedIds.has(p._id));
         listComponent = (
           <PuzzleList
             puzzles={retainedPuzzlesByUnlock}
-            allTags={props.allTags}
+            allTags={allTags}
             layout="grid"
             canUpdate={props.canUpdate}
           />
@@ -292,21 +292,21 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
         {listComponent}
       </div>
     );
-  }, [displayMode, props.puzzles, props.allTags, props.canUpdate]);
+  }, [displayMode, allPuzzles, allTags, props.canUpdate]);
 
   const addPuzzleContent = props.canAdd && (
     <>
       <Button variant="primary" onClick={showAddModal}>Add a puzzle</Button>
       <PuzzleModalForm
         huntId={props.huntId}
-        tags={props.allTags}
+        tags={allTags}
         ref={addModalRef}
         onSubmit={onAdd}
       />
     </>
   );
 
-  const matchingSearch = puzzlesMatchingSearchString(props.puzzles);
+  const matchingSearch = puzzlesMatchingSearchString(allPuzzles);
   const matchingSearchAndSolved = puzzlesMatchingSolvedFilter(matchingSearch);
   // Normally, we'll just show matchingSearchAndSolved, but if that produces
   // no results, and there *is* a solved puzzle that is not being displayed due
@@ -337,7 +337,7 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
           </ViewControlsSection>
           <ViewControlsSectionExpand>
             <FormLabel htmlFor="jr-puzzle-search">
-              {`Showing ${retainedPuzzles.length}/${props.puzzles.length} items`}
+              {`Showing ${retainedPuzzles.length}/${allPuzzles.length} items`}
             </FormLabel>
             <FilterToolbar>
               <FilterToolbarInputGroup>
@@ -428,16 +428,6 @@ const PuzzleListPage = () => {
 
   // Assertion is safe because hunt is already subscribed and checked by HuntApp
   const hunt = useTracker(() => Hunts.findOne(huntId)!, [huntId]);
-  const allPuzzles = useTracker(() => (
-    loading ?
-      [] :
-      Puzzles.find({ hunt: huntId }).fetch()
-  ), [loading, huntId]);
-  const allTags = useTracker(() => (
-    loading ?
-      [] :
-      Tags.find({ hunt: huntId }).fetch()
-  ), [loading, huntId]);
   const { canAdd, canUpdate } = useTracker(() => {
     return {
       canAdd: userMayWritePuzzlesForHunt(Meteor.userId(), huntId),
@@ -459,8 +449,6 @@ const PuzzleListPage = () => {
       huntId={huntId}
       canAdd={canAdd}
       canUpdate={canUpdate}
-      puzzles={allPuzzles}
-      allTags={allTags}
     />
   );
   return (

--- a/imports/client/components/RootRedirector.tsx
+++ b/imports/client/components/RootRedirector.tsx
@@ -4,31 +4,23 @@ import React from 'react';
 import { Navigate } from 'react-router-dom';
 import HasUsers from '../has_users';
 
-interface RootRedirectorTracker {
-  loggingIn: boolean;
-  userId: string | null;
-  hasUser: boolean;
-}
-
 const RootRedirector = () => {
   const hasUsersLoading = useSubscribe('hasUsers');
   const loading = hasUsersLoading();
 
-  const tracker = useTracker<RootRedirectorTracker>(() => {
-    const hasUser = !!HasUsers.findOne({});
-
+  const { loggingIn, userId, hasUser } = useTracker(() => {
     return {
       loggingIn: Meteor.loggingIn(),
       userId: Meteor.userId(),
-      hasUser,
+      hasUser: !!HasUsers.findOne({}),
     };
   }, []);
 
-  if (tracker.loggingIn) {
+  if (loggingIn) {
     return <div>loading redirector...</div>;
   }
 
-  if (tracker.userId) {
+  if (userId) {
     // Logged in.
     return <Navigate to="/hunts" />;
   }
@@ -38,7 +30,7 @@ const RootRedirector = () => {
   // to the create-first-user page.
   if (loading) {
     return <div>loading redirector...</div>;
-  } else if (tracker.hasUser) {
+  } else if (hasUser) {
     return <Navigate to="/login" />;
   } else {
     return <Navigate to="/create-first-user" />;

--- a/imports/client/components/RootRedirector.tsx
+++ b/imports/client/components/RootRedirector.tsx
@@ -1,5 +1,5 @@
 import { Meteor } from 'meteor/meteor';
-import { useTracker } from 'meteor/react-meteor-data';
+import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import React from 'react';
 import { Navigate } from 'react-router-dom';
 import HasUsers from '../has_users';
@@ -7,19 +7,19 @@ import HasUsers from '../has_users';
 interface RootRedirectorTracker {
   loggingIn: boolean;
   userId: string | null;
-  hasUsersReady: boolean;
   hasUser: boolean;
 }
 
 const RootRedirector = () => {
+  const hasUsersLoading = useSubscribe('hasUsers');
+  const loading = hasUsersLoading();
+
   const tracker = useTracker<RootRedirectorTracker>(() => {
-    const hasUsersHandle = Meteor.subscribe('hasUsers');
     const hasUser = !!HasUsers.findOne({});
 
     return {
       loggingIn: Meteor.loggingIn(),
       userId: Meteor.userId(),
-      hasUsersReady: hasUsersHandle.ready(),
       hasUser,
     };
   }, []);
@@ -36,7 +36,7 @@ const RootRedirector = () => {
   // Definitely not logged in.  Wait for the hasUsers sub to be ready,
   // and then if there's a user, go to the login page, and if not, go
   // to the create-first-user page.
-  if (!tracker.hasUsersReady) {
+  if (loading) {
     return <div>loading redirector...</div>;
   } else if (tracker.hasUser) {
     return <Navigate to="/login" />;

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -1328,12 +1328,13 @@ const BrandingRowContent = styled.div`
   justify-content: flex-start;
 `;
 
-const BrandingRowImage = styled.div`
+const BrandingRowImage = styled.div<{ backgroundImage: string, backgroundSize: string }>`
   width: 200px;
   height: 200px;
   background-position: center;
   background-repeat: no-repeat;
-  // background-size and background-image are defined inline per div
+  background-image: url(${(props) => props.backgroundImage});
+  background-size: ${(props) => props.backgroundSize};
 `;
 
 const BrandingAssetRow = (props: BrandingAssetRowProps) => {
@@ -1398,10 +1399,8 @@ const BrandingAssetRow = (props: BrandingAssetRowProps) => {
       ) : null}
       <BrandingRowContent>
         <BrandingRowImage
-          style={{
-            backgroundImage: `url("${blobUrl}")`,
-            backgroundSize: props.backgroundSize || 'auto',
-          }}
+          backgroundImage={blobUrl}
+          backgroundSize={props.backgroundSize || 'auto'}
         />
         <label htmlFor={`asset-input-${props.asset}`}>
           <div>{props.asset}</div>

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -2,7 +2,7 @@ import { Google } from 'meteor/google-oauth';
 import { Meteor } from 'meteor/meteor';
 import { OAuth } from 'meteor/oauth';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
-import { ServiceConfiguration, Configuration } from 'meteor/service-configuration';
+import { ServiceConfiguration } from 'meteor/service-configuration';
 import { _ } from 'meteor/underscore';
 import React, { ReactChild, useCallback, useState } from 'react';
 import Alert from 'react-bootstrap/Alert';
@@ -17,6 +17,7 @@ import Flags from '../../flags';
 import isAdmin from '../../lib/is-admin';
 import DiscordCache from '../../lib/models/discord_cache';
 import Settings from '../../lib/models/settings';
+import { SavedDiscordObjectType } from '../../lib/schemas/hunt';
 import { SettingType } from '../../lib/schemas/setting';
 import { DiscordGuildType } from '../discord';
 import { useBreadcrumb } from '../hooks/breadcrumb';
@@ -331,49 +332,56 @@ const GoogleDriveTemplateForm = (props: GoogleDriveTemplateFormProps) => {
   );
 };
 
-interface GoogleIntegrationSectionProps {
-  oauthSettings: any;
-  gdriveCredential: any;
-  docTemplate?: string;
-  spreadsheetTemplate?: string;
-  enabled: boolean;
-}
+const GoogleIntegrationSection = () => {
+  const {
+    enabled, oauthSettings, gdriveCredential, docTemplate, spreadsheetTemplate,
+  } = useTracker(() => {
+    const docTemplateSetting = Settings.findOne({ name: 'gdrive.template.document' }) as SettingType & { name: 'gdrive.template.document' } | undefined;
+    const spreadsheetTemplateSetting = Settings.findOne({ name: 'gdrive.template.spreadsheet' }) as SettingType & { name: 'gdrive.template.spreadsheet' } | undefined;
+    const gdriveSetting = Settings.findOne({ name: 'gdrive.credential' }) as SettingType & { name: 'gdrive.credential' } | undefined;
+    return {
+      enabled: !Flags.active('disable.google'),
+      oauthSettings: ServiceConfiguration.configurations.findOne({ service: 'google' }) as any,
+      gdriveCredential: gdriveSetting,
+      docTemplate: docTemplateSetting?.value.id,
+      spreadsheetTemplate: spreadsheetTemplateSetting?.value.id,
+    };
+  }, []);
 
-const GoogleIntegrationSection = (props: GoogleIntegrationSectionProps) => {
   const onToggleEnabled = useCallback(() => {
-    const newValue = !props.enabled;
+    const newValue = !enabled;
     const ffValue = newValue ? 'off' : 'on';
     Meteor.call('setFeatureFlag', 'disable.google', ffValue);
-  }, [props.enabled]);
+  }, [enabled]);
 
   const disconnectGdrive = useCallback(() => {
     Meteor.call('clearGdriveCreds');
   }, []);
 
-  const firstButtonLabel = props.enabled ? 'Enabled' : 'Enable';
-  const secondButtonLabel = props.enabled ? 'Disable' : 'Disabled';
-  const clientId = (props.oauthSettings && props.oauthSettings.clientId) || '';
+  const firstButtonLabel = enabled ? 'Enabled' : 'Enable';
+  const secondButtonLabel = enabled ? 'Disable' : 'Disabled';
+  const clientId = (oauthSettings && oauthSettings.clientId) || '';
 
   let stepsDone = 0;
-  if (props.oauthSettings) {
+  if (oauthSettings) {
     stepsDone += 1;
   }
-  if (props.gdriveCredential) {
+  if (gdriveCredential) {
     stepsDone += 1;
   }
-  if (props.spreadsheetTemplate) {
+  if (spreadsheetTemplate) {
     stepsDone += 1;
   }
 
   const comp = googleCompletenessStrings[stepsDone];
   const compBadgeVariant = stepsDone === 3 ? 'success' : 'warning';
-  const oauthBadgeLabel = props.oauthSettings ? 'configured' : 'unconfigured';
-  const oauthBadgeVariant = props.oauthSettings ? 'success' : 'warning';
-  const driveBadgeLabel = props.gdriveCredential ? 'configured' : 'unconfigured';
-  const driveBadgeVariant = props.gdriveCredential ? 'success' : 'warning';
-  const maybeDriveUserEmail = props.gdriveCredential && props.gdriveCredential.value && props.gdriveCredential.value.email;
-  const templateBadgeLabel = props.spreadsheetTemplate ? 'configured' : 'unconfigured';
-  const templateBadgeVariant = props.spreadsheetTemplate ? 'success' : 'warning';
+  const oauthBadgeLabel = oauthSettings ? 'configured' : 'unconfigured';
+  const oauthBadgeVariant = oauthSettings ? 'success' : 'warning';
+  const driveBadgeLabel = gdriveCredential ? 'configured' : 'unconfigured';
+  const driveBadgeVariant = gdriveCredential ? 'success' : 'warning';
+  const maybeDriveUserEmail = gdriveCredential && gdriveCredential.value && gdriveCredential.value.email;
+  const templateBadgeLabel = spreadsheetTemplate ? 'configured' : 'unconfigured';
+  const templateBadgeVariant = spreadsheetTemplate ? 'success' : 'warning';
 
   return (
     <Section id="google">
@@ -385,10 +393,10 @@ const GoogleIntegrationSection = (props: GoogleIntegrationSectionProps) => {
           {comp}
         </Badge>
         <SectionHeaderButtons>
-          <Button variant="light" disabled={props.enabled} onClick={onToggleEnabled}>
+          <Button variant="light" disabled={enabled} onClick={onToggleEnabled}>
             {firstButtonLabel}
           </Button>
-          <Button variant="light" disabled={!props.enabled} onClick={onToggleEnabled}>
+          <Button variant="light" disabled={!enabled} onClick={onToggleEnabled}>
             {secondButtonLabel}
           </Button>
         </SectionHeaderButtons>
@@ -436,7 +444,7 @@ const GoogleIntegrationSection = (props: GoogleIntegrationSectionProps) => {
         <p>
           Then, copy the client ID and secret into the fields here and click the Save button.
         </p>
-        <GoogleOAuthForm initialClientId={clientId} isConfigured={!!props.oauthSettings} />
+        <GoogleOAuthForm initialClientId={clientId} isConfigured={!!oauthSettings} />
       </Subsection>
 
       <Subsection>
@@ -482,8 +490,8 @@ const GoogleIntegrationSection = (props: GoogleIntegrationSectionProps) => {
           <li>Template documents must be accessible by the Drive user connected above.</li>
         </ul>
         <GoogleDriveTemplateForm
-          initialSpreadsheetTemplate={props.spreadsheetTemplate}
-          initialDocTemplate={props.docTemplate}
+          initialSpreadsheetTemplate={spreadsheetTemplate}
+          initialDocTemplate={docTemplate}
         />
       </Subsection>
     </Section>
@@ -491,11 +499,11 @@ const GoogleIntegrationSection = (props: GoogleIntegrationSectionProps) => {
 };
 
 interface EmailConfigFormProps {
-  initialConfig: SettingType | undefined;
+  initialConfig?: SettingType & { name: 'email.branding' };
 }
 
 const EmailConfigForm = (props: EmailConfigFormProps) => {
-  const initialConfig = (props.initialConfig && props.initialConfig.name === 'email.branding') ? props.initialConfig : undefined;
+  const initialConfig = props.initialConfig;
   const [from, setFrom] = useState<string>(initialConfig?.value.from || '');
   const [enrollAccountSubject, setEnrollAccountSubject] =
     useState<string>(initialConfig?.value.enrollAccountMessageSubjectTemplate || '');
@@ -796,12 +804,11 @@ const EmailConfigForm = (props: EmailConfigFormProps) => {
   );
 };
 
-interface EmailConfigSectionProps {
-  config: SettingType | undefined;
-}
-
-const EmailConfigSection = (props: EmailConfigSectionProps) => {
-  const configured = props.config && props.config.name === 'email.branding' && props.config.value.from;
+const EmailConfigSection = () => {
+  const config = useTracker(() => {
+    return Settings.findOne({ name: 'email.branding' }) as SettingType & { name: 'email.branding' } | undefined;
+  }, []);
+  const configured = !!(config?.value.from);
   const badgeVariant = configured ? 'success' : 'warning';
   return (
     <Section id="email">
@@ -836,7 +843,7 @@ const EmailConfigSection = (props: EmailConfigSectionProps) => {
         for an overview of the supported syntax.  The <code>view</code>
         variables available to each context are described below.
       </p>
-      <EmailConfigForm initialConfig={props.config} />
+      <EmailConfigForm initialConfig={config} />
     </Section>
   );
 };
@@ -1011,24 +1018,12 @@ interface DiscordGuildFormProps {
   guild?: DiscordGuildType;
 }
 
-interface DiscordGuildFormTracker {
-  // List of possible guilds from server
-  guilds: DiscordGuildType[];
-}
-
 const DiscordGuildForm = (props: DiscordGuildFormProps) => {
   useSubscribe('discord.guilds');
-
-  const tracker = useTracker<DiscordGuildFormTracker>(() => {
-    const guilds = DiscordCache.find({ type: 'guild' }).fetch().map((c) => {
-      const { id, name } = c.object as DiscordGuildType;
-      return { id, name };
-    });
-    return {
-      guilds,
-    };
+  const guilds = useTracker(() => {
+    return DiscordCache.find({ type: 'guild' }, { fields: { 'object.id': 1, 'object.name': 1 } })
+      .map((c) => c.object as SavedDiscordObjectType);
   }, []);
-
   const [guildId, setGuildId] = useState<string>((props.guild && props.guild.id) || '');
   const [submitState, setSubmitState] = useState<SubmitState>(SubmitState.IDLE);
   const [submitError, setSubmitError] = useState<string>('');
@@ -1045,7 +1040,7 @@ const DiscordGuildForm = (props: DiscordGuildFormProps) => {
   const onSaveGuild = useCallback((e: React.FormEvent<any>) => {
     e.preventDefault();
 
-    const guild = tracker.guilds.find((g) => g.id === guildId);
+    const guild = guilds.find((g) => g.id === guildId);
     setSubmitState(SubmitState.SUBMITTING);
     Meteor.call('setupDiscordBotGuild', guild, (err?: Error) => {
       if (err) {
@@ -1055,14 +1050,14 @@ const DiscordGuildForm = (props: DiscordGuildFormProps) => {
         setSubmitState(SubmitState.SUCCESS);
       }
     });
-  }, [tracker.guilds, guildId]);
+  }, [guilds, guildId]);
 
   const shouldDisableForm = submitState === SubmitState.SUBMITTING;
   const noneOption = {
     id: 'empty',
     name: 'No guild assigned',
   };
-  const formOptions = [noneOption, ...tracker.guilds];
+  const formOptions = [noneOption, ...guilds];
   return (
     <div>
       {submitState === 'submitting' ? <Alert variant="info">Saving...</Alert> : null}
@@ -1102,33 +1097,42 @@ const DiscordGuildForm = (props: DiscordGuildFormProps) => {
   );
 };
 
-interface DiscordIntegrationSectionProps {
-  enabled: boolean;
-  oauthSettings?: Configuration;
-  botToken?: string;
-  guild?: DiscordGuildType;
-}
+const DiscordIntegrationSection = () => {
+  const {
+    enabled,
+    oauthSettings,
+    botToken,
+    guild,
+  } = useTracker(() => {
+    const botSetting = Settings.findOne({ name: 'discord.bot' }) as SettingType & { name: 'discord.bot' } | undefined;
+    const guildSetting = Settings.findOne({ name: 'discord.guild' }) as SettingType & { name: 'discord.guild' } | undefined;
+    return {
+      enabled: !Flags.active('disable.discord'),
+      oauthSettings: ServiceConfiguration.configurations.findOne({ service: 'discord' }),
+      botToken: botSetting?.value.token,
+      guild: guildSetting?.value.guild,
+    };
+  }, []);
 
-const DiscordIntegrationSection = (props: DiscordIntegrationSectionProps) => {
   const onToggleEnabled = useCallback(() => {
-    const newValue = !props.enabled;
+    const newValue = !enabled;
     const ffValue = newValue ? 'off' : 'on';
     Meteor.call('setFeatureFlag', 'disable.discord', ffValue);
-  }, [props.enabled]);
+  }, [enabled]);
 
-  const firstButtonLabel = props.enabled ? 'Enabled' : 'Enable';
-  const secondButtonLabel = props.enabled ? 'Disable' : 'Disabled';
+  const firstButtonLabel = enabled ? 'Enabled' : 'Enable';
+  const secondButtonLabel = enabled ? 'Disable' : 'Disabled';
 
-  const configured = !!props.oauthSettings;
+  const configured = !!oauthSettings;
   const headerBadgeVariant = configured ? 'success' : 'warning';
-  const clientId = props.oauthSettings && props.oauthSettings.appId;
+  const clientId = oauthSettings && oauthSettings.appId;
   const addGuildLink = `https://discord.com/api/oauth2/authorize?client_id=${clientId}&scope=bot&permissions=8`;
-  const oauthBadgeLabel = props.oauthSettings ? 'configured' : 'unconfigured';
-  const oauthBadgeVariant = props.oauthSettings ? 'success' : 'warning';
-  const botBadgeLabel = props.botToken ? 'configured' : 'unconfigured';
-  const botBadgeVariant = props.botToken ? 'success' : 'warning';
-  const guildBadgeLabel = props.guild ? 'configured' : 'unconfigured';
-  const guildBadgeVariant = props.guild ? 'success' : 'warning';
+  const oauthBadgeLabel = oauthSettings ? 'configured' : 'unconfigured';
+  const oauthBadgeVariant = oauthSettings ? 'success' : 'warning';
+  const botBadgeLabel = botToken ? 'configured' : 'unconfigured';
+  const botBadgeVariant = botToken ? 'success' : 'warning';
+  const guildBadgeLabel = guild ? 'configured' : 'unconfigured';
+  const guildBadgeVariant = guild ? 'success' : 'warning';
   return (
     <Section id="discord">
       <SectionHeader>
@@ -1140,10 +1144,10 @@ const DiscordIntegrationSection = (props: DiscordIntegrationSectionProps) => {
         </Badge>
         {configured && (
         <SectionHeaderButtons>
-          <Button variant="light" disabled={props.enabled} onClick={onToggleEnabled}>
+          <Button variant="light" disabled={enabled} onClick={onToggleEnabled}>
             {firstButtonLabel}
           </Button>
-          <Button variant="light" disabled={!props.enabled} onClick={onToggleEnabled}>
+          <Button variant="light" disabled={!enabled} onClick={onToggleEnabled}>
             {secondButtonLabel}
           </Button>
         </SectionHeaderButtons>
@@ -1202,7 +1206,7 @@ const DiscordIntegrationSection = (props: DiscordIntegrationSectionProps) => {
           <li>Click the save button below.</li>
           <li>Then, after you have successfully saved the client secret and bot token: as the guild (&quot;server&quot;) owner, <a href={addGuildLink}>add the bot to your Discord guild here</a>.</li>
         </ol>
-        <DiscordOAuthForm oauthSettings={props.oauthSettings} />
+        <DiscordOAuthForm oauthSettings={oauthSettings} />
       </Subsection>
 
       <Subsection>
@@ -1218,7 +1222,7 @@ const DiscordIntegrationSection = (props: DiscordIntegrationSectionProps) => {
           it to the guild for which you wish to automate invites.
         </p>
         <DiscordBotForm
-          botToken={props.botToken}
+          botToken={botToken}
         />
       </Subsection>
 
@@ -1237,19 +1241,20 @@ const DiscordIntegrationSection = (props: DiscordIntegrationSectionProps) => {
         </p>
 
         <DiscordGuildForm
-          guild={props.guild}
+          guild={guild}
         />
       </Subsection>
     </Section>
   );
 };
 
-interface BrandingTeamNameProps {
-  initialTeamName: string | undefined;
-}
+const BrandingTeamName = () => {
+  const initialTeamName = useTracker(() => {
+    const teamNameSetting = Settings.findOne({ name: 'teamname' }) as SettingType & { name: 'teamname' } | undefined;
+    return teamNameSetting?.value.teamName;
+  }, []);
 
-const BrandingTeamName = (props: BrandingTeamNameProps) => {
-  const [teamName, setTeamName] = useState<string>(props.initialTeamName || '');
+  const [teamName, setTeamName] = useState<string>(initialTeamName || '');
   const [submitState, setSubmitState] = useState<SubmitState>(SubmitState.IDLE);
   const [submitError, setSubmitError] = useState<string>('');
 
@@ -1383,7 +1388,7 @@ const BrandingAssetRow = (props: BrandingAssetRowProps) => {
   }, [props.asset]);
 
   // If no BlobMapping is present for this asset, fall back to the default one from the public/images folder
-  const blobUrl = useTracker(() => lookupUrl(props.asset));
+  const blobUrl = useTracker(() => lookupUrl(props.asset), [props.asset]);
   return (
     <BrandingRow>
       {submitState === 'submitting' ? <Alert variant="info">Saving...</Alert> : null}
@@ -1410,11 +1415,7 @@ const BrandingAssetRow = (props: BrandingAssetRowProps) => {
   );
 };
 
-interface BrandingSectionProps {
-  teamName: string | undefined;
-}
-
-const BrandingSection = (props: BrandingSectionProps) => {
+const BrandingSection = () => {
   return (
     <Section id="branding">
       <SectionHeader>
@@ -1434,7 +1435,7 @@ const BrandingSection = (props: BrandingSectionProps) => {
           <li>in the filenames of any Google Docs/Sheets created by Jolly Roger</li>
           <li>and anywhere else we may refer to the team that owns this Jolly Roger instance.</li>
         </ul>
-        <BrandingTeamName initialTeamName={props.teamName} />
+        <BrandingTeamName />
       </Subsection>
       {/* Adding a new branding asset? Make sure to add it to imports/server/lookupUrl.ts as well */}
       <Subsection>
@@ -1488,19 +1489,14 @@ const BrandingSection = (props: BrandingSectionProps) => {
 };
 
 interface CircuitBreakerControlProps {
-  // disabled should be false if the circuit breaker is not intentionally disabling the feature,
-  // and true if the feature is currently disabled.
-  // most features will have false here most of the time.
-  featureDisabled: boolean;
-
   // What do you call this circuit breaker?
   title: string;
 
+  // What is the database name for this flag
+  flagName: string;
+
   // some explanation of what this feature flag controls and why you might want to toggle it.
   children: React.ReactNode;
-
-  // callback to call when the user requests changing this flag's state
-  onChange: (desiredState: boolean) => void;
 }
 
 const CircuitBreaker = styled.div`
@@ -1530,12 +1526,18 @@ const CircuitBreakerButtons = styled.div`
 
 const CircuitBreakerControl = (props: CircuitBreakerControlProps) => {
   const {
-    featureDisabled, title, children, onChange,
+    title, flagName, children,
   } = props;
+
+  // disabled should be false if the circuit breaker is not intentionally disabling the feature,
+  // and true if the feature is currently disabled.
+  // most features will have false here most of the time.
+  const featureDisabled = useTracker(() => Flags.active(flagName), [flagName]);
+
   const onChangeCb = useCallback(() => {
     const desiredState = !featureDisabled;
-    onChange(desiredState);
-  }, [onChange, featureDisabled]);
+    Meteor.call('setFeatureFlag', flagName, desiredState ? 'on' : 'off');
+  }, [flagName, featureDisabled]);
 
   // Is the feature that this circuit breaker disables currently available?
   const featureIsEnabled = !featureDisabled;
@@ -1564,20 +1566,7 @@ const CircuitBreakerControl = (props: CircuitBreakerControlProps) => {
   );
 };
 
-interface CircuitBreakerSectionProps {
-  flagDisableGdrivePermissions: boolean;
-  flagDisableApplause: boolean;
-  flagDisableWebrtc: boolean;
-  flagDisableSpectra: boolean;
-  flagDisableDingwords: boolean;
-}
-
-const CircuitBreakerSection = (props: CircuitBreakerSectionProps) => {
-  const setFlagValue = useCallback((flag: string, value: boolean) => {
-    const type = value ? 'on' : 'off';
-    Meteor.call('setFeatureFlag', flag, type);
-  }, []);
-
+const CircuitBreakerSection = () => {
   return (
     <Section id="circuit-breakers">
       <SectionHeader>
@@ -1591,8 +1580,7 @@ const CircuitBreakerSection = (props: CircuitBreakerSectionProps) => {
       </p>
       <CircuitBreakerControl
         title="Drive permission sharing"
-        featureDisabled={props.flagDisableGdrivePermissions}
-        onChange={(newValue) => setFlagValue('disable.gdrive_permissions', newValue)}
+        flagName="disable.gdrive_permissions"
       >
         <p>
           When Jolly Roger creates a spreadsheet or document, we grant
@@ -1621,8 +1609,7 @@ const CircuitBreakerSection = (props: CircuitBreakerSectionProps) => {
       </CircuitBreakerControl>
       <CircuitBreakerControl
         title="Celebrations"
-        featureDisabled={props.flagDisableApplause}
-        onChange={(newValue) => setFlagValue('disable.applause', newValue)}
+        flagName="disable.applause"
       >
         <p>
           Some teams like broadcasting when a puzzle is solved, to make
@@ -1641,8 +1628,7 @@ const CircuitBreakerSection = (props: CircuitBreakerSectionProps) => {
       </CircuitBreakerControl>
       <CircuitBreakerControl
         title="WebRTC calls"
-        featureDisabled={props.flagDisableWebrtc}
-        onChange={(newValue) => setFlagValue('disable.webrtc', newValue)}
+        flagName="disable.webrtc"
       >
         <p>
           Jolly Roger has experimental support for making WebRTC audio calls
@@ -1667,8 +1653,7 @@ const CircuitBreakerSection = (props: CircuitBreakerSectionProps) => {
       </CircuitBreakerControl>
       <CircuitBreakerControl
         title="WebRTC call spectrograms"
-        featureDisabled={props.flagDisableSpectra}
-        onChange={(newValue) => setFlagValue('disable.spectra', newValue)}
+        flagName="disable.spectra"
       >
         <p>
           In the WebRTC call UI, we show audio activity via spectrograms.
@@ -1684,8 +1669,7 @@ const CircuitBreakerSection = (props: CircuitBreakerSectionProps) => {
       </CircuitBreakerControl>
       <CircuitBreakerControl
         title="Dingwords"
-        featureDisabled={props.flagDisableDingwords}
-        onChange={(newValue) => setFlagValue('disable.dingwords', newValue)}
+        flagName="disable.dingwords"
       >
         <p>
           User-specified &quot;dingwords&quot; allow users to get notified if anyone
@@ -1704,99 +1688,13 @@ const CircuitBreakerSection = (props: CircuitBreakerSectionProps) => {
   );
 };
 
-interface SetupPageTracker {
-  canConfigure: boolean;
-
-  googleConfig: any;
-  gdriveCredential: any;
-  docTemplate?: string;
-  spreadsheetTemplate?: string;
-
-  emailConfig: SettingType | undefined;
-  teamName: string | undefined;
-
-  discordOAuthConfig?: Configuration;
-  flagDisableDiscord: boolean;
-  discordBotToken?: string;
-  discordGuild?: DiscordGuildType;
-
-  flagDisableGoogleIntegration: boolean;
-  flagDisableGdrivePermissions: boolean;
-  flagDisableApplause: boolean;
-  flagDisableWebrtc: boolean;
-  flagDisableSpectra: boolean;
-  flagDisableDingwords: boolean;
-}
-
 const SetupPage = () => {
   useBreadcrumb({ title: 'Server setup', path: '/setup' });
 
-  // We need to fetch the contents of the Settings table
-  const settingsLoading = useSubscribe('mongo.settings');
-  const loading = settingsLoading();
+  const loading = useSubscribe('mongo.settings');
+  const canConfigure = useTracker(() => isAdmin(Meteor.userId()), []);
 
-  const tracker = useTracker<SetupPageTracker>(() => {
-    const canConfigure = isAdmin(Meteor.userId());
-
-    // Google
-    const googleConfig = ServiceConfiguration.configurations.findOne({ service: 'google' });
-    const gdriveCredential = Settings.findOne({ name: 'gdrive.credential' });
-    const docTemplate = Settings.findOne({ name: 'gdrive.template.document' });
-    const docTemplateId = docTemplate && docTemplate.name === 'gdrive.template.document' ?
-      docTemplate.value.id : undefined;
-    const spreadsheetTemplate = Settings.findOne({ name: 'gdrive.template.spreadsheet' });
-    const spreadsheetTemplateId = spreadsheetTemplate && spreadsheetTemplate.name === 'gdrive.template.spreadsheet' ?
-      spreadsheetTemplate.value.id : undefined;
-
-    // Email
-    const emailConfig = Settings.findOne({ name: 'email.branding' });
-
-    // Team name
-    const teamNameDoc = Settings.findOne({ name: 'teamname' });
-    const teamName = teamNameDoc && teamNameDoc.name === 'teamname' ? teamNameDoc.value.teamName : undefined;
-
-    // Discord
-    const discordOAuthConfig = ServiceConfiguration.configurations.findOne({ service: 'discord' });
-    const flagDisableDiscord = Flags.active('disable.discord');
-    const discordBotTokenDoc = Settings.findOne({ name: 'discord.bot' });
-    const discordBotToken = discordBotTokenDoc && discordBotTokenDoc.name === 'discord.bot' ? discordBotTokenDoc.value.token : undefined;
-    const discordGuildDoc = Settings.findOne({ name: 'discord.guild' });
-    const discordGuild = discordGuildDoc && discordGuildDoc.name === 'discord.guild' ? discordGuildDoc.value.guild : undefined;
-
-    // Circuit breakers
-    const flagDisableGoogleIntegration = Flags.active('disable.google');
-    const flagDisableGdrivePermissions = Flags.active('disable.gdrive_permissions');
-    const flagDisableApplause = Flags.active('disable.applause');
-    const flagDisableWebrtc = Flags.active('disable.webrtc');
-    const flagDisableSpectra = Flags.active('disable.spectra');
-    const flagDisableDingwords = Flags.active('disable.dingwords');
-
-    return {
-      canConfigure,
-
-      googleConfig,
-      gdriveCredential,
-      docTemplate: docTemplateId,
-      spreadsheetTemplate: spreadsheetTemplateId,
-
-      teamName,
-      emailConfig,
-
-      discordOAuthConfig,
-      flagDisableDiscord,
-      discordBotToken,
-      discordGuild,
-
-      flagDisableGoogleIntegration,
-      flagDisableGdrivePermissions,
-      flagDisableApplause,
-      flagDisableWebrtc,
-      flagDisableSpectra,
-      flagDisableDingwords,
-    };
-  }, []);
-
-  if (loading) {
+  if (loading()) {
     return (
       <div>
         Loading...
@@ -1804,7 +1702,7 @@ const SetupPage = () => {
     );
   }
 
-  if (!tracker.canConfigure) {
+  if (!canConfigure) {
     return (
       <div>
         <h1>Not authorized</h1>
@@ -1813,35 +1711,13 @@ const SetupPage = () => {
     );
   }
 
-  const discordEnabled = !tracker.flagDisableDiscord;
   return (
     <div>
-      <GoogleIntegrationSection
-        oauthSettings={tracker.googleConfig}
-        enabled={!tracker.flagDisableGoogleIntegration}
-        gdriveCredential={tracker.gdriveCredential}
-        docTemplate={tracker.docTemplate}
-        spreadsheetTemplate={tracker.spreadsheetTemplate}
-      />
-      <EmailConfigSection
-        config={tracker.emailConfig}
-      />
-      <DiscordIntegrationSection
-        oauthSettings={tracker.discordOAuthConfig}
-        enabled={discordEnabled}
-        botToken={tracker.discordBotToken}
-        guild={tracker.discordGuild}
-      />
-      <BrandingSection
-        teamName={tracker.teamName}
-      />
-      <CircuitBreakerSection
-        flagDisableGdrivePermissions={tracker.flagDisableGdrivePermissions}
-        flagDisableApplause={tracker.flagDisableApplause}
-        flagDisableWebrtc={tracker.flagDisableWebrtc}
-        flagDisableSpectra={tracker.flagDisableSpectra}
-        flagDisableDingwords={tracker.flagDisableDingwords}
-      />
+      <GoogleIntegrationSection />
+      <EmailConfigSection />
+      <DiscordIntegrationSection />
+      <BrandingSection />
+      <CircuitBreakerSection />
     </div>
   );
 };

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -333,15 +333,13 @@ const GoogleDriveTemplateForm = (props: GoogleDriveTemplateFormProps) => {
 };
 
 const GoogleIntegrationSection = () => {
-  const {
-    enabled, oauthSettings, gdriveCredential, docTemplate, spreadsheetTemplate,
-  } = useTracker(() => {
+  const enabled = useTracker(() => !Flags.active('disable.google'), []);
+  const oauthSettings = useTracker(() => ServiceConfiguration.configurations.findOne({ service: 'google' }) as any, []);
+  const { gdriveCredential, docTemplate, spreadsheetTemplate } = useTracker(() => {
     const docTemplateSetting = Settings.findOne({ name: 'gdrive.template.document' }) as SettingType & { name: 'gdrive.template.document' } | undefined;
     const spreadsheetTemplateSetting = Settings.findOne({ name: 'gdrive.template.spreadsheet' }) as SettingType & { name: 'gdrive.template.spreadsheet' } | undefined;
     const gdriveSetting = Settings.findOne({ name: 'gdrive.credential' }) as SettingType & { name: 'gdrive.credential' } | undefined;
     return {
-      enabled: !Flags.active('disable.google'),
-      oauthSettings: ServiceConfiguration.configurations.findOne({ service: 'google' }) as any,
       gdriveCredential: gdriveSetting,
       docTemplate: docTemplateSetting?.value.id,
       spreadsheetTemplate: spreadsheetTemplateSetting?.value.id,
@@ -1098,17 +1096,12 @@ const DiscordGuildForm = (props: DiscordGuildFormProps) => {
 };
 
 const DiscordIntegrationSection = () => {
-  const {
-    enabled,
-    oauthSettings,
-    botToken,
-    guild,
-  } = useTracker(() => {
+  const enabled = useTracker(() => !Flags.active('disable.discord'), []);
+  const oauthSettings = useTracker(() => ServiceConfiguration.configurations.findOne({ service: 'discord' }), []);
+  const { botToken, guild } = useTracker(() => {
     const botSetting = Settings.findOne({ name: 'discord.bot' }) as SettingType & { name: 'discord.bot' } | undefined;
     const guildSetting = Settings.findOne({ name: 'discord.guild' }) as SettingType & { name: 'discord.guild' } | undefined;
     return {
-      enabled: !Flags.active('disable.discord'),
-      oauthSettings: ServiceConfiguration.configurations.findOne({ service: 'discord' }),
       botToken: botSetting?.value.token,
       guild: guildSetting?.value.guild,
     };

--- a/imports/client/components/SplashPage.tsx
+++ b/imports/client/components/SplashPage.tsx
@@ -22,12 +22,10 @@ interface SplashPageProps {
 }
 
 const SplashPage = (props: SplashPageProps) => {
-  const data = useTracker(() => {
-    const heroSrc = lookupUrl('hero.png');
-    const heroSrc2x = lookupUrl('hero@2x.png');
+  const { heroSrc, heroSrc2x } = useTracker(() => {
     return {
-      heroSrc,
-      heroSrc2x,
+      heroSrc: lookupUrl('hero.png'),
+      heroSrc2x: lookupUrl('hero@2x.png'),
     };
   }, []);
 
@@ -35,7 +33,7 @@ const SplashPage = (props: SplashPageProps) => {
     <Container>
       <Jumbotron id="jr-login">
         <Container>
-          <Image src={data.heroSrc} className="d-block mx-auto" srcSet={`${data.heroSrc} 1x, ${data.heroSrc2x} 2x`} />
+          <Image src={heroSrc} className="d-block mx-auto" srcSet={`${heroSrc} 1x, ${heroSrc2x} 2x`} />
           <Row>
             <Col md={{ span: 6, offset: 3 }}>
               {props.children}

--- a/imports/client/components/SubscriberCount.tsx
+++ b/imports/client/components/SubscriberCount.tsx
@@ -8,16 +8,9 @@ interface SubscriberCountProps {
   puzzleId: string;
 }
 
-interface SubscriberCountTracker {
-  viewCount: number;
-}
-
 const SubscriberCount = (props: SubscriberCountProps) => {
-  const tracker = useTracker<SubscriberCountTracker>(() => {
-    const count = SubscriberCounters.findOne(`puzzle:${props.puzzleId}`);
-    return {
-      viewCount: count ? count.value : 0,
-    };
+  const viewCount = useTracker(() => {
+    return SubscriberCounters.findOne(`puzzle:${props.puzzleId}`)?.value ?? 0;
   }, [props.puzzleId]);
 
   const countTooltip = (
@@ -29,7 +22,7 @@ const SubscriberCount = (props: SubscriberCountProps) => {
     <OverlayTrigger placement="top" overlay={countTooltip}>
       <span>
         (
-        {tracker.viewCount}
+        {viewCount}
         )
       </span>
     </OverlayTrigger>

--- a/imports/client/components/TagEditor.tsx
+++ b/imports/client/components/TagEditor.tsx
@@ -2,7 +2,6 @@ import { useTracker } from 'meteor/react-meteor-data';
 import React, { Suspense, useCallback } from 'react';
 import Tags from '../../lib/models/tags';
 import { PuzzleType } from '../../lib/schemas/puzzle';
-import { TagType } from '../../lib/schemas/tag';
 import Loading from './Loading';
 
 // Casting away the React.lazy because otherwise we lose access to the generic parameter
@@ -14,15 +13,9 @@ interface TagEditorProps {
   onCancel: () => void;
 }
 
-interface TagEditorTracker {
-  allTags: TagType[];
-}
-
 const TagEditor = (props: TagEditorProps) => {
-  const tracker = useTracker<TagEditorTracker>(() => {
-    return {
-      allTags: Tags.find({ hunt: props.puzzle.hunt }).fetch(),
-    };
+  const allTags = useTracker(() => {
+    return Tags.find({ hunt: props.puzzle.hunt }).fetch();
   }, [props.puzzle.hunt]);
 
   const { onCancel } = props;
@@ -32,7 +25,7 @@ const TagEditor = (props: TagEditorProps) => {
     onCancel();
   }, [onCancel]);
 
-  const options = tracker.allTags
+  const options = allTags
     .map((t) => t.name)
     .filter(Boolean)
     .map((t) => {

--- a/imports/client/components/UserInvitePage.tsx
+++ b/imports/client/components/UserInvitePage.tsx
@@ -13,10 +13,6 @@ import styled from 'styled-components';
 import { userMayBulkAddToHunt } from '../../lib/permission_stubs';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 
-interface UserInvitePageTracker {
-  canBulkInvite: boolean;
-}
-
 const BulkError = styled.p`
   white-space: pre-wrap;
 `;
@@ -31,9 +27,8 @@ const UserInvitePage = () => {
   const [bulkEmails, setBulkEmails] = useState<string>('');
   const [bulkError, setBulkError] = useState<Meteor.Error | undefined>(undefined);
 
-  const tracker = useTracker<UserInvitePageTracker>(() => {
-    const canBulkInvite = userMayBulkAddToHunt(Meteor.userId(), huntId);
-    return { canBulkInvite };
+  const canBulkInvite = useTracker(() => {
+    return userMayBulkAddToHunt(Meteor.userId(), huntId);
   }, [huntId]);
 
   const onEmailChanged: FormControlProps['onChange'] = useCallback((e) => {
@@ -73,7 +68,7 @@ const UserInvitePage = () => {
   }, [huntId, bulkEmails]);
 
   const bulkInvite = useMemo(() => {
-    return tracker.canBulkInvite ? (
+    return canBulkInvite ? (
       <div>
         <h2>Bulk invite</h2>
 
@@ -104,7 +99,7 @@ const UserInvitePage = () => {
         </form>
       </div>
     ) : undefined;
-  }, [tracker.canBulkInvite, submitting, bulkEmails, bulkError, onBulkSubmit, onBulkEmailsChanged]);
+  }, [canBulkInvite, submitting, bulkEmails, bulkError, onBulkSubmit, onBulkEmailsChanged]);
 
   return (
     <div>

--- a/imports/client/components/UserInvitePage.tsx
+++ b/imports/client/components/UserInvitePage.tsx
@@ -9,12 +9,17 @@ import FormGroup from 'react-bootstrap/FormGroup';
 import FormLabel from 'react-bootstrap/FormLabel';
 import Row from 'react-bootstrap/Row';
 import { useNavigate, useParams } from 'react-router-dom';
+import styled from 'styled-components';
 import { userMayBulkAddToHunt } from '../../lib/permission_stubs';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 
 interface UserInvitePageTracker {
   canBulkInvite: boolean;
 }
+
+const BulkError = styled.p`
+  white-space: pre-wrap;
+`;
 
 const UserInvitePage = () => {
   const huntId = useParams<'huntId'>().huntId!;
@@ -74,7 +79,7 @@ const UserInvitePage = () => {
 
         {bulkError ? (
           <Alert variant="danger">
-            <p style={{ whiteSpace: 'pre-wrap' }}>{bulkError.reason}</p>
+            <BulkError>{bulkError.reason}</BulkError>
           </Alert>
         ) : undefined}
 

--- a/imports/client/hooks/use-subscribe-avatars.ts
+++ b/imports/client/hooks/use-subscribe-avatars.ts
@@ -1,0 +1,7 @@
+import { useSubscribe } from 'meteor/react-meteor-data';
+
+export default function useSubscribeAvatars() {
+  return useSubscribe('mongo.profiles', {}, {
+    fields: { displayName: 1, discordAccount: 1 },
+  });
+}

--- a/imports/client/hooks/use-subscribe-display-names.ts
+++ b/imports/client/hooks/use-subscribe-display-names.ts
@@ -1,0 +1,5 @@
+import { useSubscribe } from 'meteor/react-meteor-data';
+
+export default function useSubscribeDisplayNames() {
+  return useSubscribe('mongo.profiles', {}, { fields: { displayName: 1 } });
+}

--- a/imports/lib/models/profiles.ts
+++ b/imports/lib/models/profiles.ts
@@ -1,20 +1,9 @@
-import { Meteor } from 'meteor/meteor';
 import ProfileSchema, { ProfileType } from '../schemas/profile';
 import Base from './base';
 
 const Profiles = new class extends Base<ProfileType> {
   constructor() {
     super('profiles');
-  }
-
-  subscribeDisplayNames() {
-    return Meteor.subscribe('mongo.profiles', {}, { fields: { displayName: 1 } });
-  }
-
-  subscribeAvatars() {
-    return Meteor.subscribe('mongo.profiles', {}, {
-      fields: { displayName: 1, discordAccount: 1 },
-    });
   }
 
   displayNames() {


### PR DESCRIPTION
This makes a handful of updates to how we use Meteor's React hooks in a way that I think is generally better, although it's certainly debatable the extent to which these are objective improvements vs. my own personal sense of hygiene. The diff is churn-y, but relatively rote, and should be reviewable commit-by-commit against the specific goal of that commit. My high-level goals were:

* Use [`useSubscribe`](https://github.com/meteor/react-packages/tree/master/packages/react-meteor-data#usesubscribesubname-args-a-convenient-wrapper-for-subscriptions) for everything. IMO its behavior is much cleaner than having `Meteor.subscribe` calls inside of `useTracker`, and my experiences using it for the new WebRTC code were quite positive. In the past, I observed that when a `useTracker` re-runs its reactive function, it will create a new subscription on that run, and tear down the old subscription afterwards. This is mostly not user-visible to clients, but creates unnecessary churn with the server. (It's also bad if, say, your subscriptions have side-effects, like we do with view counts or WebRTC stuff). I'm admittedly not entirely sure of the circumstances in which this happens - when I was testing out this PR, I wasn't able to reproduce it - but I did definitely see it happen in the past and that's enough for me to believe in this change.
* Stop returning a `tracker` object from `useTracker`, instead favoring modern JS object destructuring. In addition to reading a bit more fluidly IMO, this makes it harder to accidentally return a value from a `useTracker` hook and then fail to use it. When returning an object, there's no linting to ensure that all of the properties of that object are used, but if you fully destructure the object, then you get the advantage of [`@typescript-eslint/no-unused-vars`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-unused-vars.md).
* Split up trackers by collection. Meteor doesn't have a single centralized dispatch for triggering re-rendering of reactive functions on updates; updates are dispatched through collections, and those collections trigger re-rendering. That means that you don't reduce the number of updates triggered by putting multiple queries in the same `useTracker` function. When updates are triggered, it's likely _less_ efficient to consolidate queries, since it will re-run all queries and generate new objects (which won't match the referential identity of the objects they replace). One potential downside here is that it may make the first render of a component more expensive; certainly it wasn't a noticeable difference in my testing.
* Avoid passing lists or dictionaries of database objects across component boundaries. We can hope to eventually use `useFind` for most queries, which will ensure that individual database objects maintain their referential identity across re-renders where their value doesn't change. However, the list of records that `useFind` returns (or the dictionary that `Profiles.displayNames()` returns, etc.) will change, which can in turn increase how much re-rendering happens. In cases where we fetch a set of data only to pass that entire set through to a child component, I tried to move away from that where I didn't feel like it significantly impacted legibility.

I do eventually want to switch to [`useFind`](https://github.com/meteor/react-packages/tree/master/packages/react-meteor-data#usefindcursorfactory-deps-accelerate-your-lists) wherever it's feasible to do so, but my experiences with the new WebRTC debug page left me skeptical. In my testing, I've observed (e.g.) duplicate results intermittently. I haven't been able to reproduce it reliably enough to understand the buggy behavior, but for the time being I'm going to hold off on switching to `useFind`.