### PR TITLE
Add a puzzle delete button

### DIFF
--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -76,6 +76,7 @@ const PeopleListHeader = styled.header`
 interface ChatPeopleProps {
   huntId: string;
   puzzleId: string;
+  puzzleDeleted: boolean;
   onHeightChange: () => void;
 }
 
@@ -454,14 +455,15 @@ const ChatPeople = (props: ChatPeopleProps) => {
     // * when joining the audiocall
     onHeightChange();
   }, [
-    loading,
     onHeightChange,
+    loading,
     rtcViewers.length,
     viewers.length,
     callersExpanded,
     viewersExpanded,
     callState,
     voiceActivityRelative,
+    props.puzzleDeleted,
   ]);
 
   trace('ChatPeople render', { loading });
@@ -535,7 +537,7 @@ const ChatPeople = (props: ChatPeopleProps) => {
   const viewersHeaderIcon = viewersExpanded ? faCaretDown : faCaretRight;
   return (
     <section className="chatter-section">
-      {!rtcDisabled && callersSubsection}
+      {!rtcDisabled && !props.puzzleDeleted && callersSubsection}
       <div className="chatter-subsection non-av-viewers">
         <PeopleListHeader onClick={toggleViewersExpanded}>
           <FontAwesomeIcon fixedWidth icon={viewersHeaderIcon} />

--- a/imports/client/components/PuzzleDeleteModal.tsx
+++ b/imports/client/components/PuzzleDeleteModal.tsx
@@ -1,0 +1,131 @@
+import { Meteor } from 'meteor/meteor';
+import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
+import React, {
+  Suspense, useCallback, useImperativeHandle, useState,
+} from 'react';
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/esm/Modal';
+import Peers from '../../lib/models/mediasoup/peers';
+import Profiles from '../../lib/models/profiles';
+import Puzzles from '../../lib/models/puzzles';
+import { PuzzleType } from '../../lib/schemas/puzzle';
+import useSubscribeDisplayNames from '../hooks/use-subscribe-display-names';
+import { Subscribers } from '../subscribers';
+import Loading from './Loading';
+
+// Casting away the React.lazy because otherwise we lose access to the generic parameter
+const Select = React.lazy(() => import('react-select')) as typeof import('react-select').default;
+
+export type PuzzleDeleteModalHandle = {
+  show: () => void;
+}
+
+interface PuzzleSelectOption {
+  label: string;
+  value: string;
+}
+
+const PuzzleDeleteModal = React.forwardRef((
+  { puzzle }: { puzzle: PuzzleType },
+  forwardedRef: React.Ref<PuzzleDeleteModalHandle>,
+) => {
+  const [visible, setVisible] = useState(true);
+  const show = useCallback(() => setVisible(true), []);
+  const hide = useCallback(() => setVisible(false), []);
+  useImperativeHandle(forwardedRef, () => ({ show }), [show]);
+
+  const subscriberTopic = `puzzle:${puzzle._id}`;
+  const puzzlesLoading = useSubscribe('mongo.puzzles', { hunt: puzzle.hunt });
+  const viewersLoading = useSubscribe('subscribers.fetch', subscriberTopic);
+  const callersLoading = useSubscribe('mediasoup:metadata', puzzle.hunt, puzzle._id);
+  const displayNamesLoading = useSubscribeDisplayNames();
+  const loading = puzzlesLoading() || viewersLoading() || callersLoading() || displayNamesLoading();
+
+  const puzzles = useTracker(() => (
+    loading ?
+      [] :
+      Puzzles.find({ hunt: puzzle.hunt, _id: { $ne: puzzle._id } }).fetch()
+  ), [loading, puzzle.hunt, puzzle._id]);
+  const viewers = useTracker(() => (
+    loading ?
+      [] :
+      Subscribers.find({ name: subscriberTopic }).fetch()
+  ), [loading, subscriberTopic]);
+  const callers = useTracker(() => (
+    loading ?
+      [] :
+      Peers.find({ hunt: puzzle.hunt, puzzle: puzzle._id }).fetch()
+  ), [loading, puzzle.hunt, puzzle._id]);
+  const displayNames = Profiles.displayNames();
+  const uniqueViewers = [...new Set([
+    ...viewers.map(({ user }) => user),
+    ...callers.map(({ createdBy }) => createdBy),
+  ])]
+    .map((u) => {
+      return { id: u, name: displayNames[u] ?? 'Unknown viewer' };
+    });
+
+  const [replacementId, setReplacementId] = useState<PuzzleSelectOption | null>(null);
+  const setReplacementIdCallback = useCallback((v: PuzzleSelectOption | null) => {
+    return setReplacementId(v);
+  }, []);
+  const replacementOptions: PuzzleSelectOption[] = [
+    ...puzzles.map((p) => ({ label: p.title, value: p._id })),
+  ];
+
+  const deletePuzzle = useCallback(() => {
+    Meteor.call('deletePuzzle', puzzle._id, replacementId?.value);
+    // Hide immediately before the component gets unmounted
+    hide();
+  }, [puzzle._id, replacementId?.value, hide]);
+
+  return (
+    <Modal show={visible} onHide={hide}>
+      <Modal.Header closeButton>
+        <Modal.Title>Delete Puzzle</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Suspense fallback={<div><Loading inline /></div>}>
+          <p>
+            Are you sure you want to delete this puzzle? Anyone actively
+            working on this puzzle will lose the ability to make further edits
+            or chat comments.
+          </p>
+          <p>
+            You can optionally specify a replacement to be used instead of this puzzle
+          </p>
+          <p>
+            <Select
+              options={replacementOptions}
+              value={replacementId}
+              onChange={setReplacementIdCallback}
+            />
+          </p>
+          <p>
+            This puzzle is currently being viewed by
+            {' '}
+            {uniqueViewers.length}
+            {' '}
+            {uniqueViewers.length === 1 ? 'person' : 'people'}
+            {uniqueViewers.length > 0 && ':'}
+          </p>
+          <ul>
+            {uniqueViewers.map(({ id, name }) => (
+              <li key={id}>{name}</li>
+            ))}
+          </ul>
+        </Suspense>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="secondary" onClick={hide}>
+          Cancel
+        </Button>
+        <Button variant="danger" onClick={deletePuzzle}>
+          Delete
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+});
+
+export default PuzzleDeleteModal;

--- a/imports/lib/schemas/puzzle.ts
+++ b/imports/lib/schemas/puzzle.ts
@@ -11,6 +11,7 @@ const PuzzleFields = t.type({
   url: t.union([t.string, t.undefined]),
   answers: t.array(t.string),
   expectedAnswerCount: t.number,
+  replacedBy: t.union([t.string, t.undefined]),
 });
 
 const PuzzleFieldsOverrides: Overrides<t.TypeOf<typeof PuzzleFields>> = {
@@ -36,6 +37,9 @@ const PuzzleFieldsOverrides: Overrides<t.TypeOf<typeof PuzzleFields>> = {
 
       return undefined;
     },
+  },
+  replacedBy: {
+    regEx: SimpleSchema.RegEx.Id,
   },
 };
 


### PR DESCRIPTION
Operators are now allowed to delete puzzles. When they do, they can
optionally specify another puzzle that hunters should treat as its
replacement. When a puzzle is deleted, chat and guesses are disabled,
all edit permissions are revoked from the shared Google document, and a
modal pops up advising hunters that the puzzle is deleted and now
read-only.

Deleted puzzles show up in the operators' puzzle list view at the very
bottom in an independent group, and the modal on the individual puzzle
page has a "undelete" button in case of error.

Fixes #425.

Here are some screenshots

<img width="960" alt="image" src="https://user-images.githubusercontent.com/28167/149407566-b3377bfa-5e3e-45b5-aa09-378b91474ab7.png">
<img width="960" alt="image" src="https://user-images.githubusercontent.com/28167/149407615-b5a1c863-de71-4588-b6bd-dbbf1689a410.png">
<img width="960" alt="image" src="https://user-images.githubusercontent.com/28167/149407644-8d77898b-6cc5-44b7-92fa-8f3fb6008dfc.png">
<img width="960" alt="image" src="https://user-images.githubusercontent.com/28167/149407672-6c5e6372-2594-45f0-864a-1625f553deb1.png">
