### PR TITLE
Use destructuring assignment for React props

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -113,7 +113,6 @@
       "functions": "ignore"
     }],
     "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
-    "react/destructuring-assignment": ["off"],
     "react/function-component-definition": ["error", {
       "namedComponents": "arrow-function"
     }],

--- a/imports/client/components/AccountForm.tsx
+++ b/imports/client/components/AccountForm.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 /* eslint-disable max-len, jsx-a11y/anchor-is-valid, jsx-a11y/label-has-associated-control, jsx-a11y/label-has-for */
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';

--- a/imports/client/components/AnnouncementsPage.tsx
+++ b/imports/client/components/AnnouncementsPage.tsx
@@ -15,10 +15,6 @@ import { useBreadcrumb } from '../hooks/breadcrumb';
 import useSubscribeDisplayNames from '../hooks/use-subscribe-display-names';
 import markdown from '../markdown';
 
-interface AnnouncementFormProps {
-  huntId: string;
-}
-
 enum AnnouncementFormSubmitState {
   IDLE = 'idle',
   SUBMITTING = 'submitting',
@@ -45,7 +41,7 @@ const AnnouncementFormContainer = styled.div`
   }
 `;
 
-const AnnouncementForm = (props: AnnouncementFormProps) => {
+const AnnouncementForm = ({ huntId }: { huntId: string }) => {
   const [message, setMessage] = useState<string>('');
   const [submitState, setSubmitState] = useState<AnnouncementFormSubmitState>(AnnouncementFormSubmitState.IDLE);
   const [errorMessage, setErrorMessage] = useState<string>('');
@@ -57,7 +53,7 @@ const AnnouncementForm = (props: AnnouncementFormProps) => {
   const postAnnouncement = useCallback(() => {
     if (message) {
       setSubmitState(AnnouncementFormSubmitState.SUBMITTING);
-      Meteor.call('postAnnouncement', props.huntId, message, (error?: Error) => {
+      Meteor.call('postAnnouncement', huntId, message, (error?: Error) => {
         if (error) {
           setErrorMessage(error.message);
           setSubmitState(AnnouncementFormSubmitState.FAILED);
@@ -67,7 +63,7 @@ const AnnouncementForm = (props: AnnouncementFormProps) => {
         }
       });
     }
-  }, [message, props.huntId]);
+  }, [message, huntId]);
 
   return (
     <AnnouncementFormContainer>
@@ -92,11 +88,6 @@ const AnnouncementForm = (props: AnnouncementFormProps) => {
   );
 };
 
-interface AnnouncementProps {
-  announcement: AnnouncementType;
-  displayName: string;
-}
-
 const AnnouncementContainer = styled.div`
   margin-top: 8px;
   margin-bottom: 8px;
@@ -112,8 +103,10 @@ const AnnouncementTimestamp = styled.div`
   text-align: right;
 `;
 
-const Announcement = (props: AnnouncementProps) => {
-  const ann = props.announcement;
+const Announcement = ({ announcement, displayName }: {
+  announcement: AnnouncementType, displayName: string,
+}) => {
+  const ann = announcement;
 
   // TODO: All the styles here could stand to be improved, but this gets it on the screen in a
   // minimally-offensive manner, and preserves the intent of newlines.
@@ -121,7 +114,7 @@ const Announcement = (props: AnnouncementProps) => {
     <AnnouncementContainer>
       <AnnouncementOrigin>
         <AnnouncementTimestamp>{calendarTimeFormat(ann.createdAt)}</AnnouncementTimestamp>
-        <div>{props.displayName}</div>
+        <div>{displayName}</div>
       </AnnouncementOrigin>
       <div
         // eslint-disable-next-line react/no-danger

--- a/imports/client/components/Celebration.tsx
+++ b/imports/client/components/Celebration.tsx
@@ -2,14 +2,6 @@ import React, { useCallback, useEffect, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-interface CelebrationProps {
-  url: string;
-  title: string;
-  answer: string;
-  playAudio: boolean;
-  onClose: () => void;
-}
-
 const CelebrationOverlay = styled.div`
   position: fixed;
   left: 0;
@@ -36,10 +28,16 @@ const CelebrationCloseButton = styled.button`
   right: 0;
 `;
 
-const Celebration = (props: CelebrationProps) => {
+const Celebration = ({
+  url, title, answer, playAudio, onClose,
+}: {
+  url: string;
+  title: string;
+  answer: string;
+  playAudio: boolean;
+  onClose: () => void;
+}) => {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
-
-  const { onClose } = props;
 
   const onCloseCb = useCallback(() => {
     if (onClose) {
@@ -91,17 +89,17 @@ const Celebration = (props: CelebrationProps) => {
         <CelebrationCloseButton type="button" onClick={onCloseCb} aria-label="Close" ref={closeButtonRef}>
           <span aria-hidden="true">×</span>
         </CelebrationCloseButton>
-        {props.playAudio ? <audio src="/audio/applause.mp3" autoPlay /> : null}
+        {playAudio ? <audio src="/audio/applause.mp3" autoPlay /> : null}
         <h1>
           We solved
           {' '}
-          <Link to={props.url}>{props.title}</Link>
+          <Link to={url}>{title}</Link>
           !
         </h1>
         <h2>
           Answer:
           {' '}
-          <span className="answer">{props.answer}</span>
+          <span className="answer">{answer}</span>
         </h2>
       </CelebrationContainer>
     </CelebrationOverlay>

--- a/imports/client/components/CelebrationCenter.tsx
+++ b/imports/client/components/CelebrationCenter.tsx
@@ -8,10 +8,6 @@ import Puzzles from '../../lib/models/puzzles';
 import { PuzzleType } from '../../lib/schemas/puzzle';
 import Celebration from './Celebration';
 
-interface CelebrationCenterProps {
-  huntId: string;
-}
-
 interface CelebrationCenterQueueItem {
   puzzleId: string;
   url: string;
@@ -19,11 +15,11 @@ interface CelebrationCenterQueueItem {
   title: string;
 }
 
-const CelebrationCenter = (props: CelebrationCenterProps) => {
+const CelebrationCenter = ({ huntId }: { huntId: string }) => {
   const [playbackQueue, setPlaybackQueue] = useState<CelebrationCenterQueueItem[]>([]);
 
   // This should be effectively a noop, since we're already fetching it for every hunt
-  useSubscribe('mongo.puzzles', { hunt: props.huntId });
+  useSubscribe('mongo.puzzles', { hunt: huntId });
 
   const disabled = useTracker(() => Flags.active('disable.applause'), []);
   const muted = useTracker(() => !!(Profiles.findOne({ _id: Meteor.userId()! })?.muteApplause), []);

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -73,13 +73,6 @@ const PeopleListHeader = styled.header`
   text-indent: -1rem;
 `;
 
-interface ChatPeopleProps {
-  huntId: string;
-  puzzleId: string;
-  puzzleDeleted: boolean;
-  onHeightChange: () => void;
-}
-
 enum CallState {
   CHAT_ONLY = 'chatonly',
   REQUESTING_STREAM = 'requestingstream',
@@ -131,7 +124,14 @@ function participantState(explicitlyMuted: boolean, deafened: boolean) {
 
 // ChatPeople is the component that deals with all user presence and
 // WebRTC call subscriptions, state, and visualization.
-const ChatPeople = (props: ChatPeopleProps) => {
+const ChatPeople = ({
+  huntId, puzzleId, puzzleDeleted, onHeightChange,
+}: {
+  huntId: string;
+  puzzleId: string;
+  puzzleDeleted: boolean;
+  onHeightChange: () => void;
+}) => {
   const [callState, setCallState] = useState<CallState>(CallState.CHAT_ONLY);
   const [error, setError] = useState<string>('');
 
@@ -149,8 +149,6 @@ const ChatPeople = (props: ChatPeopleProps) => {
     gainNode: undefined,
     leveledStreamSource: undefined,
   });
-
-  const { huntId, puzzleId, onHeightChange } = props;
 
   const subscriberTopic = `puzzle:${puzzleId}`;
   const subscribersLoading = useSubscribe('subscribers.fetch', subscriberTopic);
@@ -463,7 +461,7 @@ const ChatPeople = (props: ChatPeopleProps) => {
     viewersExpanded,
     callState,
     voiceActivityRelative,
-    props.puzzleDeleted,
+    puzzleDeleted,
   ]);
 
   trace('ChatPeople render', { loading });
@@ -537,7 +535,7 @@ const ChatPeople = (props: ChatPeopleProps) => {
   const viewersHeaderIcon = viewersExpanded ? faCaretDown : faCaretRight;
   return (
     <section className="chatter-section">
-      {!rtcDisabled && !props.puzzleDeleted && callersSubsection}
+      {!rtcDisabled && !puzzleDeleted && callersSubsection}
       <div className="chatter-subsection non-av-viewers">
         <PeopleListHeader onClick={toggleViewersExpanded}>
           <FontAwesomeIcon fixedWidth icon={viewersHeaderIcon} />

--- a/imports/client/components/ConnectionStatus.tsx
+++ b/imports/client/components/ConnectionStatus.tsx
@@ -7,14 +7,8 @@ import Button from 'react-bootstrap/Button';
 import styled from 'styled-components';
 import Ansible from '../../ansible';
 
-interface WaitingAlertProps {
-  retryTime: DDP.DDPStatus['retryTime'];
-}
-
-const WaitingAlert = (props: WaitingAlertProps) => {
-  const now = Date.now();
-  const retryTime = props.retryTime || now;
-  const [lastUpdated, setLastUpdated] = useState<number>(now);
+const WaitingAlert = ({ retryTime = Date.now() }: { retryTime: DDP.DDPStatus['retryTime'] }) => {
+  const [lastUpdated, setLastUpdated] = useState<number>(Date.now());
 
   useEffect(() => {
     const timer = window.setInterval(() => {

--- a/imports/client/components/DeepLink.tsx
+++ b/imports/client/components/DeepLink.tsx
@@ -19,14 +19,16 @@ type DeepLinkState = {
   startNativeLoad: Date;
 };
 
-const DeepLinkHook = (props: DeepLinkProps) => {
+const DeepLinkHook = ({
+  children, nativeUrl, browserUrl, ...rest
+}: DeepLinkProps) => {
   const [state, setState] = useState<DeepLinkState>({
     state: DeepLinkLoadState.IDLE,
   });
 
   const browserOpen = useCallback(() => {
-    window.open(props.browserUrl, '_blank');
-  }, [props.browserUrl]);
+    window.open(browserUrl, '_blank');
+  }, [browserUrl]);
 
   const onAttemptingNativeTimeout = useCallback(() => {
     if (state.state === DeepLinkLoadState.IDLE) {
@@ -52,13 +54,10 @@ const DeepLinkHook = (props: DeepLinkProps) => {
 
   const nativeIframe = () => {
     return (
-      <iframe title="Open document" width="1px" height="1px" src={props.nativeUrl} />
+      <iframe title="Open document" width="1px" height="1px" src={nativeUrl} />
     );
   };
 
-  const {
-    children, nativeUrl, browserUrl, ...rest
-  } = props;
   return (
     <div onClick={onClick} {...rest}>
       {state.state === 'attemptingNative' && nativeIframe()}

--- a/imports/client/components/Documents.tsx
+++ b/imports/client/components/Documents.tsx
@@ -11,20 +11,20 @@ interface DocumentDisplayProps {
   displayMode: 'link' | 'embed';
 }
 
-const GoogleDocumentDisplay = (props: DocumentDisplayProps) => {
+const GoogleDocumentDisplay = ({ document, displayMode }: DocumentDisplayProps) => {
   let url: string;
   let deepUrl: string;
   let title: string;
   let icon: IconDefinition;
-  switch (props.document.value.type) {
+  switch (document.value.type) {
     case 'spreadsheet':
-      url = `https://docs.google.com/spreadsheets/d/${props.document.value.id}/edit?ui=2&rm=embedded#gid=0`;
+      url = `https://docs.google.com/spreadsheets/d/${document.value.id}/edit?ui=2&rm=embedded#gid=0`;
       deepUrl = `googlesheets://${url}`;
       title = 'Sheet';
       icon = faTable;
       break;
     case 'document':
-      url = `https://docs.google.com/document/d/${props.document.value.id}/edit?ui=2&rm=embedded#gid=0`;
+      url = `https://docs.google.com/document/d/${document.value.id}/edit?ui=2&rm=embedded#gid=0`;
       deepUrl = `googledocs://${url}`;
       title = 'Doc';
       icon = faFileAlt;
@@ -34,12 +34,12 @@ const GoogleDocumentDisplay = (props: DocumentDisplayProps) => {
         <span className="puzzle-document-message">
           Don&apos;t know how to link to a document of type
           {' '}
-          {props.document.value.type}
+          {document.value.type}
         </span>
       );
   }
 
-  switch (props.displayMode) {
+  switch (displayMode) {
     case 'link':
       return (
         <DeepLink className="gdrive-button" nativeUrl={deepUrl} browserUrl={url}>
@@ -60,19 +60,19 @@ const GoogleDocumentDisplay = (props: DocumentDisplayProps) => {
         <span className="puzzle-document-message">
           Unknown displayMode
           {' '}
-          {props.displayMode}
+          {displayMode}
         </span>
       );
   }
 };
 
-const DocumentDisplay = (props: DocumentDisplayProps) => {
-  switch (props.document.provider) {
+const DocumentDisplay = ({ document, displayMode }: DocumentDisplayProps) => {
+  switch (document.provider) {
     case 'google':
       return (
         <GoogleDocumentDisplay
-          document={props.document}
-          displayMode={props.displayMode}
+          document={document}
+          displayMode={displayMode}
         />
       );
     default:
@@ -80,7 +80,7 @@ const DocumentDisplay = (props: DocumentDisplayProps) => {
         <span className="puzzle-document-message">
           Unable to display document from provider
           {' '}
-          {props.document.provider}
+          {document.provider}
         </span>
       );
   }

--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -24,11 +24,7 @@ import { useBreadcrumb } from '../hooks/breadcrumb';
 import useSubscribeDisplayNames from '../hooks/use-subscribe-display-names';
 import Breakable from './styling/Breakable';
 
-interface AutoSelectInputProps {
-  value: string;
-}
-
-const AutoSelectInput = (props: AutoSelectInputProps) => {
+const AutoSelectInput = ({ value }: { value: string }) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const onFocus = useCallback(() => {
     // Use the selection API to select the contents of this, for easier clipboarding.
@@ -41,21 +37,13 @@ const AutoSelectInput = (props: AutoSelectInputProps) => {
     <input
       ref={inputRef}
       readOnly
-      value={props.value}
+      value={value}
       onFocus={onFocus}
     />
   );
 };
 
 const daysOfWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
-
-interface GuessBlockProps {
-  canEdit: boolean;
-  hunt: HuntType;
-  guess: GuessType;
-  createdByDisplayName: string;
-  puzzle: PuzzleType;
-}
 
 const StyledGuessBlock = styled.div<{ $state: GuessType['state'] }>`
   margin-bottom: 8px;
@@ -134,24 +122,31 @@ const formatDate = (date: Date) => {
   return `${date.toLocaleTimeString()} on ${day}`;
 };
 
-const GuessBlock = React.memo((props: GuessBlockProps) => {
+const GuessBlock = React.memo(({
+  canEdit, hunt, guess, createdByDisplayName, puzzle,
+}: {
+  canEdit: boolean;
+  hunt: HuntType;
+  guess: GuessType;
+  createdByDisplayName: string;
+  puzzle: PuzzleType;
+}) => {
   const markPending = useCallback(() => {
-    Meteor.call('markGuessPending', props.guess._id);
-  }, [props.guess._id]);
+    Meteor.call('markGuessPending', guess._id);
+  }, [guess._id]);
 
   const markCorrect = useCallback(() => {
-    Meteor.call('markGuessCorrect', props.guess._id);
-  }, [props.guess._id]);
+    Meteor.call('markGuessCorrect', guess._id);
+  }, [guess._id]);
 
   const markIncorrect = useCallback(() => {
-    Meteor.call('markGuessIncorrect', props.guess._id);
-  }, [props.guess._id]);
+    Meteor.call('markGuessIncorrect', guess._id);
+  }, [guess._id]);
 
   const markRejected = useCallback(() => {
-    Meteor.call('markGuessRejected', props.guess._id);
-  }, [props.guess._id]);
+    Meteor.call('markGuessRejected', guess._id);
+  }, [guess._id]);
 
-  const guess = props.guess;
   const timestamp = formatDate(guess.createdAt);
   const guessButtons = (
     <StyledGuessButtonGroup>
@@ -168,13 +163,13 @@ const GuessBlock = React.memo((props: GuessBlockProps) => {
         <div>
           {timestamp}
           {' from '}
-          <Breakable>{props.createdByDisplayName || '<no name given>'}</Breakable>
+          <Breakable>{createdByDisplayName || '<no name given>'}</Breakable>
         </div>
         <div>
           {'Puzzle: '}
-          <a href={guessURL(props.hunt, props.puzzle)} target="_blank" rel="noopener noreferrer">{props.puzzle.title}</a>
+          <a href={guessURL(hunt, puzzle)} target="_blank" rel="noopener noreferrer">{puzzle.title}</a>
           {' ('}
-          <Link to={`/hunts/${props.puzzle.hunt}/puzzles/${props.puzzle._id}`}>discussion</Link>
+          <Link to={`/hunts/${puzzle.hunt}/puzzles/${puzzle._id}`}>discussion</Link>
           )
         </div>
         <div>
@@ -187,7 +182,7 @@ const GuessBlock = React.memo((props: GuessBlockProps) => {
         </div>
         <div><AutoSelectInput value={guess.guess} /></div>
       </StyledGuessInfo>
-      {props.canEdit ? guessButtons : <StyledGuessButtonGroup>{guess.state}</StyledGuessButtonGroup>}
+      {canEdit ? guessButtons : <StyledGuessButtonGroup>{guess.state}</StyledGuessButtonGroup>}
     </StyledGuessBlock>
   );
 });

--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -21,18 +21,16 @@ import HuntProfileListPage from './HuntProfileListPage';
 import PuzzleListPage from './PuzzleListPage';
 import PuzzlePage from './PuzzlePage';
 
-interface HuntDeletedErrorProps {
+const HuntDeletedError = React.memo(({ hunt, canUndestroy }: {
   hunt: HuntType;
   canUndestroy: boolean;
-}
-
-const HuntDeletedError = React.memo((props: HuntDeletedErrorProps) => {
+}) => {
   const undestroy = useCallback(() => {
-    Hunts.undestroy(props.hunt._id);
-  }, [props.hunt._id]);
+    Hunts.undestroy(hunt._id);
+  }, [hunt._id]);
 
   const undestroyButton = useMemo(() => {
-    if (props.canUndestroy) {
+    if (canUndestroy) {
       return (
         <Button variant="primary" onClick={undestroy}>
           Undelete this hunt
@@ -40,7 +38,7 @@ const HuntDeletedError = React.memo((props: HuntDeletedErrorProps) => {
       );
     }
     return null;
-  }, [props.canUndestroy, undestroy]);
+  }, [canUndestroy, undestroy]);
 
   const navigate = useNavigate();
   const goBack = useCallback(() => navigate(-1), [navigate]);
@@ -61,22 +59,20 @@ const HuntDeletedError = React.memo((props: HuntDeletedErrorProps) => {
   );
 });
 
-interface HuntMemberErrorProps {
+const HuntMemberError = React.memo(({ hunt, canJoin }: {
   hunt: HuntType;
   canJoin: boolean;
-}
-
-const HuntMemberError = React.memo((props: HuntMemberErrorProps) => {
+}) => {
   const join = useCallback(() => {
     const user = Meteor.user();
     if (!user || !user.emails) {
       return;
     }
-    Meteor.call('addToHunt', props.hunt._id, user.emails[0].address);
-  }, [props.hunt._id]);
+    Meteor.call('addToHunt', hunt._id, user.emails[0].address);
+  }, [hunt._id]);
 
   const joinButton = useMemo(() => {
-    if (props.canJoin) {
+    if (canJoin) {
       return (
         <Button variant="primary" onClick={join}>
           Use operator permissions to join
@@ -84,17 +80,17 @@ const HuntMemberError = React.memo((props: HuntMemberErrorProps) => {
       );
     }
     return null;
-  }, [props.canJoin, join]);
+  }, [canJoin, join]);
 
   const navigate = useNavigate();
   const goBack = useCallback(() => navigate(-1), [navigate]);
 
-  const msg = markdown(props.hunt.signupMessage || '');
+  const msg = markdown(hunt.signupMessage || '');
   return (
     <div>
       <Alert variant="warning">
         You&apos;re not signed up for this hunt (
-        {props.hunt.name}
+        {hunt.name}
         ) yet.
       </Alert>
 

--- a/imports/client/components/LabelledRadioGroup.tsx
+++ b/imports/client/components/LabelledRadioGroup.tsx
@@ -15,7 +15,12 @@ const Radio = styled.input`
   margin: 8px;
 `;
 
-interface LabelledRadioProps {
+// Bootstrap's approach to exclusive options does not look particularly good nor
+// does it produce accessibility-friendly markup, so here's a touch of our own
+// instead.  Uses some bootstrap styles.
+const LabelledRadio = ({
+  id, name, value, label, defaultChecked, onChange,
+}: {
   id: string;
   // eslint-disable-next-line no-restricted-globals
   // The name of the exclusive group for the radio buttons
@@ -24,28 +29,25 @@ interface LabelledRadioProps {
   label: string;
   defaultChecked: boolean;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-}
-
-// Bootstrap's approach to exclusive options does not look particularly good nor
-// does it produce accessibility-friendly markup, so here's a touch of our own
-// instead.  Uses some bootstrap styles.
-const LabelledRadio = (props: LabelledRadioProps) => {
+}) => {
   return (
-    <RadioLabel htmlFor={props.id}>
+    <RadioLabel htmlFor={id}>
       <Radio
-        id={props.id}
+        id={id}
         type="radio"
-        name={props.name}
-        onChange={props.onChange}
-        value={props.value}
-        defaultChecked={!!props.defaultChecked}
+        name={name}
+        onChange={onChange}
+        value={value}
+        defaultChecked={!!defaultChecked}
       />
-      {props.label}
+      {label}
     </RadioLabel>
   );
 };
 
-interface LabelledRadioGroupProps {
+const LabelledRadioGroup = ({
+  header, name, options, onChange, initialValue, help,
+}: {
   header: string;
   // eslint-disable-next-line no-restricted-globals
   name: string; // The name of the exclusive group for the radio buttons
@@ -53,12 +55,8 @@ interface LabelledRadioGroupProps {
   onChange: (value: string) => void;
   initialValue: string;
   help: string;
-}
-
-const LabelledRadioGroup = (props: LabelledRadioGroupProps) => {
-  const [value, setValue] = useState<string>(props.initialValue);
-
-  const { onChange } = props;
+}) => {
+  const [value, setValue] = useState<string>(initialValue);
 
   const onValueChanged = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     const v = event.target.value;
@@ -66,12 +64,12 @@ const LabelledRadioGroup = (props: LabelledRadioGroupProps) => {
     onChange(v);
   }, [onChange]);
 
-  const buttons = props.options.map((option, index) => {
+  const buttons = options.map((option, index) => {
     return (
       <LabelledRadio
-        id={`radiobutton-${props.name}-${index}`}
+        id={`radiobutton-${name}-${index}`}
         key={option.value}
-        name={props.name}
+        name={name}
         onChange={onValueChanged}
         label={option.label}
         value={option.value}
@@ -81,11 +79,11 @@ const LabelledRadioGroup = (props: LabelledRadioGroupProps) => {
   });
   return (
     <div className="radio-group">
-      <RadioHeader>{props.header}</RadioHeader>
+      <RadioHeader>{header}</RadioHeader>
       <fieldset>
         {buttons}
       </fieldset>
-      {props.help && <span className="help-block">{props.help}</span>}
+      {help && <span className="help-block">{help}</span>}
     </div>
   );
 };

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -107,12 +107,10 @@ const StyledNotificationActionItem = styled.li`
   }
 `;
 
-interface MessengerDismissButtonProps {
+const MessengerDismissButton = React.memo(({ onDismiss }: {
   onDismiss: (event: React.MouseEvent<HTMLButtonElement>) => void;
-}
-
-const MessengerDismissButton = React.memo((props: MessengerDismissButtonProps) => {
-  return <StyledDismissButton type="button" onClick={props.onDismiss}>×</StyledDismissButton>;
+}) => {
+  return <StyledDismissButton type="button" onClick={onDismiss}>×</StyledDismissButton>;
 });
 
 const MessengerContent = styled.div`
@@ -149,19 +147,15 @@ const MessengerSpinner = React.memo(() => {
   );
 });
 
-interface GuessMessageProps {
+const GuessMessage = React.memo(({
+  guess, puzzle, hunt, guesser, onDismiss,
+}: {
   guess: GuessType;
   puzzle: PuzzleType;
   hunt: HuntType;
   guesser: string;
   onDismiss: (guessId: string) => void;
-}
-
-const GuessMessage = React.memo((props: GuessMessageProps) => {
-  const {
-    guess, puzzle, hunt, guesser, onDismiss,
-  } = props;
-
+}) => {
   const markCorrect = useCallback(() => {
     Meteor.call('markGuessCorrect', guess._id);
   }, [guess._id]);
@@ -275,10 +269,6 @@ const GuessMessage = React.memo((props: GuessMessageProps) => {
   );
 });
 
-interface DiscordMessageProps {
-  onDismiss: () => void;
-}
-
 enum DiscordMessageStatus {
   IDLE = 'idle',
   LINKING = 'linking',
@@ -291,7 +281,9 @@ type DiscordMessageState = {
   error?: string;
 }
 
-const DiscordMessage = React.memo((props: DiscordMessageProps) => {
+const DiscordMessage = React.memo(({ onDismiss }: {
+  onDismiss: () => void;
+}) => {
   const [state, setState] = useState<DiscordMessageState>({ status: DiscordMessageStatus.IDLE });
 
   const requestComplete = useCallback((token: string) => {
@@ -338,23 +330,23 @@ const DiscordMessage = React.memo((props: DiscordMessageProps) => {
         </StyledNotificationActionBar>
         {state.status === DiscordMessageStatus.ERROR ? state.error! : null}
       </MessengerContent>
-      <MessengerDismissButton onDismiss={props.onDismiss} />
+      <MessengerDismissButton onDismiss={onDismiss} />
     </StyledNotificationMessage>
   );
 });
 
-interface AnnouncementMessageProps {
+const AnnouncementMessage = React.memo(({
+  id, announcement, createdByDisplayName,
+}: {
   id: string;
   announcement: AnnouncementType;
   createdByDisplayName: string;
-}
-
-const AnnouncementMessage = React.memo((props: AnnouncementMessageProps) => {
+}) => {
   const [dismissed, setDismissed] = useState<boolean>(false);
   const onDismiss = useCallback(() => {
     setDismissed(true);
-    Meteor.call('dismissPendingAnnouncement', props.id);
-  }, [props.id]);
+    Meteor.call('dismissPendingAnnouncement', id);
+  }, [id]);
 
   if (dismissed) {
     return null;
@@ -366,13 +358,13 @@ const AnnouncementMessage = React.memo((props: AnnouncementMessageProps) => {
       <MessengerContent>
         <div
           // eslint-disable-next-line react/no-danger
-          dangerouslySetInnerHTML={{ __html: markdown(props.announcement.message) }}
+          dangerouslySetInnerHTML={{ __html: markdown(announcement.message) }}
         />
         <footer>
           {'- '}
-          {props.createdByDisplayName}
+          {createdByDisplayName}
           {', '}
-          {calendarTimeFormat(props.announcement.createdAt)}
+          {calendarTimeFormat(announcement.createdAt)}
         </footer>
       </MessengerContent>
       <MessengerDismissButton onDismiss={onDismiss} />
@@ -380,10 +372,9 @@ const AnnouncementMessage = React.memo((props: AnnouncementMessageProps) => {
   );
 });
 
-interface ProfileMissingMessageProps {
+const ProfileMissingMessage = ({ onDismiss }: {
   onDismiss: () => void;
-}
-const ProfileMissingMessage = (props: ProfileMissingMessageProps) => {
+}) => {
   return (
     <StyledNotificationMessage>
       <MessengerSpinner />
@@ -397,38 +388,38 @@ const ProfileMissingMessage = (props: ProfileMissingMessageProps) => {
         </Link>
         .
       </MessengerContent>
-      <MessengerDismissButton onDismiss={props.onDismiss} />
+      <MessengerDismissButton onDismiss={onDismiss} />
     </StyledNotificationMessage>
   );
 };
 
-interface ChatNotificationMessageProps {
+const ChatNotificationMessage = ({
+  cn, hunt, puzzle, senderDisplayName, onDismiss,
+}: {
   cn: ChatNotificationType;
   hunt: HuntType;
   puzzle: PuzzleType;
   senderDisplayName: string;
   onDismiss: (chatNotificationId: string) => void;
-}
-const ChatNotificationMessage = (props: ChatNotificationMessageProps) => {
-  const { onDismiss } = props;
-  const id = props.cn._id;
+}) => {
+  const id = cn._id;
   const dismiss = useCallback(() => onDismiss(id), [id, onDismiss]);
   return (
     <StyledNotificationMessage>
       <MessengerSpinner />
       <MessengerContent>
-        <Link to={`/hunts/${props.hunt._id}/puzzles/${props.puzzle._id}`}>
-          {props.puzzle.title}
+        <Link to={`/hunts/${hunt._id}/puzzles/${puzzle._id}`}>
+          {puzzle.title}
         </Link>
         <div>
-          {props.senderDisplayName}
+          {senderDisplayName}
           {': '}
           <div>
-            {props.cn.text}
+            {cn.text}
           </div>
         </div>
         <footer>
-          {calendarTimeFormat(props.cn.createdAt)}
+          {calendarTimeFormat(cn.createdAt)}
         </footer>
       </MessengerContent>
       <MessengerDismissButton onDismiss={dismiss} />

--- a/imports/client/components/OthersProfilePage.tsx
+++ b/imports/client/components/OthersProfilePage.tsx
@@ -12,13 +12,6 @@ import { getAvatarCdnUrl } from '../../lib/discord';
 import Hunts from '../../lib/models/hunts';
 import { ProfileType } from '../../lib/schemas/profile';
 
-interface OthersProfilePageProps {
-  profile: ProfileType;
-  viewerCanMakeOperator: boolean;
-  targetIsOperator: boolean;
-  huntMembership?: string[];
-}
-
 const AvatarTooltip = styled(Tooltip)`
   opacity: 1 !important;
   .tooltip-inner {
@@ -32,23 +25,29 @@ const ProfileTable = styled.table`
   }
 `;
 
-const OthersProfilePage = (props: OthersProfilePageProps) => {
+const OthersProfilePage = ({
+  profile, viewerCanMakeOperator, targetIsOperator, huntMembership,
+}: {
+  profile: ProfileType;
+  viewerCanMakeOperator: boolean;
+  targetIsOperator: boolean;
+  huntMembership?: string[];
+}) => {
   const [shouldShowOperatorConfirm, setShouldShowOperatorConfirm] = useState(false);
   const showConfirm = useCallback(() => setShouldShowOperatorConfirm(true), []);
   const hideConfirm = useCallback(() => setShouldShowOperatorConfirm(false), []);
 
-  const huntsLoading = useSubscribe(props.viewerCanMakeOperator ? 'mongo.hunts' : undefined, {});
+  const huntsLoading = useSubscribe(viewerCanMakeOperator ? 'mongo.hunts' : undefined, {});
   const loading = huntsLoading();
   const hunts = useTracker(() => (loading ? {} : _.indexBy(Hunts.find().fetch(), '_id')), [loading]);
 
   const makeOperator = useCallback(() => {
-    Meteor.call('makeOperator', props.profile._id);
+    Meteor.call('makeOperator', profile._id);
     hideConfirm();
-  }, [props.profile._id, hideConfirm]);
+  }, [profile._id, hideConfirm]);
 
-  const profile = props.profile;
-  const showOperatorBadge = props.targetIsOperator;
-  const showMakeOperatorButton = props.viewerCanMakeOperator && !props.targetIsOperator;
+  const showOperatorBadge = targetIsOperator;
+  const showMakeOperatorButton = viewerCanMakeOperator && !targetIsOperator;
   const discordAvatarUrl = getAvatarCdnUrl(profile.discordAccount);
   const discordAvatarUrlLarge = getAvatarCdnUrl(profile.discordAccount, 256);
   return (
@@ -150,14 +149,14 @@ const OthersProfilePage = (props: OthersProfilePageProps) => {
                 )}
               </td>
             </tr>
-            {props.viewerCanMakeOperator && props.huntMembership && (
+            {viewerCanMakeOperator && huntMembership && (
               <tr>
                 <th>All hunts participated</th>
                 <td>
                   {(
                     loading ?
                       'loading...' :
-                      props.huntMembership.map((huntId) => (
+                      huntMembership.map((huntId) => (
                         hunts[huntId]?.name ?? `Unknown hunt ${huntId}`
                       ))
                         .join(', ')

--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -18,10 +18,6 @@ import { requestDiscordCredential } from '../discord';
 import TeamName from '../team_name';
 import AudioConfig from './AudioConfig';
 
-interface GoogleLinkBlockProps {
-  profile: ProfileType;
-}
-
 enum GoogleLinkBlockLinkState {
   IDLE = 'idle',
   LINKING = 'linking',
@@ -35,7 +31,7 @@ type GoogleLinkBlockState = {
   error: Error;
 }
 
-const GoogleLinkBlock = (props: GoogleLinkBlockProps) => {
+const GoogleLinkBlock = ({ profile }: { profile: ProfileType }) => {
   const [state, setState] =
     useState<GoogleLinkBlockState>({ state: GoogleLinkBlockLinkState.IDLE });
 
@@ -80,7 +76,7 @@ const GoogleLinkBlock = (props: GoogleLinkBlockProps) => {
       return <Button variant="primary" disabled>Google integration currently disabled</Button>;
     }
 
-    const text = (props.profile.googleAccount) ?
+    const text = (profile.googleAccount) ?
       'Link a different Google account' :
       'Link your Google account';
 
@@ -108,16 +104,16 @@ const GoogleLinkBlock = (props: GoogleLinkBlockProps) => {
         </Alert>
       ) : undefined}
       <div>
-        {props.profile.googleAccount ? (
+        {profile.googleAccount ? (
           <div>
             Currently linked to
             {' '}
-            {props.profile.googleAccount}
+            {profile.googleAccount}
           </div>
         ) : undefined}
         {linkButton()}
         {' '}
-        {props.profile.googleAccount ? (
+        {profile.googleAccount ? (
           <Button variant="danger" onClick={onUnlink}>
             Unlink
           </Button>
@@ -149,10 +145,6 @@ enum DiscordLinkBlockLinkState {
   ERROR = 'error',
 }
 
-interface DiscordLinkBlockProps {
-  profile: ProfileType;
-}
-
 type DiscordLinkBlockState = {
   state: DiscordLinkBlockLinkState.IDLE | DiscordLinkBlockLinkState.LINKING;
 } | {
@@ -160,7 +152,7 @@ type DiscordLinkBlockState = {
   error: Error;
 }
 
-const DiscordLinkBlock = (props: DiscordLinkBlockProps) => {
+const DiscordLinkBlock = ({ profile }: { profile: ProfileType }) => {
   const [state, setState] =
     useState<DiscordLinkBlockState>({ state: DiscordLinkBlockLinkState.IDLE });
 
@@ -208,7 +200,7 @@ const DiscordLinkBlock = (props: DiscordLinkBlockProps) => {
       return <Button variant="primary" disabled>Discord integration currently disabled</Button>;
     }
 
-    const text = (props.profile.discordAccount) ?
+    const text = (profile.discordAccount) ?
       'Link a different Discord account' :
       'Link your Discord account';
 
@@ -217,10 +209,10 @@ const DiscordLinkBlock = (props: DiscordLinkBlockProps) => {
         {text}
       </Button>
     );
-  }, [state.state, discordDisabled, props.profile.discordAccount, onLink]);
+  }, [state.state, discordDisabled, profile.discordAccount, onLink]);
 
   const unlinkButton = useMemo(() => {
-    if (props.profile.discordAccount) {
+    if (profile.discordAccount) {
       return (
         <Button variant="danger" onClick={onUnlink}>
           Unlink
@@ -229,11 +221,11 @@ const DiscordLinkBlock = (props: DiscordLinkBlockProps) => {
     }
 
     return null;
-  }, [props.profile.discordAccount, onUnlink]);
+  }, [profile.discordAccount, onUnlink]);
 
   const currentAccount = useMemo(() => {
-    if (props.profile.discordAccount) {
-      const acct = props.profile.discordAccount;
+    if (profile.discordAccount) {
+      const acct = profile.discordAccount;
       return (
         <div>
           Currently linked to
@@ -248,7 +240,7 @@ const DiscordLinkBlock = (props: DiscordLinkBlockProps) => {
     }
 
     return null;
-  }, [props.profile.discordAccount]);
+  }, [profile.discordAccount]);
 
   if (!config) {
     return <div />;
@@ -284,12 +276,6 @@ const DiscordLinkBlock = (props: DiscordLinkBlockProps) => {
   );
 };
 
-interface OwnProfilePageProps {
-  initialProfile: ProfileType;
-  operating: boolean;
-  canMakeOperator: boolean;
-}
-
 enum OwnProfilePageSubmitState {
   IDLE = 'idle',
   SUBMITTING = 'submitting',
@@ -297,13 +283,19 @@ enum OwnProfilePageSubmitState {
   ERROR = 'error',
 }
 
-const OwnProfilePage = (props: OwnProfilePageProps) => {
-  const [displayName, setDisplayName] = useState<string>(props.initialProfile.displayName || '');
-  const [phoneNumber, setPhoneNumber] = useState<string>(props.initialProfile.phoneNumber || '');
+const OwnProfilePage = ({
+  initialProfile, operating, canMakeOperator,
+}: {
+  initialProfile: ProfileType;
+  operating: boolean;
+  canMakeOperator: boolean;
+}) => {
+  const [displayName, setDisplayName] = useState<string>(initialProfile.displayName || '');
+  const [phoneNumber, setPhoneNumber] = useState<string>(initialProfile.phoneNumber || '');
   const [muteApplause, setMuteApplause] =
-    useState<boolean>(props.initialProfile.muteApplause || false);
-  const [dingwordsFlat, setDingwordsFlat] = useState<string>(props.initialProfile.dingwords ?
-    props.initialProfile.dingwords.join(',') : '');
+    useState<boolean>(initialProfile.muteApplause || false);
+  const [dingwordsFlat, setDingwordsFlat] = useState<string>(initialProfile.dingwords ?
+    initialProfile.dingwords.join(',') : '');
   const [submitState, setSubmitState] =
     useState<OwnProfilePageSubmitState>(OwnProfilePageSubmitState.IDLE);
   const [submitError, setSubmitError] = useState<string>('');
@@ -325,13 +317,13 @@ const OwnProfilePage = (props: OwnProfilePageProps) => {
   }, []);
 
   const toggleOperating = useCallback(() => {
-    const newState = !props.operating;
+    const newState = !operating;
     if (newState) {
       Meteor.call('makeOperator', Meteor.userId());
     } else {
       Meteor.call('stopOperating');
     }
-  }, [props.operating]);
+  }, [operating]);
 
   const handleSaveForm = useCallback(() => {
     setSubmitState(OwnProfilePageSubmitState.SUBMITTING);
@@ -362,7 +354,7 @@ const OwnProfilePage = (props: OwnProfilePageProps) => {
   return (
     <div>
       <h1>Account information</h1>
-      {props.canMakeOperator ? <FormCheck type="checkbox" checked={props.operating} onChange={toggleOperating} label="Operating" /> : null}
+      {canMakeOperator ? <FormCheck type="checkbox" checked={operating} onChange={toggleOperating} label="Operating" /> : null}
       <FormGroup>
         <FormLabel htmlFor="jr-profile-edit-email">
           Email address
@@ -370,7 +362,7 @@ const OwnProfilePage = (props: OwnProfilePageProps) => {
         <FormControl
           id="jr-profile-edit-email"
           type="text"
-          value={props.initialProfile.primaryEmail}
+          value={initialProfile.primaryEmail}
           disabled
         />
       </FormGroup>
@@ -384,9 +376,9 @@ const OwnProfilePage = (props: OwnProfilePageProps) => {
         </Alert>
       ) : null}
 
-      <GoogleLinkBlock profile={props.initialProfile} />
+      <GoogleLinkBlock profile={initialProfile} />
 
-      <DiscordLinkBlock profile={props.initialProfile} />
+      <DiscordLinkBlock profile={initialProfile} />
 
       <FormGroup>
         <FormLabel htmlFor="jr-profile-edit-display-name">

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -44,14 +44,14 @@ const ImageBlock = styled.div`
   justify-content: center;
 `;
 
-interface ProfileListProps {
+const ProfileList = ({
+  huntId, canInvite, canSyncDiscord, profiles,
+}: {
   huntId?: string;
   canInvite?: boolean;
   canSyncDiscord?: boolean;
   profiles: ProfileType[];
-}
-
-const ProfileList = (props: ProfileListProps) => {
+}) => {
   const [searchString, setSearchString] = useState<string>('');
 
   const searchBarRef = useRef<HTMLInputElement>(null); // Wrong type but I should fix it
@@ -104,11 +104,11 @@ const ProfileList = (props: ProfileListProps) => {
   }, []);
 
   const syncDiscord = useCallback(() => {
-    Meteor.call('syncDiscordRole', props.huntId);
-  }, [props.huntId]);
+    Meteor.call('syncDiscordRole', huntId);
+  }, [huntId]);
 
   const syncDiscordButton = useMemo(() => {
-    if (!props.huntId || !props.canSyncDiscord) {
+    if (!huntId || !canSyncDiscord) {
       return null;
     }
 
@@ -122,15 +122,15 @@ const ProfileList = (props: ProfileListProps) => {
         </FormText>
       </FormGroup>
     );
-  }, [props.huntId, props.canSyncDiscord, syncDiscord]);
+  }, [huntId, canSyncDiscord, syncDiscord]);
 
   const inviteToHuntItem = useMemo(() => {
-    if (!props.huntId || !props.canInvite) {
+    if (!huntId || !canInvite) {
       return null;
     }
 
     return (
-      <RRBS.LinkContainer to={`/hunts/${props.huntId}/hunters/invite`}>
+      <RRBS.LinkContainer to={`/hunts/${huntId}/hunters/invite`}>
         <StyledListGroupItem action>
           <ImageBlock>
             <FontAwesomeIcon icon={faPlus} />
@@ -139,10 +139,10 @@ const ProfileList = (props: ProfileListProps) => {
         </StyledListGroupItem>
       </RRBS.LinkContainer>
     );
-  }, [props.huntId, props.canInvite]);
+  }, [huntId, canInvite]);
 
   const globalInfo = useMemo(() => {
-    if (props.huntId) {
+    if (huntId) {
       return null;
     }
 
@@ -152,16 +152,16 @@ const ProfileList = (props: ProfileListProps) => {
         Mystery Hunt. For that, go to the hunt page and click on &quot;Hunters&quot;.
       </Alert>
     );
-  }, [props.huntId]);
+  }, [huntId]);
 
-  const profiles = props.profiles.filter(matcher);
+  const matching = profiles.filter(matcher);
   return (
     <div>
       <h1>List of hunters</h1>
       <ProfilesSummary>
         Total hunters:
         {' '}
-        {props.profiles.length}
+        {profiles.length}
       </ProfilesSummary>
 
       {syncDiscordButton}
@@ -191,7 +191,7 @@ const ProfileList = (props: ProfileListProps) => {
 
       <ListGroup>
         {inviteToHuntItem}
-        {profiles.map((profile) => {
+        {matching.map((profile) => {
           const name = profile.displayName || '<no name provided>';
           const discordAvatarUrl = getAvatarCdnUrl(profile.discordAccount);
           return (

--- a/imports/client/components/PuzzleAnswer.tsx
+++ b/imports/client/components/PuzzleAnswer.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
 
-interface PuzzleAnswerProps {
+const PuzzleAnswer = React.memo(({
+  answer, respace = false, segmentSize = 5,
+}: {
   answer: string;
   // If respace is set, answers are formatted without spaces and grouped into segments of length
   // segmentSize. If segmentSize is zero or negative, the effect is simply to strip spaces.
   respace?: boolean;
   segmentSize?: number;
-}
-
-const PuzzleAnswer = React.memo((props: PuzzleAnswerProps) => {
-  const respace = props.respace ?? false;
-  const segmentSize = Math.floor(props.segmentSize ?? 5);
-  const respacedAnswer = respace ? props.answer.replace(/\s+/g, '') : props.answer;
-  let formattedAnswer : React.ReactNode = respacedAnswer;
+}) => {
+  const respacedAnswer = respace ? answer.replace(/\s+/g, '') : answer;
+  let formattedAnswer: React.ReactNode = respacedAnswer;
   if (respace && segmentSize > 0) {
     // Use Intl.Segmenter (stage 3 proposal) if available to properly segment grapheme clusters
     // Typescript is unaware of it, so there are a few any casts...

--- a/imports/client/components/PuzzleList.tsx
+++ b/imports/client/components/PuzzleList.tsx
@@ -4,7 +4,9 @@ import { PuzzleType } from '../../lib/schemas/puzzle';
 import { TagType } from '../../lib/schemas/tag';
 import Puzzle from './Puzzle';
 
-interface PuzzleListProps {
+const PuzzleList = React.memo(({
+  puzzles, allTags, layout, canUpdate, suppressTags, segmentAnswers,
+}: {
   // The puzzles to show in this list
   puzzles: PuzzleType[];
   // All tags for this hunt, including those not used by any puzzles
@@ -13,38 +15,36 @@ interface PuzzleListProps {
   canUpdate: boolean;
   suppressTags?: string[];
   segmentAnswers?: boolean;
-}
-
-const PuzzleList = React.memo((props: PuzzleListProps) => {
+}) => {
   // This component just renders the puzzles provided, in order.
   // Adjusting order based on tags, tag groups, etc. is to be done at
   // a higher layer.
-  const puzzles = [];
-  for (let i = 0; i < props.puzzles.length; i++) {
-    const puz = props.puzzles[i];
-    puzzles.push(<Puzzle
+  const renderedPuzzles = [];
+  for (let i = 0; i < puzzles.length; i++) {
+    const puz = puzzles[i];
+    renderedPuzzles.push(<Puzzle
       key={puz._id}
       puzzle={puz}
-      allTags={props.allTags}
-      layout={props.layout}
-      canUpdate={props.canUpdate}
-      suppressTags={props.suppressTags}
-      segmentAnswers={props.segmentAnswers}
+      allTags={allTags}
+      layout={layout}
+      canUpdate={canUpdate}
+      suppressTags={suppressTags}
+      segmentAnswers={segmentAnswers}
     />);
   }
 
-  if (props.layout === 'table') {
+  if (layout === 'table') {
     return (
       <table className="puzzle-list">
         <tbody>
-          {puzzles}
+          {renderedPuzzles}
         </tbody>
       </table>
     );
   }
   return (
     <div className="puzzle-list">
-      {puzzles}
+      {renderedPuzzles}
     </div>
   );
 });

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -35,12 +35,6 @@ import RelatedPuzzleGroup from './RelatedPuzzleGroup';
 import { filteredPuzzleGroups, puzzleGroupsByRelevance } from './puzzle-sort-and-group';
 import { mediaBreakpointDown } from './styling/responsive';
 
-interface PuzzleListViewProps {
-  huntId: string
-  canAdd: boolean;
-  canUpdate: boolean;
-}
-
 const ViewControls = styled.div`
   display: flex;
   flex-wrap: wrap;
@@ -86,20 +80,26 @@ function showSolvedStorageKey(huntId: string): string {
   return `showsolved-${huntId}`;
 }
 
-const PuzzleListView = (props: PuzzleListViewProps) => {
-  const allPuzzles = useTracker(() => Puzzles.find({ hunt: props.huntId }).fetch(), [props.huntId]);
-  const allTags = useTracker(() => Tags.find({ hunt: props.huntId }).fetch(), [props.huntId]);
+const PuzzleListView = ({
+  huntId, canAdd, canUpdate,
+}: {
+  huntId: string
+  canAdd: boolean;
+  canUpdate: boolean;
+}) => {
+  const allPuzzles = useTracker(() => Puzzles.find({ hunt: huntId }).fetch(), [huntId]);
+  const allTags = useTracker(() => Tags.find({ hunt: huntId }).fetch(), [huntId]);
 
   const deletedPuzzlesLoading = useSubscribe(
-    props.canUpdate ? 'mongo.puzzles.deleted' : undefined,
-    { hunt: props.huntId }
+    canUpdate ? 'mongo.puzzles.deleted' : undefined,
+    { hunt: huntId }
   );
   const deletedLoading = deletedPuzzlesLoading();
   const deletedPuzzles = useTracker(() => (
-    !props.canUpdate || deletedLoading ?
+    !canUpdate || deletedLoading ?
       undefined :
-      Puzzles.findDeleted({ hunt: props.huntId }).fetch()
-  ), [props.canUpdate, props.huntId, deletedLoading]);
+      Puzzles.findDeleted({ hunt: huntId }).fetch()
+  ), [canUpdate, huntId, deletedLoading]);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const searchString = searchParams.get('q') || '';
@@ -107,7 +107,7 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
   const searchBarRef = useRef<HTMLInputElement>(null);
   const [displayMode, setDisplayMode] = useState<string>('group');
   const [showSolved, setShowSolved] = useState<boolean>(() => {
-    const showSolvedKey = showSolvedStorageKey(props.huntId);
+    const showSolvedKey = showSolvedStorageKey(huntId);
     const localStorageShowSolved = localStorage.getItem(showSolvedKey);
     return !(localStorageShowSolved === 'false');
   });
@@ -227,14 +227,14 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
       // last-set value again the next time we load up this view.
       try {
         // Note: localStorage serialization converts booleans to strings anyway
-        localStorage.setItem(showSolvedStorageKey(props.huntId), `${newState}`);
+        localStorage.setItem(showSolvedStorageKey(huntId), `${newState}`);
       } catch (e) {
         // Ignore failure to set value in storage; this is best-effort and if
         // localStorage isn't available then whatever
       }
       return newState;
     });
-  }, [props.huntId]);
+  }, [huntId]);
 
   const showAddModal = useCallback(() => {
     if (addModalRef.current) {
@@ -271,7 +271,7 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
               allTags={allTags}
               includeCount={false}
               layout="grid"
-              canUpdate={props.canUpdate}
+              canUpdate={canUpdate}
               suppressedTagIds={suppressedTagIds}
             />
           );
@@ -287,7 +287,7 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
             puzzles={retainedPuzzlesByUnlock}
             allTags={allTags}
             layout="grid"
-            canUpdate={props.canUpdate}
+            canUpdate={canUpdate}
           />
         );
         break;
@@ -305,19 +305,19 @@ const PuzzleListView = (props: PuzzleListViewProps) => {
             allTags={allTags}
             includeCount={false}
             layout="grid"
-            canUpdate={props.canUpdate}
+            canUpdate={canUpdate}
             suppressedTagIds={[]}
           />
         )}
       </div>
     );
-  }, [displayMode, allPuzzles, deletedPuzzles, allTags, props.canUpdate]);
+  }, [displayMode, allPuzzles, deletedPuzzles, allTags, canUpdate]);
 
-  const addPuzzleContent = props.canAdd && (
+  const addPuzzleContent = canAdd && (
     <>
       <Button variant="primary" onClick={showAddModal}>Add a puzzle</Button>
       <PuzzleModalForm
-        huntId={props.huntId}
+        huntId={huntId}
         tags={allTags}
         ref={addModalRef}
         onSubmit={onAdd}

--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -30,15 +30,6 @@ export interface PuzzleModalFormSubmitPayload {
   expectedAnswerCount: number;
 }
 
-interface PuzzleModalFormProps {
-  huntId: string;
-  puzzle?: PuzzleType;
-  // All known tags for this hunt
-  tags: TagType[];
-  onSubmit: (payload: PuzzleModalFormSubmitPayload, callback: (error?: Error) => void) => void;
-  showOnMount?: boolean;
-}
-
 enum PuzzleModalFormSubmitState {
   IDLE = 'idle',
   SUBMITTING = 'submitting',
@@ -49,11 +40,17 @@ export type PuzzleModalFormHandle = {
   show: () => void;
 }
 
-const PuzzleModalForm = React.forwardRef((props: PuzzleModalFormProps, forwardedRef: React.Ref<PuzzleModalFormHandle>) => {
-  const {
-    huntId, puzzle, tags: propsTags, onSubmit, showOnMount,
-  } = props;
+const PuzzleModalForm = React.forwardRef(({
+  huntId, puzzle, tags: propsTags, onSubmit, showOnMount,
+}: {
+  huntId: string;
+  puzzle?: PuzzleType;
+  // All known tags for this hunt
+  tags: TagType[];
+  onSubmit: (payload: PuzzleModalFormSubmitPayload, callback: (error?: Error) => void) => void;
+  showOnMount?: boolean;
 
+}, forwardedRef: React.Ref<PuzzleModalFormHandle>) => {
   const tagNamesForIds = useCallback((tagIds: string[]) => {
     const tagNames: Record<string, string> = {};
     propsTags.forEach((t) => { tagNames[t._id] = t.name; });
@@ -154,36 +151,36 @@ const PuzzleModalForm = React.forwardRef((props: PuzzleModalFormProps, forwarded
   }, []);
 
   const currentTitle = useMemo(() => {
-    if (!titleDirty && props.puzzle) {
-      return props.puzzle.title;
+    if (!titleDirty && puzzle) {
+      return puzzle.title;
     } else {
       return title;
     }
-  }, [titleDirty, props.puzzle, title]);
+  }, [titleDirty, puzzle, title]);
 
   const currentUrl = useMemo(() => {
-    if (!urlDirty && props.puzzle) {
-      return props.puzzle.url;
+    if (!urlDirty && puzzle) {
+      return puzzle.url;
     } else {
       return url;
     }
-  }, [urlDirty, props.puzzle, url]);
+  }, [urlDirty, puzzle, url]);
 
   const currentTags = useMemo(() => {
-    if (!tagsDirty && props.puzzle) {
-      return tagNamesForIds(props.puzzle.tags);
+    if (!tagsDirty && puzzle) {
+      return tagNamesForIds(puzzle.tags);
     } else {
       return tags;
     }
-  }, [tagsDirty, props.puzzle, tagNamesForIds, tags]);
+  }, [tagsDirty, puzzle, tagNamesForIds, tags]);
 
   const currentExpectedAnswerCount = useMemo(() => {
-    if (!expectedAnswerCountDirty && props.puzzle) {
-      return props.puzzle.expectedAnswerCount;
+    if (!expectedAnswerCountDirty && puzzle) {
+      return puzzle.expectedAnswerCount;
     } else {
       return expectedAnswerCount;
     }
-  }, [expectedAnswerCountDirty, props.puzzle, expectedAnswerCount]);
+  }, [expectedAnswerCountDirty, puzzle, expectedAnswerCount]);
 
   useImperativeHandle(forwardedRef, () => ({
     show,
@@ -203,7 +200,7 @@ const PuzzleModalForm = React.forwardRef((props: PuzzleModalFormProps, forwarded
       return { value: t, label: t };
     });
 
-  const docTypeSelector = !props.puzzle && docType ? (
+  const docTypeSelector = !puzzle && docType ? (
     <FormGroup as={Row}>
       <FormLabel column xs={3} htmlFor="jr-new-puzzle-doc-type">
         Document type
@@ -234,7 +231,7 @@ const PuzzleModalForm = React.forwardRef((props: PuzzleModalFormProps, forwarded
     <Suspense fallback={<div><Loading /></div>}>
       <ModalForm
         ref={formRef}
-        title={props.puzzle ? 'Edit puzzle' : 'Add puzzle'}
+        title={puzzle ? 'Edit puzzle' : 'Add puzzle'}
         onSubmit={onFormSubmit}
         submitDisabled={disableForm}
       >

--- a/imports/client/components/RelatedPuzzleGroup.tsx
+++ b/imports/client/components/RelatedPuzzleGroup.tsx
@@ -7,7 +7,9 @@ import RelatedPuzzleList from './RelatedPuzzleList';
 import Tag from './Tag';
 import { PuzzleGroup } from './puzzle-sort-and-group';
 
-interface RelatedPuzzleGroupProps {
+const RelatedPuzzleGroup = ({
+  group, noSharedTagLabel = '(no tag)', allTags, includeCount, layout, canUpdate, suppressedTagIds,
+}: {
   group: PuzzleGroup;
   // noSharedTagLabel is used to label the group only if sharedTag is undefined.
   noSharedTagLabel?: String;
@@ -16,9 +18,7 @@ interface RelatedPuzzleGroupProps {
   layout: 'grid' | 'table';
   canUpdate: boolean;
   suppressedTagIds: string[];
-}
-
-const RelatedPuzzleGroup = (props: RelatedPuzzleGroupProps) => {
+}) => {
   const [collapsed, setCollapsed] = useState<boolean>(false);
   const toggleCollapse = useCallback(() => {
     setCollapsed((prevCollapsed) => {
@@ -26,14 +26,13 @@ const RelatedPuzzleGroup = (props: RelatedPuzzleGroupProps) => {
     });
   }, []);
 
-  const relatedPuzzles = props.group.puzzles;
-  const sharedTag = props.group.sharedTag;
+  const { puzzles: relatedPuzzles, sharedTag } = group;
+
   const puzzlePlural = relatedPuzzles.length === 1 ? 'puzzle' : 'puzzles';
   const countString = `(${relatedPuzzles.length} other ${puzzlePlural})`;
-  const suppressedTagIds = [...props.suppressedTagIds];
-  const noSharedTagLabel = props.noSharedTagLabel || '(no tag)';
+  const allSuppressedTagIds = [...suppressedTagIds];
   if (sharedTag) {
-    suppressedTagIds.push(sharedTag._id);
+    allSuppressedTagIds.push(sharedTag._id);
   }
   return (
     <div className="puzzle-group">
@@ -44,20 +43,20 @@ const RelatedPuzzleGroup = (props: RelatedPuzzleGroupProps) => {
         ) : (
           <div className="tag tag-none">{noSharedTagLabel}</div>
         )}
-        {props.includeCount && <span>{countString}</span>}
+        {includeCount && <span>{countString}</span>}
       </div>
       {collapsed ? null : (
         <div className="puzzle-list-wrapper">
           <RelatedPuzzleList
             relatedPuzzles={relatedPuzzles}
-            allTags={props.allTags}
-            layout={props.layout}
-            canUpdate={props.canUpdate}
+            allTags={allTags}
+            layout={layout}
+            canUpdate={canUpdate}
             sharedTag={sharedTag}
-            suppressedTagIds={suppressedTagIds}
+            suppressedTagIds={allSuppressedTagIds}
           />
-          {props.group.subgroups.map((subgroup) => {
-            const subgroupSuppressedTagIds = [...suppressedTagIds];
+          {group.subgroups.map((subgroup) => {
+            const subgroupSuppressedTagIds = [...allSuppressedTagIds];
             if (subgroup.sharedTag) {
               subgroupSuppressedTagIds.push(subgroup.sharedTag._id);
             }
@@ -65,11 +64,11 @@ const RelatedPuzzleGroup = (props: RelatedPuzzleGroupProps) => {
               <RelatedPuzzleGroup
                 key={subgroup.sharedTag ? subgroup.sharedTag._id : 'ungrouped'}
                 group={subgroup}
-                noSharedTagLabel={props.noSharedTagLabel}
-                allTags={props.allTags}
-                includeCount={props.includeCount}
-                layout={props.layout}
-                canUpdate={props.canUpdate}
+                noSharedTagLabel={noSharedTagLabel}
+                allTags={allTags}
+                includeCount={includeCount}
+                layout={layout}
+                canUpdate={canUpdate}
                 suppressedTagIds={subgroupSuppressedTagIds}
               />
             );

--- a/imports/client/components/RelatedPuzzleList.tsx
+++ b/imports/client/components/RelatedPuzzleList.tsx
@@ -28,7 +28,9 @@ function sortPuzzlesByRelevanceWithinPuzzleGroup(
   return sortedPuzzles;
 }
 
-interface RelatedPuzzleListProps {
+const RelatedPuzzleList = React.memo(({
+  relatedPuzzles, allTags, layout, canUpdate, sharedTag, suppressedTagIds, segmentAnswers,
+}: {
   relatedPuzzles: PuzzleType[];
   allTags: TagType[];
   layout: 'grid' | 'table';
@@ -36,26 +38,24 @@ interface RelatedPuzzleListProps {
   sharedTag: TagType | undefined;
   suppressedTagIds: string[];
   segmentAnswers?: boolean;
-}
-
-const RelatedPuzzleList = React.memo((props: RelatedPuzzleListProps) => {
+}) => {
   // Sort the puzzles within each tag group by interestingness.  For instance, metas
   // should probably be at the top of the group, then of the round puzzles, unsolved should
   // maybe sort above solved, and then perhaps by unlock order.
-  const tagIndex = _.indexBy(props.allTags, '_id');
+  const tagIndex = _.indexBy(allTags, '_id');
   const sortedPuzzles = sortPuzzlesByRelevanceWithinPuzzleGroup(
-    props.relatedPuzzles,
-    props.sharedTag,
+    relatedPuzzles,
+    sharedTag,
     tagIndex
   );
   return (
     <PuzzleList
       puzzles={sortedPuzzles}
-      allTags={props.allTags}
-      layout={props.layout}
-      canUpdate={props.canUpdate}
-      suppressTags={props.suppressedTagIds}
-      segmentAnswers={props.segmentAnswers}
+      allTags={allTags}
+      layout={layout}
+      canUpdate={canUpdate}
+      suppressTags={suppressedTagIds}
+      segmentAnswers={segmentAnswers}
     />
   );
 });

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -80,11 +80,6 @@ const googleCompletenessStrings = [
   'Configured',
 ];
 
-interface GoogleOAuthFormProps {
-  isConfigured: boolean;
-  initialClientId?: string;
-}
-
 type GoogleOAuthFormSubmitState = ({
   submitState: SubmitState.IDLE | SubmitState.SUBMITTING | SubmitState.SUCCESS
 } | {
@@ -92,11 +87,14 @@ type GoogleOAuthFormSubmitState = ({
   submitError: string;
 });
 
-const GoogleOAuthForm = (props: GoogleOAuthFormProps) => {
+const GoogleOAuthForm = ({ isConfigured, initialClientId }: {
+  isConfigured: boolean;
+  initialClientId?: string;
+}) => {
   const [state, setState] = useState<GoogleOAuthFormSubmitState>({
     submitState: SubmitState.IDLE,
   });
-  const [clientId, setClientId] = useState<string>(props.initialClientId || '');
+  const [clientId, setClientId] = useState<string>(initialClientId || '');
   const [clientSecret, setClientSecret] = useState<string>('');
 
   const dismissAlert = useCallback(() => {
@@ -144,7 +142,7 @@ const GoogleOAuthForm = (props: GoogleOAuthFormProps) => {
   }, []);
 
   const shouldDisableForm = state.submitState === SubmitState.SUBMITTING;
-  const secretPlaceholder = props.isConfigured ? '<configured secret not revealed>' : '';
+  const secretPlaceholder = isConfigured ? '<configured secret not revealed>' : '';
   return (
     <form onSubmit={onSubmitOauthConfiguration}>
       {state.submitState === SubmitState.SUBMITTING ? <Alert variant="info">Saving...</Alert> : null}
@@ -335,11 +333,6 @@ const GoogleDriveRootForm = ({ initialRootId }: { initialRootId?: string }) => {
   );
 };
 
-interface GoogleDriveTemplateFormProps {
-  initialDocTemplate?: string;
-  initialSpreadsheetTemplate?: string;
-}
-
 type GoogleDriveTemplateFormState = ({
   submitState: SubmitState.IDLE | SubmitState.SUBMITTING | SubmitState.SUCCESS;
 } | {
@@ -347,12 +340,15 @@ type GoogleDriveTemplateFormState = ({
   error: Error;
 })
 
-const GoogleDriveTemplateForm = (props: GoogleDriveTemplateFormProps) => {
+const GoogleDriveTemplateForm = ({ initialDocTemplate, initialSpreadsheetTemplate }: {
+  initialDocTemplate?: string;
+  initialSpreadsheetTemplate?: string;
+}) => {
   const [state, setState] = useState<GoogleDriveTemplateFormState>({
     submitState: SubmitState.IDLE,
   });
-  const [docTemplate, setDocTemplate] = useState<string>(props.initialDocTemplate || '');
-  const [spreadsheetTemplate, setSpreadsheetTemplate] = useState<string>(props.initialSpreadsheetTemplate || '');
+  const [docTemplate, setDocTemplate] = useState<string>(initialDocTemplate || '');
+  const [spreadsheetTemplate, setSpreadsheetTemplate] = useState<string>(initialSpreadsheetTemplate || '');
 
   const dismissAlert = useCallback(() => {
     setState({ submitState: SubmitState.IDLE });
@@ -617,12 +613,9 @@ const GoogleIntegrationSection = () => {
   );
 };
 
-interface EmailConfigFormProps {
+const EmailConfigForm = ({ initialConfig }: {
   initialConfig?: SettingType & { name: 'email.branding' };
-}
-
-const EmailConfigForm = (props: EmailConfigFormProps) => {
-  const initialConfig = props.initialConfig;
+}) => {
   const [from, setFrom] = useState<string>(initialConfig?.value.from || '');
   const [enrollAccountSubject, setEnrollAccountSubject] =
     useState<string>(initialConfig?.value.enrollAccountMessageSubjectTemplate || '');
@@ -967,15 +960,13 @@ const EmailConfigSection = () => {
   );
 };
 
-interface DiscordOAuthFormProps {
+const DiscordOAuthForm = ({ oauthSettings }: {
   oauthSettings: any;
-}
-
-const DiscordOAuthForm = (props: DiscordOAuthFormProps) => {
+}) => {
   const [clientId, setClientId] =
-    useState<string>((props.oauthSettings && props.oauthSettings.appId) || '');
+    useState<string>((oauthSettings && oauthSettings.appId) || '');
   const [clientSecret, setClientSecret] =
-    useState<string>((props.oauthSettings && props.oauthSettings.secret) || '');
+    useState<string>((oauthSettings && oauthSettings.secret) || '');
   const [submitState, setSubmitState] = useState<SubmitState>(SubmitState.IDLE);
   const [submitError, setSubmitError] = useState<string>('');
 
@@ -1019,7 +1010,7 @@ const DiscordOAuthForm = (props: DiscordOAuthFormProps) => {
   }, [clientId, clientSecret]);
 
   const shouldDisableForm = submitState === 'submitting';
-  const configured = !!props.oauthSettings;
+  const configured = !!oauthSettings;
   const secretPlaceholder = configured ? '<configured secret not revealed>' : '';
   return (
     <div>
@@ -1067,12 +1058,8 @@ const DiscordOAuthForm = (props: DiscordOAuthFormProps) => {
   );
 };
 
-interface DiscordBotFormProps {
-  botToken?: string
-}
-
-const DiscordBotForm = (props: DiscordBotFormProps) => {
-  const [botToken, setBotToken] = useState<string>(props.botToken || '');
+const DiscordBotForm = ({ botToken: initialBotToken }: { botToken?: string }) => {
+  const [botToken, setBotToken] = useState<string>(initialBotToken || '');
   const [submitState, setSubmitState] = useState<SubmitState>(SubmitState.IDLE);
   const [submitError, setSubmitError] = useState<string>('');
 
@@ -1132,18 +1119,16 @@ const DiscordBotForm = (props: DiscordBotFormProps) => {
   );
 };
 
-interface DiscordGuildFormProps {
+const DiscordGuildForm = ({ guild: initialGuild }: {
   // initial value from settings
-  guild?: DiscordGuildType;
-}
-
-const DiscordGuildForm = (props: DiscordGuildFormProps) => {
+  guild?: DiscordGuildType,
+}) => {
   useSubscribe('discord.guilds');
   const guilds = useTracker(() => {
     return DiscordCache.find({ type: 'guild' }, { fields: { 'object.id': 1, 'object.name': 1 } })
       .map((c) => c.object as SavedDiscordObjectType);
   }, []);
-  const [guildId, setGuildId] = useState<string>((props.guild && props.guild.id) || '');
+  const [guildId, setGuildId] = useState<string>((initialGuild && initialGuild.id) || '');
   const [submitState, setSubmitState] = useState<SubmitState>(SubmitState.IDLE);
   const [submitError, setSubmitError] = useState<string>('');
 
@@ -1426,12 +1411,6 @@ const BrandingTeamName = () => {
   );
 };
 
-interface BrandingAssetRowProps {
-  asset: string;
-  backgroundSize?: string;
-  children?: ReactChild;
-}
-
 const BrandingRow = styled.div`
   &:not(:last-child) {
     margin-bottom: 8px;
@@ -1454,7 +1433,13 @@ const BrandingRowImage = styled.div<{ backgroundImage: string, backgroundSize: s
   background-size: ${(props) => props.backgroundSize};
 `;
 
-const BrandingAssetRow = (props: BrandingAssetRowProps) => {
+const BrandingAssetRow = ({
+  asset, backgroundSize, children,
+}: {
+  asset: string;
+  backgroundSize?: string;
+  children?: ReactChild;
+}) => {
   const [submitState, setSubmitState] = useState<SubmitState>(SubmitState.IDLE);
   const [submitError, setSubmitError] = useState<string>('');
 
@@ -1472,7 +1457,7 @@ const BrandingAssetRow = (props: BrandingAssetRowProps) => {
         return;
       }
       setSubmitState(SubmitState.SUBMITTING);
-      Meteor.call('setupGetUploadToken', props.asset, file.type, (err?: Error, uploadToken?: string) => {
+      Meteor.call('setupGetUploadToken', asset, file.type, (err?: Error, uploadToken?: string) => {
         if (err) {
           setSubmitError(err.message);
           setSubmitState(SubmitState.ERROR);
@@ -1499,10 +1484,10 @@ const BrandingAssetRow = (props: BrandingAssetRowProps) => {
         }
       });
     }
-  }, [props.asset]);
+  }, [asset]);
 
   // If no BlobMapping is present for this asset, fall back to the default one from the public/images folder
-  const blobUrl = useTracker(() => lookupUrl(props.asset), [props.asset]);
+  const blobUrl = useTracker(() => lookupUrl(asset), [asset]);
   return (
     <BrandingRow>
       {submitState === 'submitting' ? <Alert variant="info">Saving...</Alert> : null}
@@ -1517,12 +1502,12 @@ const BrandingAssetRow = (props: BrandingAssetRowProps) => {
       <BrandingRowContent>
         <BrandingRowImage
           backgroundImage={blobUrl}
-          backgroundSize={props.backgroundSize || 'auto'}
+          backgroundSize={backgroundSize || 'auto'}
         />
-        <label htmlFor={`asset-input-${props.asset}`}>
-          <div>{props.asset}</div>
-          <div>{props.children}</div>
-          <input id={`asset-input-${props.asset}`} type="file" onChange={onFileSelected} />
+        <label htmlFor={`asset-input-${asset}`}>
+          <div>{asset}</div>
+          <div>{children}</div>
+          <input id={`asset-input-${asset}`} type="file" onChange={onFileSelected} />
         </label>
       </BrandingRowContent>
     </BrandingRow>
@@ -1602,17 +1587,6 @@ const BrandingSection = () => {
   );
 };
 
-interface CircuitBreakerControlProps {
-  // What do you call this circuit breaker?
-  title: string;
-
-  // What is the database name for this flag
-  flagName: string;
-
-  // some explanation of what this feature flag controls and why you might want to toggle it.
-  children: React.ReactNode;
-}
-
 const CircuitBreaker = styled.div`
   margin-bottom: 16px;
 `;
@@ -1638,11 +1612,18 @@ const CircuitBreakerButtons = styled.div`
   }
 `;
 
-const CircuitBreakerControl = (props: CircuitBreakerControlProps) => {
-  const {
-    title, flagName, children,
-  } = props;
+const CircuitBreakerControl = ({
+  title, flagName, children,
+}: {
+  // What do you call this circuit breaker?
+  title: string;
 
+  // What is the database name for this flag
+  flagName: string;
+
+  // some explanation of what this feature flag controls and why you might want to toggle it.
+  children: React.ReactNode;
+}) => {
   // disabled should be false if the circuit breaker is not intentionally disabling the feature,
   // and true if the feature is currently disabled.
   // most features will have false here most of the time.

--- a/imports/client/components/SplashPage.tsx
+++ b/imports/client/components/SplashPage.tsx
@@ -17,11 +17,7 @@ const Image = styled(BSImage)`
   max-width: 50%;
 `;
 
-interface SplashPageProps {
-  children: React.ReactNode;
-}
-
-const SplashPage = (props: SplashPageProps) => {
+const SplashPage = ({ children }: { children: React.ReactNode }) => {
   const { heroSrc, heroSrc2x } = useTracker(() => {
     return {
       heroSrc: lookupUrl('hero.png'),
@@ -36,7 +32,7 @@ const SplashPage = (props: SplashPageProps) => {
           <Image src={heroSrc} className="d-block mx-auto" srcSet={`${heroSrc} 1x, ${heroSrc2x} 2x`} />
           <Row>
             <Col md={{ span: 6, offset: 3 }}>
-              {props.children}
+              {children}
             </Col>
           </Row>
         </Container>

--- a/imports/client/components/SplitPanePlus.tsx
+++ b/imports/client/components/SplitPanePlus.tsx
@@ -120,39 +120,36 @@ interface SplitPanePlusState {
   dragInProgress: boolean;
 }
 
-const SplitPanePlusHook = (props: SplitPanePlusProps) => {
+const SplitPanePlusHook = ({
+  children,
+  size,
+  collapsed = 0,
+  primary = 'first',
+  split = 'vertical',
+  allowResize = true,
+  minSize = 0,
+  maxSize = 0,
+  autoCollapse1 = 50,
+  autoCollapse2 = 50,
+  scaling = 'absolute',
+  onChanged,
+  onPaneChanged,
+  step,
+  className,
+  style,
+  paneClassName,
+  paneStyle,
+  pane1ClassName,
+  pane1Style,
+  pane2ClassName,
+  pane2Style,
+  resizerClassName,
+  resizerStyle,
+}: SplitPanePlusProps) => {
   const [state, setState] = useState<SplitPanePlusState>({
     collapseWarning: 0,
     dragInProgress: false,
   });
-
-  // Unpack props with defaults
-  const {
-    children,
-    size,
-    collapsed = 0,
-    primary = 'first',
-    split = 'vertical',
-    allowResize = true,
-    minSize = 0,
-    maxSize = 0,
-    autoCollapse1 = 50,
-    autoCollapse2 = 50,
-    scaling = 'absolute',
-    onChanged,
-    onPaneChanged,
-    step,
-    className,
-    style,
-    paneClassName,
-    paneStyle,
-    pane1ClassName,
-    pane1Style,
-    pane2ClassName,
-    pane2Style,
-    resizerClassName,
-    resizerStyle,
-  } = props;
 
   const ref = useRef<HTMLDivElement | null>(null);
 

--- a/imports/client/components/Tag.tsx
+++ b/imports/client/components/Tag.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import { _ } from 'meteor/underscore';
 import { faAlignJustify } from '@fortawesome/free-solid-svg-icons/faAlignJustify';
 import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';

--- a/imports/client/components/TagEditor.tsx
+++ b/imports/client/components/TagEditor.tsx
@@ -7,18 +7,17 @@ import Loading from './Loading';
 // Casting away the React.lazy because otherwise we lose access to the generic parameter
 const Creatable = React.lazy(() => import('react-select/creatable')) as typeof import('react-select/creatable').default;
 
-interface TagEditorProps {
+const TagEditor = ({
+  puzzle, onSubmit, onCancel,
+}: {
   puzzle: PuzzleType;
   onSubmit: (value: string) => void;
   onCancel: () => void;
-}
-
-const TagEditor = (props: TagEditorProps) => {
+}) => {
   const allTags = useTracker(() => {
-    return Tags.find({ hunt: props.puzzle.hunt }).fetch();
-  }, [props.puzzle.hunt]);
+    return Tags.find({ hunt: puzzle.hunt }).fetch();
+  }, [puzzle.hunt]);
 
-  const { onCancel } = props;
   const onBlur = useCallback(() => {
     // Treat blur as "no I didn't mean to do that".  We may have to change this
     // once we have autocomplete .
@@ -39,7 +38,7 @@ const TagEditor = (props: TagEditorProps) => {
           options={options}
           autoFocus
           openMenuOnFocus
-          onChange={(v) => v && props.onSubmit(v.value)}
+          onChange={(v) => v && onSubmit(v.value)}
           onBlur={onBlur}
         />
       </span>

--- a/imports/client/hooks/breadcrumb.tsx
+++ b/imports/client/hooks/breadcrumb.tsx
@@ -45,11 +45,7 @@ const defaultCallbacks: BreadcrumbContextType = {
 
 const BreadcrumbContext = React.createContext<BreadcrumbContextType>(defaultCallbacks);
 
-type BreadcrumbProviderProps = {
-  children: React.ReactNode;
-}
-
-const BreadcrumbsProvider = (props: BreadcrumbProviderProps) => {
+const BreadcrumbsProvider = ({ children }: { children: React.ReactNode }) => {
   const crumbsRef = useRef<CrumbWithId[]>([]);
   const listenersRef = useRef<((crumbs: CrumbWithId[]) => void)[]>([]);
 
@@ -134,7 +130,7 @@ const BreadcrumbsProvider = (props: BreadcrumbProviderProps) => {
 
   return (
     <BreadcrumbContext.Provider value={providerCallbacks}>
-      {props.children}
+      {children}
     </BreadcrumbContext.Provider>
   );
 };


### PR DESCRIPTION
There are a few components (AccountForm and Tag) where this isn't
practical because we're using a disjunction type to capture when certain
parameters are optional or not, and there's no way to do a destructuring
assignment that works across both sides of the disjunction.

I left them as-is for now, but at some point we should maybe reevaluate
if this is the best way to configure the types.