### PR TITLE
Show puzzle age & recent voice activity next to viewer count

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -66,9 +66,9 @@ $administrivia-puzzle-background-color: #dfdfff;
     text-align: center;
   }
 
-  .puzzle-view-count {
-    width: 5ch;
-    text-align: center;
+  .puzzle-activity {
+    width: 12ch;
+    text-align: right;
   }
 
   .puzzle-answer {

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -13,9 +13,9 @@ import { Link } from 'react-router-dom';
 import Ansible from '../../ansible';
 import { PuzzleType } from '../../lib/schemas/puzzle';
 import { TagType } from '../../lib/schemas/tag';
+import PuzzleActivity from './PuzzleActivity';
 import PuzzleAnswer from './PuzzleAnswer';
 import PuzzleModalForm, { PuzzleModalFormSubmitPayload } from './PuzzleModalForm';
-import SubscriberCount from './SubscriberCount';
 import TagList from './TagList';
 
 interface PuzzleProps {
@@ -121,8 +121,8 @@ const Puzzle = React.memo((props: PuzzleProps) => {
       <div className="puzzle-column puzzle-title">
         <Link to={linkTarget}>{props.puzzle.title}</Link>
       </div>
-      <div className="puzzle-column puzzle-view-count">
-        {!(props.puzzle.answers.length >= props.puzzle.expectedAnswerCount) && <SubscriberCount puzzleId={props.puzzle._id} />}
+      <div className="puzzle-column puzzle-activity">
+        {!(props.puzzle.answers.length >= props.puzzle.expectedAnswerCount) && <PuzzleActivity huntId={props.puzzle.hunt} puzzleId={props.puzzle._id} unlockTime={props.puzzle.createdAt} />}
       </div>
       <div className="puzzle-column puzzle-link">
         {props.puzzle.url ? (

--- a/imports/client/components/PuzzleActivity.tsx
+++ b/imports/client/components/PuzzleActivity.tsx
@@ -1,0 +1,115 @@
+import { Meteor } from 'meteor/meteor';
+import { useTracker } from 'meteor/react-meteor-data';
+import { faVolumeDown } from '@fortawesome/free-solid-svg-icons/faVolumeDown';
+import { faVolumeOff } from '@fortawesome/free-solid-svg-icons/faVolumeOff';
+import { faVolumeUp } from '@fortawesome/free-solid-svg-icons/faVolumeUp';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React, { useEffect, useState } from 'react';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+import styled from 'styled-components';
+import { RECENT_ACTIVITY_TIME_WINDOW_MS } from '../../lib/config/webrtc';
+import CallHistories from '../../lib/models/mediasoup/call_histories';
+import relativeTimeFormat, { terseRelativeTimeFormat } from '../../lib/relativeTimeFormat';
+import SubscriberCount from './SubscriberCount';
+
+const PuzzleActivitySpan = styled.span`
+  font-size: 14px;
+  color: #666666;
+`;
+
+const LastActiveSpan = styled.span`
+  display: inline-block;
+  text-align: left;
+  width: 1em;
+  margin-left: 2px;
+  margin-right: 2px;
+`;
+
+interface PuzzleActivityProps {
+  huntId: string;
+  puzzleId: string;
+  unlockTime: Date;
+}
+
+// For how long after the last audio detected should we indicate "recent audio presence"?
+// Currently set to 10 minutes.
+const RECENTLY_ACTIVE_INTERVAL = 10 * 60 * 1000;
+
+const PuzzleActivity = ({ huntId, puzzleId, unlockTime }: PuzzleActivityProps) => {
+  const callLastActive = useTracker(() => {
+    return CallHistories.findOne({ hunt: huntId, call: puzzleId })?.lastActivity;
+  }, [huntId, puzzleId]);
+
+  const [lastActiveRelative, setLastActiveRelative] = useState<string>();
+  const [lastActiveRecent, setLastActiveRecent] = useState<boolean>();
+
+  const [unlockTimeRelative, setUnlockTimeRelative] = useState<string>('');
+
+  useEffect(() => {
+    const lastActiveFormatter = () => {
+      if (callLastActive) {
+        return relativeTimeFormat(callLastActive, { minimumUnit: 'minute' });
+      }
+      return undefined;
+    };
+    const unlockTimeFormatter = () => terseRelativeTimeFormat(unlockTime, { minimumUnit: 'minute' });
+    setUnlockTimeRelative(unlockTimeFormatter());
+    if (callLastActive) {
+      setLastActiveRecent(Date.now() - callLastActive.getTime() < RECENTLY_ACTIVE_INTERVAL);
+      setLastActiveRelative(lastActiveFormatter());
+    }
+
+    const interval = Meteor.setInterval(() => {
+      setUnlockTimeRelative(unlockTimeFormatter());
+      if (callLastActive) {
+        setLastActiveRecent(Date.now() - callLastActive.getTime() < RECENTLY_ACTIVE_INTERVAL);
+        setLastActiveRelative(lastActiveFormatter());
+      }
+    }, RECENT_ACTIVITY_TIME_WINDOW_MS);
+
+    return () => {
+      if (interval) {
+        Meteor.clearInterval(interval);
+      }
+    };
+  }, [unlockTime, callLastActive]);
+
+  const unlockTooltip = (
+    <Tooltip id={`puzzle-activity-unlock-${puzzleId}`}>
+      Puzzle age (time since creation)
+    </Tooltip>
+  );
+
+  const audioTooltipText = callLastActive ? `Call last active ${lastActiveRelative}` : 'Call never used';
+  const audioTooltip = (
+    <Tooltip id={`puzzle-activity-audio-${puzzleId}`}>
+      {audioTooltipText}
+    </Tooltip>
+  );
+
+  let icon = faVolumeOff;
+  if (callLastActive) {
+    if (lastActiveRecent) {
+      icon = faVolumeUp;
+    } else {
+      icon = faVolumeDown;
+    }
+  }
+
+  return (
+    <PuzzleActivitySpan>
+      <OverlayTrigger placement="top" overlay={unlockTooltip}>
+        <span>{unlockTimeRelative}</span>
+      </OverlayTrigger>
+      <OverlayTrigger placement="top" overlay={audioTooltip}>
+        <LastActiveSpan>
+          <FontAwesomeIcon icon={icon} />
+        </LastActiveSpan>
+      </OverlayTrigger>
+      <SubscriberCount puzzleId={puzzleId} />
+    </PuzzleActivitySpan>
+  );
+};
+
+export default PuzzleActivity;

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -419,7 +419,8 @@ const PuzzleListPage = () => {
   const tagsLoading = useSubscribe('mongo.tags', { hunt: huntId });
   const loading = puzzlesLoading() || tagsLoading();
 
-  // Don't bother including this in loading - it's ok if it trickles in
+  // Don't bother including these in loading - it's ok if they trickle in
+  useSubscribe('mongo.mediasoup_call_histories', { hunt: huntId });
   useSubscribe('subscribers.counts', { hunt: huntId });
 
   // Assertion is safe because hunt is already subscribed and checked by HuntApp

--- a/imports/lib/relativeTimeFormat.ts
+++ b/imports/lib/relativeTimeFormat.ts
@@ -1,10 +1,48 @@
+/* eslint-disable object-curly-newline */
 const timeUnits = [
-  { millis: 1000, singular: 'second', plural: 'seconds' },
-  { millis: 60 * 1000, singular: 'minute', plural: 'minutes' },
-  { millis: 60 * 60 * 1000, singular: 'hour', plural: 'hours' },
-  { millis: 24 * 60 * 60 * 1000, singular: 'day', plural: 'days' },
-  { millis: 365 * 24 * 60 * 60 * 1000, singular: 'year', plural: 'years' },
+  { millis: 1000, singular: 'second', plural: 'seconds', terse: 's' },
+  { millis: 60 * 1000, singular: 'minute', plural: 'minutes', terse: 'm' },
+  { millis: 60 * 60 * 1000, singular: 'hour', plural: 'hours', terse: 'h' },
+  { millis: 24 * 60 * 60 * 1000, singular: 'day', plural: 'days', terse: 'd' },
+  { millis: 365 * 24 * 60 * 60 * 1000, singular: 'year', plural: 'years', terse: 'y' },
 ].reverse();
+/* eslint-enable object-curly-newline */
+
+export function terseRelativeTimeFormat(d: Date, opts: {
+  minimumUnit?: 'second' | 'minute' | 'hour' | 'day' | 'year',
+  now?: Date,
+} = {}) {
+  const {
+    minimumUnit = 'seconds',
+    now = new Date(),
+  } = opts;
+  const diff = now.getTime() - d.getTime();
+  let remainder = Math.abs(diff);
+  const terms = [] as string[];
+  let stop = false;
+
+  timeUnits.forEach(({ millis, singular, terse }) => {
+    if (stop) {
+      return;
+    }
+
+    const count = Math.floor(remainder / millis);
+    if (count > 0) {
+      terms.push(`${count}${terse}`);
+    }
+    remainder %= millis;
+
+    if (minimumUnit === singular) {
+      stop = true;
+    }
+  });
+
+  if (terms.length === 0) {
+    return 'now';
+  }
+
+  return terms.join('');
+}
 
 export default function relativeTimeFormat(d: Date, opts: {
   complete?: boolean,


### PR DESCRIPTION
In the interest of showing more context about each puzzle on the puzzle
list page, for unsolved puzzles, next to the subscriber count, we've added:

* time since unlock, which is nice to peruse to see what puzzles are
  older and how long they've been there
* an icon indicating time since last voice detected in the audio call

These generally aren't the most important data on the page, though, so
I've made them slightly smaller font and muted in color, so as to reduce
the space they take up and the amount they draw the eye.

Fixes #299.

Example:
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/307325/149495453-9b46bbcb-e55d-4cba-b483-f5bec24326d3.png">

Tooltips:
<img width="833" alt="image" src="https://user-images.githubusercontent.com/307325/149495650-192ed6e3-05f7-4127-9416-b244b4ee3618.png">

<img width="833" alt="image" src="https://user-images.githubusercontent.com/307325/149495699-139f98cc-a53f-448f-8c19-18147353b7a4.png">

<img width="833" alt="image" src="https://user-images.githubusercontent.com/307325/149495719-65833834-f110-4fa4-8db4-444e836690f3.png">

<img width="833" alt="image" src="https://user-images.githubusercontent.com/307325/149495745-fae178fc-bcab-4dc6-bb1c-9d9937c395fa.png">

