### PR TITLE
Limit size of Discord avatars

### DIFF
--- a/imports/client/components/OthersProfilePage.tsx
+++ b/imports/client/components/OthersProfilePage.tsx
@@ -81,13 +81,20 @@ const OthersProfilePage = (props: OthersProfilePageProps) => {
                 placement="bottom-start"
                 overlay={(
                   <AvatarTooltip id="tooltip-avatar">
-                    <img src={discordAvatarUrlLarge} width={256} height={256} alt="Discord avatar" />
+                    <img
+                      alt="Discord avatar"
+                      src={discordAvatarUrlLarge}
+                      width={128}
+                      height={128}
+                    />
                   </AvatarTooltip>
                 )}
               >
                 <img
                   alt={`${profile.displayName}'s Discord avatar`}
                   src={discordAvatarUrl}
+                  width={40}
+                  height={40}
                   className="discord-avatar"
                 />
               </OverlayTrigger>

--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -238,7 +238,7 @@ const DiscordLinkBlock = (props: DiscordLinkBlockProps) => {
         <div>
           Currently linked to
           {' '}
-          <img src={getAvatarCdnUrl(acct)} alt="Discord Avatar" />
+          <img src={getAvatarCdnUrl(acct)} width={40} height={40} alt="Discord Avatar" />
           {' '}
           {acct.username}
           #

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -202,6 +202,8 @@ const ProfileList = (props: ProfileListProps) => {
                     <img
                       alt={`${name}'s Discord avatar`}
                       src={discordAvatarUrl}
+                      width={40}
+                      height={40}
                       className="discord-avatar"
                     />
                   )}

--- a/imports/client/components/RTCDebugPage.tsx
+++ b/imports/client/components/RTCDebugPage.tsx
@@ -120,6 +120,8 @@ const UserDisplay = ({ userId }: { userId: string }) => {
         <img
           alt={`${name}'s Discord avatar`}
           src={discordAvatarUrl}
+          width={40}
+          height={40}
         />
       )}
       {' '}


### PR DESCRIPTION
Fixes a bug introduced in 8f81153.

Most Discord avatar images were unstyled, so fetching higher resolution images caused formatting issues.