### PR TITLE
PuzzlePage interface style polish

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -275,7 +275,8 @@ $puzzle-page-padding: 8px;
 
     .btn {
       flex: 1;
-      padding: 0 auto;
+      padding-right: 2px;
+      padding-left: 2px;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -420,8 +420,8 @@ $comm-pane-padding: 8px;
 // Puzzle metadata
 .puzzle-metadata {
   flex: none;
-  padding: 2px 4px;
-  border-bottom: 1px solid black;
+  padding: 2px 8px;
+  border-bottom: 1px solid #dadce0;
 }
 
 .puzzle-metadata-row {

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -383,8 +383,7 @@ $puzzle-page-padding: 8px;
 }
 
 .chat-message, .chat-placeholder {
-  padding: 0 $puzzle-page-padding;
-  margin-bottom: 2px;
+  padding: 0px $puzzle-page-padding 2px;
   word-wrap: break-word;
   font-size: 14px;
   &.system-message {

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -319,77 +319,50 @@ $puzzle-page-padding: 8px;
     display: flex;
     align-items: center;
     justify-content: center;
-    text-transform: uppercase;
-    font-weight: bold;
-    font-size: 24px;
-    color: black;
-    line-height: 24px;
     position: relative;
     margin: 4px 4px 0 0;
 
     .icon {
       font-size: 12px;
       width: 16px;
-      text-align: center;
+      height: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
       color: $danger;
-      height: 50%;
-    }
-
-    $mutedTop: -4px;
-    $mutedRight: -2px;
-    $deafenDiff: 2px;
-
-    &.muted .muted-icon {
       position: absolute;
-      top: $mutedTop;
-      right: $mutedRight;
+      right: 0px;
+
+      &.muted-icon {
+        top: 0px;
+      }
+
+      &.deafened-icon {
+        bottom: 0px;
+      }
     }
 
-    &.deafened {
-      color: $secondary;
-      background: #ffffff88;
-      border: $deafenDiff solid white;
-
-      .muted-icon {
-        position: absolute;
-        top: $mutedTop - $deafenDiff;
-        right: $mutedRight - $deafenDiff;
-      }
-
-      .deafened-icon {
-        position: absolute;
-        bottom: 1px;
-        right: $mutedRight - $deafenDiff;
-      }
+    .discord-avatar {
+      width: 100%;
+      height: 100%;
     }
 
     .initial {
       z-index: 10;
+      text-transform: uppercase;
+      font-weight: bold;
+      font-size: 24px;
+      color: black;
+      line-height: 24px;
     }
 
     &.live .initial {
       // white border around initial
       // aids readability if the spectrum graph is high
-      text-shadow: -1px 1px 0 white,
-				  1px 1px 0 white,
-				 1px -1px 0 white,
-				-1px -1px 0 white;
-    }
-
-    .connection {
-      position: absolute;
-      bottom: 0;
-      left: 0;
-      width: 100%;
-      height: 3px;
-      background-color: #cccccc;
-    }
-
-    &.deafened .connection {
-      bottom: -$deafenDiff;
-      left: -$deafenDiff;
-      right: -$deafenDiff;
-      width: auto;
+      text-shadow: -1px  1px 0 white,
+                    1px  1px 0 white,
+                    1px -1px 0 white,
+                   -1px -1px 0 white;
     }
   }
 }

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -234,6 +234,8 @@ table.puzzle-list {
   flex-direction: column;
 }
 
+$comm-pane-padding: 8px;
+
 // Chat
 .chat-section {
   flex: 1 1 auto;
@@ -253,9 +255,9 @@ table.puzzle-list {
 }
 
 .chat-input-row {
-  padding: 8px;
+  padding: $comm-pane-padding;
   //capitalize Max to prefer css max over scss max
-  padding-bottom: Max(env(safe-area-inset-bottom, 0px), 8px);
+  padding-bottom: Max(env(safe-area-inset-bottom, 0px), $comm-pane-padding);
 }
 
 .chatter-section {
@@ -263,12 +265,13 @@ table.puzzle-list {
   background-color: #ebd0e3;
   font-size: 12px;
   line-height: 12px;
-  border-bottom: 1px solid #000;
+  padding: $comm-pane-padding;
 
   .av-actions {
     display: flex;
     flex-direction: row;
-    //margin-top: 6px;
+    margin-bottom: $comm-pane-padding;
+    gap: $comm-pane-padding;
 
     .btn {
       flex: 1;
@@ -276,14 +279,15 @@ table.puzzle-list {
       display: flex;
       align-items: center;
       justify-content: center;
-      border-radius: 0;
     }
   }
 }
 
 .chatter-subsection {
+  margin-top: 4px;
+
   header {
-    margin: 4px 2px;
+    margin: 4px 0;
     cursor: pointer;
   }
 
@@ -291,6 +295,7 @@ table.puzzle-list {
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-end;
+    gap: 4px;
 
     &.collapsed {
       display: none;
@@ -302,7 +307,7 @@ table.puzzle-list {
     width: 40px;
     height: 40px;
     background: white;
-
+    cursor: default;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -311,7 +316,6 @@ table.puzzle-list {
     font-size: 24px;
     color: black;
     line-height: 24px;
-    margin-left: 4px;
     position: relative;
 
     .icon {
@@ -397,7 +401,7 @@ table.puzzle-list {
 }
 
 .chat-message, .chat-placeholder {
-  padding: 0 8px;
+  padding: 0 $comm-pane-padding;
   margin-bottom: 2px;
   word-wrap: break-word;
   font-size: 14px;

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -245,10 +245,6 @@ table.puzzle-list {
     margin-bottom: 0;
   }
 
-  textarea {
-    border-radius: 0;
-  }
-
   blockquote {
     font-size: 14px;
     margin-left: 10px;
@@ -257,30 +253,7 @@ table.puzzle-list {
 }
 
 .chat-input-row {
-  flex: none;
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  justify-content: space-between;
-  border-top: $input-border-width solid $input-border-color;
-  border-bottom: $input-border-width solid $input-border-color;
-  overflow: hidden;
-  &:focus-within {
-    border-color: $input-focus-border-color;
-    box-shadow: $input-focus-box-shadow;
-  }
-
-  textarea {
-    flex: 1 1 auto;
-    border: none;
-    &:focus {
-        box-shadow: none;
-    }
-  }
-
-  button {
-    border-radius: 0;
-  }
+  padding: 8px;
 }
 
 .chatter-section {
@@ -422,7 +395,7 @@ table.puzzle-list {
 }
 
 .chat-message, .chat-placeholder {
-  padding: 0 4px;
+  padding: 0 8px;
   margin-bottom: 2px;
   word-wrap: break-word;
   font-size: 14px;

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -272,7 +272,6 @@ $puzzle-page-padding: 8px;
     display: flex;
     flex-direction: row;
     margin-bottom: $puzzle-page-padding;
-    gap: $puzzle-page-padding;
 
     .btn {
       flex: 1;
@@ -280,6 +279,10 @@ $puzzle-page-padding: 8px;
       display: flex;
       align-items: center;
       justify-content: center;
+
+      + .btn {
+        margin-left: $puzzle-page-padding;
+      }
     }
   }
 }
@@ -296,7 +299,10 @@ $puzzle-page-padding: 8px;
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-end;
-    gap: 4px;
+
+    &:not(:empty) {
+      margin: -4px -4px 0 0;
+    }
 
     &.collapsed {
       display: none;
@@ -318,6 +324,7 @@ $puzzle-page-padding: 8px;
     color: black;
     line-height: 24px;
     position: relative;
+    margin: 4px 4px 0 0;
 
     .icon {
       font-size: 12px;

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -214,6 +214,9 @@ table.puzzle-list {
 
 ////////////
 // Puzzle page styles
+
+$puzzle-page-padding: 8px;
+
 .puzzle-page {
   .Pane > .puzzle-content, .Pane > .chat-section {
     position: absolute;
@@ -234,8 +237,6 @@ table.puzzle-list {
   flex-direction: column;
 }
 
-$comm-pane-padding: 8px;
-
 // Chat
 .chat-section {
   flex: 1 1 auto;
@@ -255,9 +256,9 @@ $comm-pane-padding: 8px;
 }
 
 .chat-input-row {
-  padding: $comm-pane-padding;
+  padding: $puzzle-page-padding;
   //capitalize Max to prefer css max over scss max
-  padding-bottom: Max(env(safe-area-inset-bottom, 0px), $comm-pane-padding);
+  padding-bottom: Max(env(safe-area-inset-bottom, 0px), $puzzle-page-padding);
 }
 
 .chatter-section {
@@ -265,13 +266,13 @@ $comm-pane-padding: 8px;
   background-color: #ebd0e3;
   font-size: 12px;
   line-height: 12px;
-  padding: $comm-pane-padding;
+  padding: $puzzle-page-padding;
 
   .av-actions {
     display: flex;
     flex-direction: row;
-    margin-bottom: $comm-pane-padding;
-    gap: $comm-pane-padding;
+    margin-bottom: $puzzle-page-padding;
+    gap: $puzzle-page-padding;
 
     .btn {
       flex: 1;
@@ -401,7 +402,7 @@ $comm-pane-padding: 8px;
 }
 
 .chat-message, .chat-placeholder {
-  padding: 0 $comm-pane-padding;
+  padding: 0 $puzzle-page-padding;
   margin-bottom: 2px;
   word-wrap: break-word;
   font-size: 14px;
@@ -420,7 +421,7 @@ $comm-pane-padding: 8px;
 // Puzzle metadata
 .puzzle-metadata {
   flex: none;
-  padding: 2px 8px;
+  padding: ($puzzle-page-padding - 2px) 8px;
   border-bottom: 1px solid #dadce0;
 }
 

--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -254,6 +254,8 @@ table.puzzle-list {
 
 .chat-input-row {
   padding: 8px;
+  //capitalize Max to prefer css max over scss max
+  padding-bottom: Max(env(safe-area-inset-bottom, 0px), 8px);
 }
 
 .chatter-section {
@@ -522,6 +524,8 @@ table.puzzle-list {
   bottom: 0;
   left: 0;
   border: 0;
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  background-color: #f1f3f4;
 }
 
 .popover.related-puzzle-popover {
@@ -647,7 +651,7 @@ table.puzzle-list {
 }
 
 .Resizer {
-  background: #000;
+  background: $gray-600;
   z-index: 1;
   box-sizing: border-box;
   background-clip: padding-box;

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -791,16 +791,16 @@ const CallSection = ({
           size="sm"
           onClick={onToggleMute}
         >
-          {muted ? 'unmute' : 'mute self'}
+          {muted ? 'Unmute' : 'Mute self'}
         </Button>
         <Button
           variant={deafened ? 'secondary' : 'light'}
           size="sm"
           onClick={onToggleDeafen}
         >
-          {deafened ? 'undeafen' : 'deafen self'}
+          {deafened ? 'Undeafen' : 'Deafen self'}
         </Button>
-        <Button variant="danger" size="sm" onClick={onLeaveCall}>leave call</Button>
+        <Button variant="danger" size="sm" onClick={onLeaveCall}>Leave call</Button>
       </div>
       <CallJoiner
         huntId={huntId}

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -234,7 +234,6 @@ const ProducerBox = ({
               stream={stream}
             />
           ) : null}
-          <span className="connection" />
         </div>
         {tracks.map((track) => (
           <ProducerManager
@@ -402,7 +401,6 @@ const PeerBox = ({
               stream={stream}
             />
           ) : null}
-          <span className="connection" />
         </div>
         <audio ref={audioRef} className="audio-sink" autoPlay playsInline muted={selfDeafened} />
         {consumers.map((consumer) => (

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -791,14 +791,14 @@ const CallSection = ({
           size="sm"
           onClick={onToggleMute}
         >
-          {muted ? 'Unmute' : 'Mute self'}
+          {muted ? 'Un\u00ADmute' : 'Mute self'}
         </Button>
         <Button
           variant={deafened ? 'secondary' : 'light'}
           size="sm"
           onClick={onToggleDeafen}
         >
-          {deafened ? 'Undeafen' : 'Deafen self'}
+          {deafened ? 'Un\u00ADdeafen' : 'Deafen self'}
         </Button>
         <Button variant="danger" size="sm" onClick={onLeaveCall}>Leave call</Button>
       </div>

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -422,7 +422,7 @@ const ChatPeople = (props: ChatPeopleProps) => {
     switch (callState) {
       case CallState.CHAT_ONLY:
       case CallState.REQUESTING_STREAM: {
-        const joinLabel = rtcViewers.length > 0 ? 'join audio call' : 'start audio call';
+        const joinLabel = rtcViewers.length > 0 ? 'Join audio call' : 'Start audio call';
         return (
           <>
             <div className="av-actions">

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -320,28 +320,31 @@ const ChatInput = React.memo((props: ChatInputProps) => {
 
   return (
     <div className="chat-input-row">
-      <TextareaAutosize
-        ref={textAreaRef}
-        className="form-control"
-        style={chatInputStyles.textarea}
-        maxLength={4000}
-        minRows={1}
-        maxRows={12}
-        value={text}
-        onChange={onInputChanged}
-        onKeyDown={onKeyDown}
-        onHeightChange={onHeightChangeCb}
-        placeholder="Chat"
-      />
-      <Button
-        variant="light"
-        onClick={sendMessageIfHasText}
-        onMouseDown={preventDefaultCallback}
-        disabled={text.length === 0}
-        tabIndex={-1}
-      >
-        <FontAwesomeIcon icon={faPaperPlane} />
-      </Button>
+      <div className="input-group">
+        <TextareaAutosize
+          ref={textAreaRef}
+          className="form-control"
+          style={chatInputStyles.textarea}
+          maxLength={4000}
+          minRows={1}
+          maxRows={12}
+          value={text}
+          onChange={onInputChanged}
+          onKeyDown={onKeyDown}
+          onHeightChange={onHeightChangeCb}
+          placeholder="Chat"
+        />
+        <span className="input-group-append">
+          <Button
+            variant="secondary"
+            onClick={sendMessageIfHasText}
+            onMouseDown={preventDefaultCallback}
+            disabled={text.length === 0}
+          >
+            <FontAwesomeIcon icon={faPaperPlane} />
+          </Button>
+        </span>
+      </div>
     </div>
   );
 });

--- a/imports/client/components/styling/FixedLayout.tsx
+++ b/imports/client/components/styling/FixedLayout.tsx
@@ -4,7 +4,7 @@ import { NavBarHeight } from './constants';
 export default styled.div`
   position: fixed;
   top: calc(env(safe-area-inset-top, 0px) + ${NavBarHeight});
-  bottom: calc(env(safe-area-inset-bottom, 0px));
+  bottom: 0px;
   left: env(safe-area-inset-left, 0px);
   right: env(safe-area-inset-right, 0px);
 `;

--- a/imports/lib/discord.ts
+++ b/imports/lib/discord.ts
@@ -3,7 +3,7 @@ import { DiscordAccountType } from './schemas/discord_account';
 const DiscordOAuthScopes = ['identify', 'guilds.join'];
 const API_BASE = 'https://discord.com/api/v8';
 
-function getAvatarCdnUrl(da?: DiscordAccountType, size: number = 40): string | undefined {
+function getAvatarCdnUrl(da?: DiscordAccountType, size: number = 128): string | undefined {
   if (da?.avatar) {
     return `https://cdn.discordapp.com/avatars/${da.id}/${da.avatar}.png?size=${size}`;
   } else {


### PR DESCRIPTION
- Move chat controls and call interface away from edges. The nonstandard controls are more trouble than they're worth. Adding padding makes buttons more clear, improves the focus effect, looks more natural when a bottom inset is present, and reduces amount of non-standard styling.
- Extend the fixed layout to the bottom, when bottom inset is non-zero. Resizer makes more sense stretched to full height and chat input needn't waste vertical padding. This is a first step in better using the areas outside the inset.
- Style improvements for people in chatter
  - Add gap between. Remove disused connection status bar.
  - Remove inconsistently visible background shading on deafen.
  - Fix mute and deafen icon overflow.
  - Get higher resolution discord icons (for hiDPI displays).
- Capitalize voice chat buttons (for consistency) and fix overflow on narrow chat panes
- Increase chat and metadata padding to match left-pane interface
- Make chat highlights unbroken
- Remove or lighten borders where possible

Open to suggestions.

![Screenshot](https://user-images.githubusercontent.com/2136874/149031544-00990924-5396-4802-9277-8f6423e19c67.png)

