### PR TITLE
Run errors through StackTrace.JS before rendering them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2239,6 +2239,14 @@
         "ansi-colors": "^4.1.1"
       }
     },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "es-abstract": {
       "version": "1.17.7",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
@@ -6825,6 +6833,45 @@
       "integrity": "sha1-Zwl8YB1pfOE2j0GPBs0gHPBSGlc=",
       "requires": {
         "through": "2"
+      }
+    },
+    "stack-generator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
+    "stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+    },
+    "stacktrace-gps": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
+      "integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.1.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "requires": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
       }
     },
     "statuses": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-split-pane": "^0.1.92",
     "react-textarea-autosize": "^8.3.3",
     "simpl-schema": "^1.12.0",
+    "stacktrace-js": "^2.0.2",
     "styled-components": "^5.3.1",
     "url": "^0.11.0"
   },


### PR DESCRIPTION
This is a little frivolous, but probably worth merging. In particular, this gives us some indirection around differences in browser behavior. Chrome includes the exception message in `Error.stack`; Firefox does not. I also thought Firefox's stacktraces were kind of ugly, but that's really just because of the minification in prod. This doesn't do anything about minification yet, because `stacktrace-gps` only supports the `//# sourceMappingURL` magic comments and not the `X-SourceMap` header that Meteor uses.

Before:

![87FE4A11-145C-42BA-8646-E8F84A6B405B](https://user-images.githubusercontent.com/28167/149279427-fbe02401-0a20-4f50-ac87-808ed4f77149.png)

After:

![A140F83C-74FE-4CD4-91D3-F91D656DE74C](https://user-images.githubusercontent.com/28167/149279404-7f36fab0-10e3-4235-8228-9a6201524fe8.png)

(The rendering on Chrome is about the same before and after)
