### PR TITLE
Track recent activity in voice chat

### DIFF
--- a/imports/lib/config/webrtc.ts
+++ b/imports/lib/config/webrtc.ts
@@ -1,0 +1,9 @@
+import { Meteor } from 'meteor/meteor';
+
+// eslint-disable-next-line import/prefer-default-export
+export const RECENT_ACTIVITY_TIME_WINDOW_MS = (
+  Meteor.isDevelopment ?
+    // Make the timeout much faster in development for easier testing
+    5 * 1000 :
+    60 * 1000
+);

--- a/imports/lib/models/facade.ts
+++ b/imports/lib/models/facade.ts
@@ -8,6 +8,7 @@ import FeatureFlags from './feature_flags';
 import FolderPermissions from './folder_permissions';
 import Guesses from './guesses';
 import Hunts from './hunts';
+import CallHistories from './mediasoup/call_histories';
 import ConnectAcks from './mediasoup/connect_acks';
 import ConnectRequests from './mediasoup/connect_requests';
 import ConsumerAcks from './mediasoup/consumer_acks';
@@ -39,6 +40,7 @@ const Models = {
   Guesses,
   Hunts,
   MediaSoup: {
+    CallHistories,
     ConsumerAcks,
     Consumers,
     ConnectAcks,

--- a/imports/lib/models/mediasoup/call_histories.ts
+++ b/imports/lib/models/mediasoup/call_histories.ts
@@ -1,0 +1,31 @@
+import { check, Match } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+import { Mongo } from 'meteor/mongo';
+import { huntsMatchingCurrentUser } from '../../../model-helpers';
+import CallHistorySchema, { CallHistoryType } from '../../schemas/mediasoup/call_history';
+import { FindOptions } from '../base';
+
+const CallHistories = new Mongo.Collection<CallHistoryType>('jr_mediasoup_call_histories');
+CallHistories.attachSchema(CallHistorySchema);
+if (Meteor.isServer) {
+  Meteor.publish('mongo.mediasoup_call_histories', function (
+    q: Mongo.Selector<CallHistoryType> = {},
+    opts: FindOptions = {}
+  ) {
+    check(q, Object);
+    check(opts, {
+      fields: Match.Maybe(Object),
+      sort: Match.Maybe(Object),
+      skip: Match.Maybe(Number),
+      limit: Match.Maybe(Number),
+    });
+
+    if (!this.userId) {
+      return [];
+    }
+
+    return CallHistories.find(huntsMatchingCurrentUser(this.userId, q), opts);
+  });
+}
+
+export default CallHistories;

--- a/imports/lib/relativeTimeFormat.ts
+++ b/imports/lib/relativeTimeFormat.ts
@@ -1,0 +1,50 @@
+const timeUnits = [
+  { millis: 1000, singular: 'second', plural: 'seconds' },
+  { millis: 60 * 1000, singular: 'minute', plural: 'minutes' },
+  { millis: 60 * 60 * 1000, singular: 'hour', plural: 'hours' },
+  { millis: 24 * 60 * 60 * 1000, singular: 'day', plural: 'days' },
+  { millis: 365 * 24 * 60 * 60 * 1000, singular: 'year', plural: 'years' },
+].reverse();
+
+export default function relativeTimeFormat(d: Date, opts: {
+  complete?: boolean,
+  minimumUnit?: 'second' | 'minute' | 'hour' | 'day' | 'year',
+  now?: Date,
+} = {}) {
+  const {
+    complete = false,
+    minimumUnit = 'seconds',
+    now = new Date(),
+  } = opts;
+  const diff = now.getTime() - d.getTime();
+  const relative = diff < 0 ? ' from now' : ' ago';
+
+  let remainder = Math.abs(diff);
+  const terms = [] as string[];
+  let stop = false;
+  timeUnits.forEach(({ millis, singular, plural }) => {
+    if (stop) {
+      return;
+    }
+
+    const count = Math.floor(remainder / millis);
+    if (count > 0) {
+      terms.push(`${count} ${count === 1 ? singular : plural}`);
+    }
+    remainder %= millis;
+
+    if (minimumUnit === singular) {
+      stop = true;
+    }
+  });
+
+  if (terms.length === 0) {
+    return 'just now';
+  }
+
+  if (complete) {
+    return `${terms.join(', ')}${relative}`;
+  }
+
+  return `${terms[0]}${relative}`;
+}

--- a/imports/lib/schemas/facade.ts
+++ b/imports/lib/schemas/facade.ts
@@ -8,6 +8,7 @@ import FeatureFlag from './feature_flag';
 import FolderPermission from './folder_permission';
 import Guess from './guess';
 import Hunt from './hunt';
+import CallHistory from './mediasoup/call_history';
 import ConnectAck from './mediasoup/connect_ack';
 import ConnectRequest from './mediasoup/connect_request';
 import Consumer from './mediasoup/consumer';
@@ -40,6 +41,7 @@ const Schemas = {
   Guess,
   Hunt,
   MediaSoup: {
+    CallHistory,
     ConnectAck,
     ConnectRequest,
     Consumer,

--- a/imports/lib/schemas/mediasoup/call_history.ts
+++ b/imports/lib/schemas/mediasoup/call_history.ts
@@ -1,0 +1,27 @@
+import * as t from 'io-ts';
+import { date } from 'io-ts-types';
+import SimpleSchema from 'simpl-schema';
+import { Overrides, buildSchema } from '../typedSchemas';
+
+// Don't use the BaseCodec here - unlike most database objects, this isn't
+// manipulated by users, so many of the fields don't make sense
+const CallHistoryCodec = t.type({
+  _id: t.string,
+  hunt: t.string,
+  call: t.string,
+  lastActivity: t.union([date, t.undefined]),
+});
+
+const CallHistoryOverrides: Overrides<t.TypeOf<typeof CallHistoryCodec>> = {
+  hunt: {
+    regEx: SimpleSchema.RegEx.Id,
+  },
+  call: {
+    regEx: SimpleSchema.RegEx.Id,
+  },
+};
+
+export { CallHistoryCodec };
+export type CallHistoryType = t.TypeOf<typeof CallHistoryCodec>;
+
+export default buildSchema(CallHistoryCodec, CallHistoryOverrides);

--- a/imports/lib/schemas/mediasoup/room.ts
+++ b/imports/lib/schemas/mediasoup/room.ts
@@ -7,11 +7,16 @@ import { Overrides, inheritSchema, buildSchema } from '../typedSchemas';
 // mediasoup integration to create a router.
 
 const RoomFields = t.type({
+  hunt: t.string,
   call: t.string,
   routedServer: t.string,
 });
 
 const RoomFieldsOverrides: Overrides<t.TypeOf<typeof RoomFields>> = {
+  hunt: {
+    regEx: SimpleSchema.RegEx.Id,
+    denyUpdate: true,
+  },
   call: {
     regEx: SimpleSchema.RegEx.Id,
     denyUpdate: true,

--- a/imports/lib/schemas/mediasoup/router.ts
+++ b/imports/lib/schemas/mediasoup/router.ts
@@ -4,6 +4,7 @@ import { BaseCodec, BaseOverrides } from '../base';
 import { Overrides, buildSchema, inheritSchema } from '../typedSchemas';
 
 const RouterFields = t.type({
+  hunt: t.string,
   call: t.string,
   createdServer: t.string,
   routerId: t.string, // mediasoup identifier
@@ -11,6 +12,10 @@ const RouterFields = t.type({
 });
 
 const RouterFieldsOverrides: Overrides<t.TypeOf<typeof RouterFields>> = {
+  hunt: {
+    regEx: SimpleSchema.RegEx.Id,
+    denyUpdate: true,
+  },
   call: {
     regEx: SimpleSchema.RegEx.Id,
     denyUpdate: true,

--- a/imports/server/migrations/36-call-history-indexes.ts
+++ b/imports/server/migrations/36-call-history-indexes.ts
@@ -1,0 +1,11 @@
+import { Migrations } from 'meteor/percolate:migrations';
+import CallHistories from '../../lib/models/mediasoup/call_histories';
+
+Migrations.add({
+  version: 36,
+  name: 'Add indexes to CallHistory collection',
+  up() {
+    CallHistories.createIndex({ call: 1 }, { unique: true });
+    CallHistories.createIndex({ hunt: 1 });
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -34,3 +34,4 @@ import './32-index-chat-notifications';
 import './33-index-profile-dingwords';
 import './34-mediasoup-indexes';
 import './35-folder-permissions-indexes';
+import './36-call-history-indexes';

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -1,2 +1,3 @@
 import './unit/imports/lib/calendarTimeFormat';
+import './unit/imports/lib/relativeTimeFormat';
 import './acceptance/authentication';

--- a/tests/unit/imports/lib/relativeTimeFormat.ts
+++ b/tests/unit/imports/lib/relativeTimeFormat.ts
@@ -1,0 +1,56 @@
+import { assert } from 'chai';
+import relativeTimeFormat from '../../../../imports/lib/relativeTimeFormat';
+
+describe('calendarTimeFormat', function () {
+  let timezone: string | undefined;
+  before(function () {
+    timezone = process.env.TZ;
+    process.env.TZ = 'UTC';
+  });
+
+  after(function () {
+    process.env.TZ = timezone;
+  });
+
+  it('formats correctly with single item', function () {
+    const now = new Date(2022, 1, 10, 21, 55, 10);
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 55, 9), { complete: false, now }), '1 second ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 55, 8), { complete: false, now }), '2 seconds ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 54, 11), { complete: false, now }), '59 seconds ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 54, 10), { complete: false, now }), '1 minute ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 53, 40), { complete: false, now }), '1 minute ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 53, 10), { complete: false, now }), '2 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 20, 55, 11), { complete: false, now }), '59 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 20, 55, 10), { complete: false, now }), '1 hour ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 20, 25, 10), { complete: false, now }), '1 hour ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 19, 55, 10), { complete: false, now }), '2 hours ago');
+  });
+
+  it('formats correctly with multiple items', function () {
+    const now = new Date(2022, 1, 10, 21, 55, 10);
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 55, 9), { complete: true, now }), '1 second ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 55, 8), { complete: true, now }), '2 seconds ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 54, 11), { complete: true, now }), '59 seconds ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 54, 10), { complete: true, now }), '1 minute ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 53, 40), { complete: true, now }), '1 minute, 30 seconds ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 53, 10), { complete: true, now }), '2 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 20, 55, 11), { complete: true, now }), '59 minutes, 59 seconds ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 20, 55, 10), { complete: true, now }), '1 hour ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 20, 25, 10), { complete: true, now }), '1 hour, 30 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 19, 55, 10), { complete: true, now }), '2 hours ago');
+
+    assert.equal(relativeTimeFormat(new Date(2020, 7, 1, 18, 20, 40), { complete: true, now }), '1 year, 193 days, 3 hours, 34 minutes, 30 seconds ago');
+  });
+
+  it('formats correctly with a minimum unit', function () {
+    const now = new Date(2022, 1, 10, 21, 55, 10);
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 53, 40), { complete: true, minimumUnit: 'minute', now }), '1 minute ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 21, 53, 10), { complete: true, minimumUnit: 'minute', now }), '2 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 20, 55, 11), { complete: true, minimumUnit: 'minute', now }), '59 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 20, 55, 10), { complete: true, minimumUnit: 'minute', now }), '1 hour ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 20, 25, 10), { complete: true, minimumUnit: 'minute', now }), '1 hour, 30 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(2022, 1, 10, 19, 55, 10), { complete: true, minimumUnit: 'minute', now }), '2 hours ago');
+
+    assert.equal(relativeTimeFormat(new Date(2020, 7, 1, 18, 20, 40), { complete: true, minimumUnit: 'day', now }), '1 year, 193 days ago');
+  });
+});


### PR DESCRIPTION
Use AudioLevelObserver + some debouncing to keep track of the last time
there was voice activity (with roughly 60 second granularity), and keep
that on a new CallHistories model (which persists across calls being
started/stopped, unlike any of the other Mediasoup models).

This data gets displayed in the call section if you're not currently
joined to a call.

Here are some examples of what that might look like:

<img width="1619" alt="Screen Shot 2022-01-10 at 8 22 01 PM" src="https://user-images.githubusercontent.com/28167/148880703-95cbe137-12f5-4b5d-83c2-5dda9835bd67.png">

(Note that we'll only ever see "seconds ago" in development mode. Adding the activity note to the puzzle list page is left as an exercise for future-me assuming we're happy with the rest of this.)