### PR TITLE
Progressive Web App support

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -259,6 +259,7 @@ table.puzzle-list {
   align-items: stretch;
   justify-content: space-between;
   border-top: $input-border-width solid $input-border-color;
+  border-bottom: $input-border-width solid $input-border-color;
   overflow: hidden;
   &:focus-within {
     border-color: $input-focus-border-color;

--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -38,7 +38,10 @@ const Breadcrumb = styled.nav`
 `;
 
 const ContentContainer = styled.div`
-  margin-top: ${NavBarHeight};
+  margin-top: calc(env(safe-area-inset-top, 0px) + ${NavBarHeight});
+  padding-bottom: max(env(safe-area-inset-bottom, 0px), 20px);
+  padding-left: max(env(safe-area-inset-left, 0px), 15px);
+  padding-right: max(env(safe-area-inset-right, 0px), 15px);
 `;
 
 const BreadcrumbList = styled.ol`
@@ -62,6 +65,12 @@ const BreadcrumbItem = styled.li`
       padding-right: 0.5rem;
     }
   }
+`;
+
+const NavbarInset = styled(Navbar)`
+  margin-top: env(safe-area-inset-top, 0px);
+  padding-left: env(safe-area-inset-right, 0px);
+  padding-right: calc(env(safe-area-inset-right, 0px) + 4px);
 `;
 
 const NavUsername = styled.span`
