### PR TITLE
Add some prod-enableable client-side tracing to debug scroll position issue

### DIFF
--- a/client/main.ts
+++ b/client/main.ts
@@ -13,10 +13,12 @@ declare global {
 }
 
 window.loadFacades = async () => {
-  const [models, schemas] = await Promise.all([
+  const [models, schemas, tracing] = await Promise.all([
     import('../imports/lib/models/facade'),
     import('../imports/lib/schemas/facade'),
+    import('../imports/client/tracing'),
   ]);
   Object.defineProperty(window, 'Models', { value: models.default });
   Object.defineProperty(window, 'Schemas', { value: schemas.default });
+  Object.defineProperty(window, 'Tracing', { value: tracing });
 };

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -34,6 +34,7 @@ import { ConsumerType } from '../../lib/schemas/mediasoup/consumer';
 import { PeerType } from '../../lib/schemas/mediasoup/peer';
 import { RouterType } from '../../lib/schemas/mediasoup/router';
 import { TransportType } from '../../lib/schemas/mediasoup/transport';
+import { trace } from '../tracing';
 import Loading from './Loading';
 import Spectrum from './Spectrum';
 
@@ -579,8 +580,19 @@ const CallTransportConnector = ({
   const notReadyYet = !sendTransport || !recvTransport;
   useLayoutEffect(() => {
     // Notify any time we might change the height of what we render
+    trace('CallTransportConnector useLayoutEffect', {
+      notReadyYet,
+      callersExpanded,
+      otherPeers: otherPeers.length,
+    });
     onHeightChange();
   }, [onHeightChange, notReadyYet, callersExpanded, otherPeers.length]);
+
+  trace('CallTransportConnector render', {
+    hasSend: !!sendTransport,
+    hasRecv: !!recvTransport,
+    otherPeers: otherPeers.length,
+  });
 
   if (!sendTransport || !recvTransport) {
     // No JoiningCall warning here - if we have params coming in we're
@@ -657,8 +669,19 @@ const CallTransportCreator = ({
 
   const hasDevice = !!device;
   useLayoutEffect(() => {
+    trace('CallSection useLayoutEffect', {
+      hasDevice,
+      sendId: sendServerParams?._id,
+      recvId: recvServerParams?._id,
+    });
     onHeightChange();
   }, [onHeightChange, hasDevice, sendServerParams?._id, recvServerParams?._id]);
+
+  trace('CallSection render', {
+    hasDevice,
+    sendServerParams,
+    recvServerParams,
+  });
 
   if (!device) {
     return null;

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -22,6 +22,7 @@ import relativeTimeFormat from '../../lib/relativeTimeFormat';
 import { PeerType } from '../../lib/schemas/mediasoup/peer';
 import useSubscribeAvatars from '../hooks/use-subscribe-avatars';
 import { Subscribers } from '../subscribers';
+import { trace } from '../tracing';
 import { PREFERRED_AUDIO_DEVICE_STORAGE_KEY } from './AudioConfig';
 import CallSection from './CallSection';
 
@@ -339,6 +340,7 @@ const ChatPeople = (props: ChatPeopleProps) => {
   const { muted, deafened } = localAudioControls;
 
   const joinCall = useCallback(async () => {
+    trace('ChatPeople joinCall');
     if (navigator.mediaDevices) {
       setCallState(CallState.REQUESTING_STREAM);
       const preferredAudioDeviceId = localStorage.getItem(PREFERRED_AUDIO_DEVICE_STORAGE_KEY) ||
@@ -412,6 +414,7 @@ const ChatPeople = (props: ChatPeopleProps) => {
   }, [muted]);
 
   const leaveCall = useCallback(() => {
+    trace('ChatPeople leaveCall');
     stopTracks(audioState.rawMediaSource);
     setCallState(CallState.CHAT_ONLY);
     setLocalAudioControls({
@@ -429,12 +432,22 @@ const ChatPeople = (props: ChatPeopleProps) => {
   useEffect(() => {
     // When unmounting, stop any tracks that might be running
     return () => {
+      trace('ChatPeople stop tracks on unmount');
       // Stop any tracks that might be running.
       stopTracks(audioState.rawMediaSource);
     };
   }, [audioState.rawMediaSource]);
 
   useLayoutEffect(() => {
+    trace('ChatPeople useLayoutEffect', {
+      loading,
+      rtcViewers: rtcViewers.length,
+      viewers: viewers.length,
+      callersExpanded,
+      viewersExpanded,
+      callState,
+      voiceActivityRelative,
+    });
     // Notify parent whenever we might have changed size:
     // * on viewers or rtcViewers counts change
     // * on expand/collapse of the callers or viewers
@@ -450,6 +463,8 @@ const ChatPeople = (props: ChatPeopleProps) => {
     callState,
     voiceActivityRelative,
   ]);
+
+  trace('ChatPeople render', { loading });
 
   if (loading) {
     return null;

--- a/imports/client/tracing.ts
+++ b/imports/client/tracing.ts
@@ -1,0 +1,53 @@
+/* eslint-disable no-console */
+
+// A dumb, mostly-oblivious trace buffer to enable getting some event ordering
+// information out of production, hopefully  without generating terrible
+// overhead or memory usage unless manually enabled by a user.
+
+// Allow initial trace state to be set via localStorage, so we can
+// enable recording traces on initial page load before a human can
+// poke things in the console.
+let TRACING_ENABLED = localStorage.getItem('enableTracing') !== null;
+
+type TraceItem = {
+  stamp: number;
+  args: any;
+}
+
+const eventBuffer: TraceItem[] = [];
+const trace = (...args: any[]) => {
+  if (TRACING_ENABLED) {
+    const now = performance.now();
+    eventBuffer.push({
+      stamp: now,
+      args,
+    });
+    console.log(now, ...args);
+  }
+};
+
+const replayEvents = () => {
+  eventBuffer.forEach(({ stamp, args }) => {
+    console.log(stamp, ...args);
+  });
+};
+
+const begin = () => {
+  TRACING_ENABLED = true;
+};
+
+const end = () => {
+  TRACING_ENABLED = false;
+};
+
+const clear = () => {
+  eventBuffer.splice(0, eventBuffer.length);
+};
+
+const dumpBuffer = () => {
+  console.log(JSON.stringify(eventBuffer));
+};
+
+export {
+  dumpBuffer, eventBuffer, replayEvents, begin, end, clear, trace,
+};


### PR DESCRIPTION
My primary goal here was to have something I could turn on for myself at
runtime from a JS console in production without causing notable
performance degradation or increased memory usage for anyone else.

This has the potential to cause nontrivial memory usage when tracing is
enabled, as I didn't bother dropping traces or capping the trace buffer
size or anything.  I recommend leaving it off unless you're actively
debugging an issue in prod that you're unable to reproduce locally,
which is unfortunately where I am right now with the sidebar scrolling
on page load.

To enable tracing on initial page load, run
`localStorage.setItem("tracingEnabled", 1)` from the browser JS console.

To disable tracing on page load, run
`localStorage.removeItem("tracingEnabled")` from the browser JS console.

The `Tracing` module can be accessed from a global in the browser JS
console after running `await loadFacades()`.  Of particular use for
offline examination is `Tracing.dumpBuffer()`, which will generate a
string which can usually be copied to the clipboard for use elsewhere.

In the second commit, I added `trace()` calls to all the known places that can bottom out in affecting the scroll position of the chat pane on initial render, in hopes of being able to collect some data in prod that would help me understand what sequence of events is triggering the scroll position not being sticky at the bottom, since I'm sadly unable to reproduce the issue locally.