### PR TITLE
Add an error boundary to the main App component

### DIFF
--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -1,8 +1,10 @@
 import { Meteor } from 'meteor/meteor';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
+import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons/faExclamationTriangle';
 import { faUser } from '@fortawesome/free-solid-svg-icons/faUser';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { useCallback, useMemo } from 'react';
+import Alert from 'react-bootstrap/Alert';
 import Dropdown from 'react-bootstrap/Dropdown';
 import DropdownItem from 'react-bootstrap/DropdownItem';
 import DropdownMenu from 'react-bootstrap/DropdownMenu';
@@ -12,6 +14,9 @@ import NavItem from 'react-bootstrap/NavItem';
 import NavLink from 'react-bootstrap/NavLink';
 import Navbar from 'react-bootstrap/Navbar';
 import NavbarBrand from 'react-bootstrap/NavbarBrand';
+import Button from 'react-bootstrap/esm/Button';
+import Container from 'react-bootstrap/esm/Container';
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import * as RRBS from 'react-router-bootstrap';
 import { useNavigate, Link } from 'react-router-dom';
 import styled from 'styled-components';
@@ -76,6 +81,58 @@ const Brand = styled.img`
   width: ${NavBarHeight};
   height: ${NavBarHeight};
 `;
+
+const ErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+  const navigate = useNavigate();
+  const goBack = useCallback(() => navigate(-1), [navigate]);
+  return (
+    <Container>
+      <Alert variant="danger">
+        <Alert.Heading>
+          <FontAwesomeIcon icon={faExclamationTriangle} fixedWidth />
+          {' '}
+          Something went wrong
+        </Alert.Heading>
+
+        <p>
+          Something went wrong while you were using Jolly Roger. This is most
+          likely a bug in the app, rather than something you did.
+        </p>
+
+        <p>
+          Send these details to the Jolly Roger team so that they can help fix
+          it:
+        </p>
+
+        <pre>
+          {error.stack}
+        </pre>
+
+        <p>
+          In the mean time, you can try resetting this part of the site or
+          going back to the last page (a particularly useful option if you just
+          clicked on a link)
+        </p>
+
+        <p>
+          <Button type="button" onClick={resetErrorBoundary}>
+            Reset
+          </Button>
+          {' '}
+          <Button type="button" onClick={goBack}>
+            Go back
+          </Button>
+        </p>
+
+        <p>
+          But that may just make things crash again. If it does, try navigating
+          to a different part of the site using the navigation bar at the top of
+          the page.
+        </p>
+      </Alert>
+    </Container>
+  );
+};
 
 const AppNavbar = () => {
   const userId = useTracker(() => Meteor.userId()!, []);
@@ -181,7 +238,9 @@ const App = ({ children }: { children: React.ReactNode }) => {
       <AppNavbar />
       <ConnectionStatus />
       <ContentContainer className="container-fluid pt-2">
-        {children}
+        <ErrorBoundary FallbackComponent={ErrorFallback}>
+          {children}
+        </ErrorBoundary>
       </ContentContainer>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -6421,6 +6421,14 @@
         "scheduler": "^0.20.2"
       }
     },
+    "react-error-boundary": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.4.tgz",
+      "integrity": "sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
+      }
+    },
     "react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-bootstrap": "^1.6.4",
     "react-copy-to-clipboard": "^5.0.4",
     "react-dom": "^17.0.2",
+    "react-error-boundary": "^3.1.4",
     "react-router-bootstrap": "^0.26.0",
     "react-router-dom": "^6.2.1",
     "react-select": "^5.2.1",


### PR DESCRIPTION
This gives us a slightly better UX than having the entire app unmount
and leave the user with a blank screen. The "reset" button is admittedly
not likely to solve anyone's problems, but it at least gives them some
agency and an opportunity to go somewhere else

Here's an example of what it looks like:

<img width="1912" alt="Screen Shot 2022-01-12 at 5 20 20 PM" src="https://user-images.githubusercontent.com/28167/149248933-fac8fb17-893d-484d-b53c-8d420aff3526.png">

I was hoping to include the stack from Mobile Firefox, but sadly I don't seem to be able to repro on my local dev environment.
.