### PR TITLE
Pick up node-forge security update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3840,11 +3840,11 @@
       }
     },
     "google-p12-pem": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.1.tgz",
-      "integrity": "sha512-e9CwdD2QYkpvJsktki3Bm8P8FSGIneF+/42a9F9QHcQvJ73C2RoYZdrwRl6BhwksWtzl65gT4OnBROhUIFw95Q==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.3.tgz",
+      "integrity": "sha512-MC0jISvzymxePDVembypNefkAQp+DRP7dBE+zNUPaIjEspIlYg0++OrsNr248V9tPbz6iqtZ7rX1hxWA5B8qBQ==",
       "requires": {
-        "node-forge": "^0.10.0"
+        "node-forge": "^1.0.0"
       }
     },
     "googleapis": {
@@ -5676,9 +5676,9 @@
       "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.0.tgz",
+      "integrity": "sha512-M4AsdaP0bGNaSPtatd/+f76asocI0cFaURRdeQVZvrJBrYp2Qohv5hDbGHykuNqCb1BYjWHjdS6HlN50qbztwA=="
     },
     "nopt": {
       "version": "5.0.0",


### PR DESCRIPTION
I was hoping dependabot would figure out how to do this on its own but I guess not. (Generated with `meteor npm audit fix && meteor npm i`)