@@ -133,7 +142,7 @@ const AppNavbar = () => {
   // correct amount of space in the top bar even if we haven't actually picked
   // a nonempty source for it yet.
   return (
-    <Navbar fixed="top" bg="light" variant="light" className="px-0 py-0">
+    <NavbarInset fixed="top" bg="light" variant="light" className="py-0">
       <NavbarBrand className="p-0">
         <Link to="/">
           <Brand
@@ -167,7 +176,7 @@ const AppNavbar = () => {
           </DropdownMenu>
         </Dropdown>
       </Nav>
-    </Navbar>
+    </NavbarInset>
   );
 };
 

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -112,10 +112,6 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
   }, []);
 
   useEffect(() => {
-    // Focus search bar on page load
-    if (searchBarRef.current) {
-      searchBarRef.current.focus();
-    }
     window.addEventListener('keydown', maybeStealCtrlF);
     return () => {
       window.removeEventListener('keydown', maybeStealCtrlF);

--- a/imports/client/components/styling/FixedLayout.tsx
+++ b/imports/client/components/styling/FixedLayout.tsx
@@ -3,8 +3,8 @@ import { NavBarHeight } from './constants';
 
 export default styled.div`
   position: fixed;
-  top: ${NavBarHeight};
-  bottom: 0;
-  left: 0;
-  right: 0;
+  top: calc(env(safe-area-inset-top, 0px) + ${NavBarHeight});
+  bottom: calc(env(safe-area-inset-bottom, 0px));
+  left: env(safe-area-inset-left, 0px);
+  right: env(safe-area-inset-right, 0px);
 `;

--- a/imports/server/server-render.ts
+++ b/imports/server/server-render.ts
@@ -11,7 +11,7 @@ onPageLoad((sink) => {
     sink.appendToHead(
       '  <meta charset="utf-8">\n' +
       '  <meta http-equiv="X-UA-Compatible" content="IE=edge">\n' +
-      '  <meta name="viewport" content="width=device-width, initial-scale=1">\n' +
+      '  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">\n' +
       `  <link rel="apple-touch-icon" sizes="180x180" href="${appleTouchIconSrc}">\n` +
       `  <link rel="icon" type="image/png" sizes="32x32" href="${favicon32Src}">\n` +
       `  <link rel="icon" type="image/png" sizes="16x16" href="${favicon16Src}">\n` +

--- a/imports/server/site-manifest.ts
+++ b/imports/server/site-manifest.ts
@@ -30,6 +30,7 @@ const serveSiteManifest = (
     ],
     theme_color: '#ffffff',
     background_color: '#ffffff',
+    display: 'standalone',
   };
   const body = JSON.stringify(manifest);
 


### PR DESCRIPTION
Adds basic PWA support, so the app can be used without browser UI. To take full advantage of this, switch viewport-fit to cover and enforce inset environmental variables.
- Support standalone functionality without browser UI ("Web Clip" on iOS)
- Accommodate bottom inset (home indicator on iOS devices) to avoid blocking content. Scrolling layouts scroll under it, but with bottom padding to clear it when scrolled to the bottom. Fixed layouts keep out entirely. Notably, the home indicator no longer overlaps Google Sheets tab navigation on PuzzlePage.
- The navigation bar is now always full screen width, but its content is padded to respect insets. (Somewhat out of scope: also addressed padding the user dropdown away from the edge.)
- On windows with horizontal insetting (like an iPhone in landscape), layout is only slightly changed from the default viewport-fit (Redundant horizontal padding on non-fixed layouts is removed).
- Chat input now has a bottom edge, as it will be visible on some displays.
- Somewhat out of scope: No longer autofocus on filter input in PuzzleListPage. Autofocus caused the keyboard to immediately open on platforms with onscreen keyboards, which was frustrating. On desktop, the convenience of this autofocus is minimal at best, so just dropping it seemed sensible. (A quick search suggests that past versions of iOS simply didn't allow focus without user input, which is probably why this hasn't come up before.)

Future work (probably for next year...)
- Most users probably wouldn't think to try to install JR as a web app. Add something for discoverability - a one time alert, perhaps.
- The fixed PuzzlePage layout in windows with horizontal insets can definitely be improved cosmetically.
- Opening the keyboard on iOS does not affect safe-area-inset-bottom, so the space below the chat input on PuzzlePage slides up with the keyboard, which is a little surprising if you're used to how it's looked in the past. Giving that input some margins will address both this and the awkwardness of its focus aesthetic.

The following are believed to be issues with Safari in iOS15.2. They are not present in iOS14.5 or using Web Clips in iOS15.2. I anticipate them resolving in future iOS releases.
- In Safari for iPad with the toolbar hidden, safe-area-inset-bottom is 0, so the home indicator overlaps content.
- In Safari for iPhone with the onscreen keyboard opens, the page can be scrolled substantially past the intended bottom. This actually affects most websites and can be reproduced with a page consisting only of a single div smaller in height than the viewport. This issue wasn't introduced with this branch - in fact, a related problem was actually solved by changing viewport-fit to cover - but it's broadly related and feels worth documenting here.

iOS 15.2 on iPhone 13 Pro
<img width="452" alt="iPhone-Portrait-PuzzleList" src="https://user-images.githubusercontent.com/2136874/148863446-2790aee3-169f-4832-8477-20a817753c20.png">
<img width="452" alt="iPhone-Portrait-PuzzlePage" src="https://user-images.githubusercontent.com/2136874/148863459-11e529da-d3dd-4367-87a8-773147c8a11b.png">
<img width="888" alt="iPhone-Landscape-PuzzleList" src="https://user-images.githubusercontent.com/2136874/148863465-bd75deab-e6e0-4e53-9a2b-127d3cede85d.png">
<img width="888" alt="iPhone-Landscape-PuzzlePage" src="https://user-images.githubusercontent.com/2136874/148863472-00ff6d24-4889-4952-b32f-c3156effcdac.png">

iPadOS 15.2 on iPad Pro 11" (3rd generation)
<img width="760" alt="iPad-Portrait-PuzzleList" src="https://user-images.githubusercontent.com/2136874/148863482-9c354ef6-5e78-409e-85d8-ff97b4a4d38d.png">
<img width="760" alt="iPad-Portrait-PuzzlePage" src="https://user-images.githubusercontent.com/2136874/148863489-0037a520-4930-4084-b8ce-0f550ba7efb2.png">

