### PR TITLE
Per-hunt permissions

### DIFF
--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -23,7 +23,7 @@ import Hunts from '../../lib/models/hunts';
 import PendingAnnouncements from '../../lib/models/pending_announcements';
 import Profiles from '../../lib/models/profiles';
 import Puzzles from '../../lib/models/puzzles';
-import { deprecatedIsOperator } from '../../lib/permission_stubs';
+import { userIsOperatorForAnyHunt } from '../../lib/permission_stubs';
 import { AnnouncementType } from '../../lib/schemas/announcement';
 import { ChatNotificationType } from '../../lib/schemas/chat_notification';
 import { GuessType } from '../../lib/schemas/guess';
@@ -439,8 +439,8 @@ const StyledNotificationCenter = styled.ul`
 `;
 
 const NotificationCenter = () => {
-  const canUpdateGuesses = useTracker(() => deprecatedIsOperator(Meteor.userId()));
-  const pendingGuessesLoading = useSubscribe(canUpdateGuesses ? 'pendingGuesses' : undefined);
+  const fetchPendingGuesses = useTracker(() => userIsOperatorForAnyHunt(Meteor.userId()), []);
+  const pendingGuessesLoading = useSubscribe(fetchPendingGuesses ? 'pendingGuesses' : undefined);
 
   const [operatorActionsHidden = {}] = useOperatorActionsHidden();
 
@@ -481,10 +481,10 @@ const NotificationCenter = () => {
   const announcements = useTracker(() => (loading ? {} : _.indexBy(Announcements.find().fetch(), '_id')), [loading]);
 
   const guesses = useTracker(() => (
-    loading || !canUpdateGuesses ?
+    loading || !fetchPendingGuesses ?
       [] :
       Guesses.find({ state: 'pending' }, { sort: { createdAt: 1 } }).fetch()
-  ), [loading, canUpdateGuesses]);
+  ), [loading, fetchPendingGuesses]);
   const pendingAnnouncements = useTracker(() => (
     loading ?
       [] :

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -23,7 +23,7 @@ import Hunts from '../../lib/models/hunts';
 import PendingAnnouncements from '../../lib/models/pending_announcements';
 import Profiles from '../../lib/models/profiles';
 import Puzzles from '../../lib/models/puzzles';
-import { deprecatedIsActiveOperator } from '../../lib/permission_stubs';
+import { deprecatedIsOperator } from '../../lib/permission_stubs';
 import { AnnouncementType } from '../../lib/schemas/announcement';
 import { ChatNotificationType } from '../../lib/schemas/chat_notification';
 import { GuessType } from '../../lib/schemas/guess';
@@ -31,6 +31,7 @@ import { HuntType } from '../../lib/schemas/hunt';
 import { PuzzleType } from '../../lib/schemas/puzzle';
 import { guessURL } from '../../model-helpers';
 import { requestDiscordCredential } from '../discord';
+import { useOperatorActionsHidden } from '../hooks/persisted-state';
 import useSubscribeDisplayNames from '../hooks/use-subscribe-display-names';
 import markdown from '../markdown';
 import Breakable from './styling/Breakable';
@@ -438,8 +439,10 @@ const StyledNotificationCenter = styled.ul`
 `;
 
 const NotificationCenter = () => {
-  const canUpdateGuesses = useTracker(() => deprecatedIsActiveOperator(Meteor.userId()));
+  const canUpdateGuesses = useTracker(() => deprecatedIsOperator(Meteor.userId()));
   const pendingGuessesLoading = useSubscribe(canUpdateGuesses ? 'pendingGuesses' : undefined);
+
+  const [operatorActionsHidden = {}] = useOperatorActionsHidden();
 
   // This is overly broad, but we likely already have the data cached locally
   const userId = useTracker(() => Meteor.userId()!);
@@ -540,6 +543,7 @@ const NotificationCenter = () => {
 
   guesses.forEach((g) => {
     if (dismissedGuesses[g._id]) return;
+    if (operatorActionsHidden[g.hunt]) return;
     messages.push(<GuessMessage
       key={g._id}
       guess={g}

--- a/imports/client/components/OthersProfilePage.tsx
+++ b/imports/client/components/OthersProfilePage.tsx
@@ -1,10 +1,6 @@
-import { Meteor } from 'meteor/meteor';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import { _ } from 'meteor/underscore';
-import React, { useCallback, useState } from 'react';
-import Badge from 'react-bootstrap/Badge';
-import Button from 'react-bootstrap/Button';
-import Modal from 'react-bootstrap/Modal';
+import React from 'react';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/esm/Tooltip';
 import styled from 'styled-components';
@@ -26,148 +22,103 @@ const ProfileTable = styled.table`
 `;
 
 const OthersProfilePage = ({
-  profile, viewerCanMakeOperator, targetIsOperator, huntMembership,
+  profile, huntMembership,
 }: {
   profile: ProfileType;
-  viewerCanMakeOperator: boolean;
-  targetIsOperator: boolean;
   huntMembership?: string[];
 }) => {
-  const [shouldShowOperatorConfirm, setShouldShowOperatorConfirm] = useState(false);
-  const showConfirm = useCallback(() => setShouldShowOperatorConfirm(true), []);
-  const hideConfirm = useCallback(() => setShouldShowOperatorConfirm(false), []);
+  const showHuntList = (huntMembership?.length ?? 0) > 0;
 
-  const huntsLoading = useSubscribe(viewerCanMakeOperator ? 'mongo.hunts' : undefined, {});
+  const huntsLoading = useSubscribe(showHuntList ? 'mongo.hunts' : undefined, {});
   const loading = huntsLoading();
   const hunts = useTracker(() => (loading ? {} : _.indexBy(Hunts.find().fetch(), '_id')), [loading]);
 
-  const makeOperator = useCallback(() => {
-    Meteor.call('makeOperator', profile._id);
-    hideConfirm();
-  }, [profile._id, hideConfirm]);
-
-  const showOperatorBadge = targetIsOperator;
-  const showMakeOperatorButton = viewerCanMakeOperator && !targetIsOperator;
   const discordAvatarUrl = getAvatarCdnUrl(profile.discordAccount);
   const discordAvatarUrlLarge = getAvatarCdnUrl(profile.discordAccount, 256);
   return (
-    <>
-      {showMakeOperatorButton && (
-        <Modal show={shouldShowOperatorConfirm} onHide={hideConfirm}>
-          <Modal.Header closeButton>
-            <Modal.Title>Make Operator</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            <p>
-              Are you sure you want to make this user an operator? This can not easily be undone.
-            </p>
-          </Modal.Body>
-          <Modal.Footer>
-            <Button variant="secondary" onClick={hideConfirm}>
-              Cancel
-            </Button>
-            <Button variant="primary" onClick={makeOperator}>
-              Make Operator
-            </Button>
-          </Modal.Footer>
-        </Modal>
-      )}
-      <div>
-        <h1>
-          {discordAvatarUrl && (
-            <>
-              <OverlayTrigger
-                placement="bottom-start"
-                overlay={(
-                  <AvatarTooltip id="tooltip-avatar">
-                    <img
-                      alt="Discord avatar"
-                      src={discordAvatarUrlLarge}
-                      width={128}
-                      height={128}
-                    />
-                  </AvatarTooltip>
-                )}
-              >
-                <img
-                  alt={`${profile.displayName}'s Discord avatar`}
-                  src={discordAvatarUrl}
-                  width={40}
-                  height={40}
-                  className="discord-avatar"
-                />
-              </OverlayTrigger>
-              {' '}
-            </>
-          )}
-          {profile.displayName}
-          {showOperatorBadge && (
-            <>
-              {' '}
-              <Badge variant="primary">operator</Badge>
-            </>
-          )}
-          {showMakeOperatorButton && (
-            <>
-              {' '}
-              <Button variant="danger" onClick={showConfirm}>Make operator</Button>
-            </>
-          )}
-        </h1>
+    <div>
+      <h1>
+        {discordAvatarUrl && (
+          <>
+            <OverlayTrigger
+              placement="bottom-start"
+              overlay={(
+                <AvatarTooltip id="tooltip-avatar">
+                  <img
+                    alt="Discord avatar"
+                    src={discordAvatarUrlLarge}
+                    width={128}
+                    height={128}
+                  />
+                </AvatarTooltip>
+              )}
+            >
+              <img
+                alt={`${profile.displayName}'s Discord avatar`}
+                src={discordAvatarUrl}
+                width={40}
+                height={40}
+                className="discord-avatar"
+              />
+            </OverlayTrigger>
+            {' '}
+          </>
+        )}
+        {profile.displayName}
+      </h1>
 
-        <ProfileTable>
-          <tbody>
-            <tr>
-              <th>Email</th>
-              <td>
-                <a href={`mailto:${profile.primaryEmail}`} target="_blank" rel="noreferrer">
-                  {profile.primaryEmail}
+      <ProfileTable>
+        <tbody>
+          <tr>
+            <th>Email</th>
+            <td>
+              <a href={`mailto:${profile.primaryEmail}`} target="_blank" rel="noreferrer">
+                {profile.primaryEmail}
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <th>Phone</th>
+            <td>
+              {profile.phoneNumber ? (
+                <a href={`tel:${profile.phoneNumber}`}>{profile.phoneNumber}</a>
+              ) : (
+                '(none)'
+              )}
+            </td>
+          </tr>
+          <tr>
+            <th>Discord handle</th>
+            <td>
+              {profile.discordAccount ? (
+                <a href={`https://discord.com/users/${profile.discordAccount.id}`} target="_blank" rel="noreferrer">
+                  {profile.discordAccount.username}
+                  #
+                  {profile.discordAccount.discriminator}
                 </a>
-              </td>
-            </tr>
+              ) : (
+                '(none)'
+              )}
+            </td>
+          </tr>
+          {showHuntList && (
             <tr>
-              <th>Phone</th>
+              <th>All hunts participated</th>
               <td>
-                {profile.phoneNumber ? (
-                  <a href={`tel:${profile.phoneNumber}`}>{profile.phoneNumber}</a>
-                ) : (
-                  '(none)'
+                {(
+                  loading ?
+                    'loading...' :
+                    huntMembership?.map((huntId) => (
+                      hunts[huntId]?.name ?? `Unknown hunt ${huntId}`
+                    ))
+                      .join(', ')
                 )}
               </td>
             </tr>
-            <tr>
-              <th>Discord handle</th>
-              <td>
-                {profile.discordAccount ? (
-                  <a href={`https://discord.com/users/${profile.discordAccount.id}`} target="_blank" rel="noreferrer">
-                    {profile.discordAccount.username}
-                    #
-                    {profile.discordAccount.discriminator}
-                  </a>
-                ) : (
-                  '(none)'
-                )}
-              </td>
-            </tr>
-            {viewerCanMakeOperator && huntMembership && (
-              <tr>
-                <th>All hunts participated</th>
-                <td>
-                  {(
-                    loading ?
-                      'loading...' :
-                      huntMembership.map((huntId) => (
-                        hunts[huntId]?.name ?? `Unknown hunt ${huntId}`
-                      ))
-                        .join(', ')
-                  )}
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </ProfileTable>
-      </div>
-    </>
+          )}
+        </tbody>
+      </ProfileTable>
+    </div>
   );
 };
 

--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -283,13 +283,7 @@ enum OwnProfilePageSubmitState {
   ERROR = 'error',
 }
 
-const OwnProfilePage = ({
-  initialProfile, operating, canMakeOperator,
-}: {
-  initialProfile: ProfileType;
-  operating: boolean;
-  canMakeOperator: boolean;
-}) => {
+const OwnProfilePage = ({ initialProfile }: { initialProfile: ProfileType }) => {
   const [displayName, setDisplayName] = useState<string>(initialProfile.displayName || '');
   const [phoneNumber, setPhoneNumber] = useState<string>(initialProfile.phoneNumber || '');
   const [muteApplause, setMuteApplause] =
@@ -315,15 +309,6 @@ const OwnProfilePage = ({
   const handleDingwordsChange: FormControlProps['onChange'] = useCallback((e) => {
     setDingwordsFlat(e.currentTarget.value);
   }, []);
-
-  const toggleOperating = useCallback(() => {
-    const newState = !operating;
-    if (newState) {
-      Meteor.call('makeOperator', Meteor.userId());
-    } else {
-      Meteor.call('stopOperating');
-    }
-  }, [operating]);
 
   const handleSaveForm = useCallback(() => {
     setSubmitState(OwnProfilePageSubmitState.SUBMITTING);
@@ -354,7 +339,6 @@ const OwnProfilePage = ({
   return (
     <div>
       <h1>Account information</h1>
-      {canMakeOperator ? <FormCheck type="checkbox" checked={operating} onChange={toggleOperating} label="Operating" /> : null}
       <FormGroup>
         <FormLabel htmlFor="jr-profile-edit-email">
           Email address

--- a/imports/client/components/ProfilePage.tsx
+++ b/imports/client/components/ProfilePage.tsx
@@ -5,7 +5,6 @@ import { Navigate, useParams } from 'react-router-dom';
 import Profiles from '../../lib/models/profiles';
 import {
   deprecatedUserMayMakeOperator,
-  deprecatedIsActiveOperator,
 } from '../../lib/permission_stubs';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 import OthersProfilePage from './OthersProfilePage';
@@ -38,10 +37,9 @@ const ProfilePage = ({ userId, isSelf }: { userId: string, isSelf: boolean }) =>
     };
   }, [userId]);
   const hunts = useTracker(() => Meteor.users.findOne(userId)?.hunts, [userId]);
-  const { viewerCanMakeOperator, viewerIsOperator, targetIsOperator } = useTracker(() => {
+  const { viewerCanMakeOperator, targetIsOperator } = useTracker(() => {
     return {
       viewerCanMakeOperator: deprecatedUserMayMakeOperator(Meteor.userId()),
-      viewerIsOperator: deprecatedIsActiveOperator(Meteor.userId()),
       targetIsOperator: deprecatedUserMayMakeOperator(userId),
     };
   }, [userId]);
@@ -54,13 +52,7 @@ const ProfilePage = ({ userId, isSelf }: { userId: string, isSelf: boolean }) =>
   if (loading) {
     return <div>loading...</div>;
   } else if (isSelf) {
-    return (
-      <OwnProfilePage
-        initialProfile={profile}
-        canMakeOperator={viewerCanMakeOperator}
-        operating={viewerIsOperator}
-      />
-    );
+    return <OwnProfilePage initialProfile={profile} />;
   }
 
   return (

--- a/imports/client/components/ProfilePage.tsx
+++ b/imports/client/components/ProfilePage.tsx
@@ -3,9 +3,6 @@ import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import React from 'react';
 import { Navigate, useParams } from 'react-router-dom';
 import Profiles from '../../lib/models/profiles';
-import {
-  deprecatedUserMayMakeOperator,
-} from '../../lib/permission_stubs';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 import OthersProfilePage from './OthersProfilePage';
 import OwnProfilePage from './OwnProfilePage';
@@ -37,12 +34,6 @@ const ProfilePage = ({ userId, isSelf }: { userId: string, isSelf: boolean }) =>
     };
   }, [userId]);
   const hunts = useTracker(() => Meteor.users.findOne(userId)?.hunts, [userId]);
-  const { viewerCanMakeOperator, targetIsOperator } = useTracker(() => {
-    return {
-      viewerCanMakeOperator: deprecatedUserMayMakeOperator(Meteor.userId()),
-      targetIsOperator: deprecatedUserMayMakeOperator(userId),
-    };
-  }, [userId]);
 
   useBreadcrumb({
     title: loading ? 'loading...' : profile.displayName,
@@ -58,8 +49,6 @@ const ProfilePage = ({ userId, isSelf }: { userId: string, isSelf: boolean }) =>
   return (
     <OthersProfilePage
       profile={profile}
-      viewerCanMakeOperator={viewerCanMakeOperator}
-      targetIsOperator={targetIsOperator}
       huntMembership={hunts}
     />
   );

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -15,6 +15,7 @@ import { Link } from 'react-router-dom';
 import Ansible from '../../ansible';
 import { PuzzleType } from '../../lib/schemas/puzzle';
 import { TagType } from '../../lib/schemas/tag';
+import { useOperatorActionsHidden } from '../hooks/persisted-state';
 import PuzzleActivity from './PuzzleActivity';
 import PuzzleAnswer from './PuzzleAnswer';
 import PuzzleDeleteModal from './PuzzleDeleteModal';
@@ -32,6 +33,9 @@ const Puzzle = React.memo(({
   suppressTags?: string[];
   segmentAnswers?: boolean;
 }) => {
+  const [operatorActionsHidden] = useOperatorActionsHidden();
+  const showEdit = canUpdate && !operatorActionsHidden;
+
   // Generating the edit modals for all puzzles is expensive, so we do it
   // lazily. The first time the modal button is clicked, we change this state
   // variable, which causes us to mount a new modal, which is set to open on
@@ -65,7 +69,7 @@ const Puzzle = React.memo(({
   }, [renderDeleteModal]);
 
   const editButtons = useMemo(() => {
-    if (canUpdate) {
+    if (showEdit) {
       return (
         <ButtonGroup size="sm">
           <Button onClick={onShowEditModal} variant="light" title="Edit puzzle...">
@@ -80,7 +84,7 @@ const Puzzle = React.memo(({
       );
     }
     return null;
-  }, [canUpdate, puzzle.deleted, onShowEditModal, onShowDeleteModal]);
+  }, [showEdit, puzzle.deleted, onShowEditModal, onShowDeleteModal]);
 
   // id, title, answer, tags
   const linkTarget = `/hunts/${puzzle.hunt}/puzzles/${puzzle._id}`;
@@ -138,7 +142,7 @@ const Puzzle = React.memo(({
           puzzle={puzzle}
         />
       )}
-      {canUpdate && (
+      {showEdit && (
         <div className="puzzle-column puzzle-edit-button">
           {editButtons}
         </div>

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -6,6 +6,7 @@ import { faEraser } from '@fortawesome/free-solid-svg-icons/faEraser';
 import { faFaucet } from '@fortawesome/free-solid-svg-icons/faFaucet';
 import { faMap } from '@fortawesome/free-solid-svg-icons/faMap';
 import { faReceipt } from '@fortawesome/free-solid-svg-icons/faReceipt';
+import { faUserCog } from '@fortawesome/free-solid-svg-icons/faUserCog';
 import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, {
@@ -13,13 +14,16 @@ import React, {
 } from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
 import FormControl, { FormControlProps } from 'react-bootstrap/FormControl';
 import FormGroup from 'react-bootstrap/FormGroup';
 import FormLabel from 'react-bootstrap/FormLabel';
 import InputGroup from 'react-bootstrap/InputGroup';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import ToggleButton from 'react-bootstrap/ToggleButton';
 import ToggleButtonGroup from 'react-bootstrap/ToggleButtonGroup';
+import Tooltip from 'react-bootstrap/Tooltip';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Hunts from '../../lib/models/hunts';
@@ -27,6 +31,7 @@ import Puzzles from '../../lib/models/puzzles';
 import Tags from '../../lib/models/tags';
 import { userMayWritePuzzlesForHunt } from '../../lib/permission_stubs';
 import { PuzzleType } from '../../lib/schemas/puzzle';
+import { useOperatorActionsHiddenForHunt } from '../hooks/persisted-state';
 import PuzzleList from './PuzzleList';
 import PuzzleModalForm, {
   PuzzleModalFormHandle, PuzzleModalFormSubmitPayload,
@@ -111,6 +116,11 @@ const PuzzleListView = ({
     const localStorageShowSolved = localStorage.getItem(showSolvedKey);
     return !(localStorageShowSolved === 'false');
   });
+
+  const [operatorActionsHidden, setOperatorActionsHidden] = useOperatorActionsHiddenForHunt(huntId);
+  const toggleOperatorActionsHidden = useCallback(() => {
+    setOperatorActionsHidden((h) => !h);
+  }, [setOperatorActionsHidden]);
 
   const maybeStealCtrlF = useCallback((e: KeyboardEvent) => {
     if (e.ctrlKey && e.key === 'f') {
@@ -315,13 +325,33 @@ const PuzzleListView = ({
 
   const addPuzzleContent = canAdd && (
     <>
-      <Button variant="primary" onClick={showAddModal}>Add a puzzle</Button>
       <PuzzleModalForm
         huntId={huntId}
         tags={allTags}
         ref={addModalRef}
         onSubmit={onAdd}
       />
+      <ButtonGroup>
+        <Button variant="primary" onClick={showAddModal}>Add a puzzle</Button>
+        <OverlayTrigger
+          placement="top"
+          overlay={(
+            <Tooltip id="operator-mode-tooltip">
+              Show/hide operator actions (currently
+              {' '}
+              {operatorActionsHidden ? 'hidden' : 'visible'}
+              )
+            </Tooltip>
+          )}
+        >
+          <Button
+            variant={operatorActionsHidden ? 'outline-primary' : 'primary'}
+            onClick={toggleOperatorActionsHidden}
+          >
+            <FontAwesomeIcon icon={faUserCog} />
+          </Button>
+        </OverlayTrigger>
+      </ButtonGroup>
     </>
   );
 

--- a/imports/client/components/RTCDebugPage.tsx
+++ b/imports/client/components/RTCDebugPage.tsx
@@ -42,7 +42,7 @@ import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { RECENT_ACTIVITY_TIME_WINDOW_MS } from '../../lib/config/webrtc';
 import { getAvatarCdnUrl } from '../../lib/discord';
-import isAdmin from '../../lib/is-admin';
+import { userIdIsAdmin } from '../../lib/is-admin';
 import CallHistories from '../../lib/models/mediasoup/call_histories';
 import ConnectAcks from '../../lib/models/mediasoup/connect_acks';
 import ConnectRequests from '../../lib/models/mediasoup/connect_requests';
@@ -893,7 +893,7 @@ const ServerTable = ({ servers }: { servers: ServerType[] }) => {
 };
 
 const RTCDebugPage = () => {
-  const viewerIsAdmin = useTracker(() => isAdmin(Meteor.userId()));
+  const viewerIsAdmin = useTracker(() => userIdIsAdmin(Meteor.userId()));
   const debugInfoLoading = useSubscribe('mediasoup:debug');
   const puzzlesLoading = useSubscribe('mongo.puzzles');
   const displayNamesLoading = useSubscribeDisplayNames();

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -15,7 +15,7 @@ import FormLabel from 'react-bootstrap/FormLabel';
 import FormText from 'react-bootstrap/FormText';
 import styled from 'styled-components';
 import Flags from '../../flags';
-import isAdmin from '../../lib/is-admin';
+import { userIdIsAdmin } from '../../lib/is-admin';
 import DiscordCache from '../../lib/models/discord_cache';
 import Settings from '../../lib/models/settings';
 import { SavedDiscordObjectType } from '../../lib/schemas/hunt';
@@ -1787,7 +1787,7 @@ const SetupPage = () => {
   useBreadcrumb({ title: 'Server setup', path: '/setup' });
 
   const loading = useSubscribe('mongo.settings');
-  const canConfigure = useTracker(() => isAdmin(Meteor.userId()), []);
+  const canConfigure = useTracker(() => userIdIsAdmin(Meteor.userId()), []);
 
   if (loading()) {
     return (

--- a/imports/client/hooks/persisted-state.ts
+++ b/imports/client/hooks/persisted-state.ts
@@ -1,0 +1,28 @@
+import { Dispatch, SetStateAction } from 'react';
+import createPersistedState from 'use-persisted-state';
+
+export type OperatorActionsHiddenState = Record<string /* huntId */, boolean>;
+export const useOperatorActionsHidden: () => [
+  OperatorActionsHiddenState | undefined,
+  Dispatch<SetStateAction<OperatorActionsHiddenState | undefined>>
+] =
+  createPersistedState('operatorActionsHidden');
+
+export const useOperatorActionsHiddenForHunt = (huntId: string): readonly [
+  boolean,
+  Dispatch<SetStateAction<boolean>>,
+] => {
+  const [operatorActionsHidden, setOperatorActionsHidden] = useOperatorActionsHidden();
+  return [
+    operatorActionsHidden?.[huntId] ?? false,
+    (update: SetStateAction<boolean>) => {
+      setOperatorActionsHidden((prevHidden) => {
+        const newHidden = {
+          ...prevHidden,
+          [huntId]: typeof update === 'function' ? update(prevHidden?.[huntId] ?? false) : update,
+        };
+        return newHidden;
+      });
+    },
+  ] as const;
+};

--- a/imports/lib/is-admin.ts
+++ b/imports/lib/is-admin.ts
@@ -1,9 +1,17 @@
+import { Meteor } from 'meteor/meteor';
 import MeteorUsers from './models/meteor_users';
 
-// This is in a separate file to avoid circular dependencies, since
+export const GLOBAL_SCOPE = '__GLOBAL__';
+
+// These are in a separate file to avoid circular dependencies, since
 // imports/lib/models/base.ts wants to use it for the global admin allow rules,
 // but permission_stubs accesses some other Base-derived collections.
-function isAdmin(userId: string | null | undefined): boolean {
+
+export function userIsAdmin(user: Meteor.User): boolean {
+  return user.roles?.[GLOBAL_SCOPE]?.includes('admin') ?? false;
+}
+
+export function userIdIsAdmin(userId: string | null | undefined): boolean {
   if (!userId) {
     return false;
   }
@@ -11,10 +19,6 @@ function isAdmin(userId: string | null | undefined): boolean {
   if (!user) {
     return false;
   }
-  if (user.roles && user.roles.includes('admin')) {
-    return true;
-  }
-  return false;
-}
 
-export default isAdmin;
+  return userIsAdmin(user);
+}

--- a/imports/lib/models/base.ts
+++ b/imports/lib/models/base.ts
@@ -1,7 +1,7 @@
 import { check, Match } from 'meteor/check';
 import { Meteor, Subscription } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
-import isAdmin from '../is-admin';
+import { userIdIsAdmin } from '../is-admin';
 import { BaseType } from '../schemas/base';
 
 const formatQuery = Symbol('formatQuery');
@@ -42,13 +42,13 @@ class Base<T extends BaseType> extends Mongo.Collection<T> {
     // relied upon by any client-side code that is part of the application.
     this.allow({
       insert(userId, _doc) {
-        return isAdmin(userId);
+        return userIdIsAdmin(userId);
       },
       update(userId, _doc, _fieldNames, _modifier) {
-        return isAdmin(userId);
+        return userIdIsAdmin(userId);
       },
       remove(userId, _doc) {
-        return isAdmin(userId);
+        return userIdIsAdmin(userId);
       },
     });
   }

--- a/imports/lib/models/settings.ts
+++ b/imports/lib/models/settings.ts
@@ -1,7 +1,7 @@
 import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
-import isAdmin from '../is-admin';
+import { userIdIsAdmin } from '../is-admin';
 import SettingSchema, { SettingType } from '../schemas/setting';
 import Base, { FindOptions } from './base';
 
@@ -23,7 +23,7 @@ if (Meteor.isServer) {
       });
 
       // Only allow admins to pull down Settings.
-      if (!this.userId || !isAdmin(this.userId)) {
+      if (!this.userId || !userIdIsAdmin(this.userId)) {
         return [];
       }
 

--- a/imports/lib/permission_stubs.ts
+++ b/imports/lib/permission_stubs.ts
@@ -41,7 +41,7 @@ export function userMayAddUsersToHunt(userId: string | null | undefined, huntId:
   return hunt.openSignups;
 }
 
-function isActiveOperatorForHunt(user: Meteor.User, _huntId: string): boolean {
+function isOperatorForHunt(user: Meteor.User, _huntId: string): boolean {
   // Today, this function doesn't consider the huntId scope, but some day, we'd like it to.
   if (user.roles && user.roles.includes('operator')) {
     return true;
@@ -50,16 +50,7 @@ function isActiveOperatorForHunt(user: Meteor.User, _huntId: string): boolean {
   return false;
 }
 
-function isInactiveOperatorForHunt(user: Meteor.User, _huntId: string): boolean {
-  // Today, this function doesn't consider the huntId scope, but some day, we'd like it to.
-  if (user.roles && user.roles.includes('inactiveOperator')) {
-    return true;
-  }
-
-  return false;
-}
-
-// Admins and active operators may add announcements to a hunt.
+// Admins and operators may add announcements to a hunt.
 export function userMayAddAnnouncementToHunt(
   userId: string | null | undefined,
   huntId: string,
@@ -82,7 +73,7 @@ export function userMayAddAnnouncementToHunt(
     return false;
   }
 
-  if (isActiveOperatorForHunt(user, huntId)) {
+  if (isOperatorForHunt(user, huntId)) {
     return true;
   }
 
@@ -117,14 +108,14 @@ export function userMayMakeOtherUserOperatorForHunt(
     return false;
   }
 
-  if (isActiveOperatorForHunt(user, huntId) || isInactiveOperatorForHunt(user, huntId)) {
+  if (isOperatorForHunt(user, huntId)) {
     return true;
   }
 
   return false;
 }
 
-export function deprecatedIsActiveOperator(userId: string | null | undefined): boolean {
+export function deprecatedIsOperator(userId: string | null | undefined): boolean {
   // TODO: move away from this in favor of hunt-scoped operator status
   if (!userId) {
     return false;
@@ -161,7 +152,7 @@ export function deprecatedUserMayMakeOperator(userId: string | null | undefined)
     return true;
   }
 
-  if (user.roles && (user.roles.includes('inactiveOperator') || user.roles.includes('operator'))) {
+  if (user.roles && user.roles.includes('operator')) {
     return true;
   }
 
@@ -182,7 +173,7 @@ export function userMayBulkAddToHunt(userId: string | null | undefined, huntId: 
     return true;
   }
 
-  if (isActiveOperatorForHunt(user, huntId) || isInactiveOperatorForHunt(user, huntId)) {
+  if (isOperatorForHunt(user, huntId)) {
     return true;
   }
 
@@ -260,7 +251,7 @@ export function userMayUpdateGuessesForHunt(
   if (user.roles && user.roles.includes('admin')) {
     return true;
   }
-  if (isActiveOperatorForHunt(user, huntId)) {
+  if (isOperatorForHunt(user, huntId)) {
     return true;
   }
   return false;
@@ -280,7 +271,7 @@ export function userMayWritePuzzlesForHunt(
   if (user.roles && user.roles.includes('admin')) {
     return true;
   }
-  if (isActiveOperatorForHunt(user, huntId)) {
+  if (isOperatorForHunt(user, huntId)) {
     return true;
   }
   return false;

--- a/imports/lib/schemas/user.ts
+++ b/imports/lib/schemas/user.ts
@@ -12,7 +12,7 @@ const UserCodec = t.type({
   createdAt: date,
   lastLogin: t.union([date, t.undefined]),
   services: t.union([t.object, t.undefined]),
-  roles: t.union([t.array(t.string), t.undefined]),
+  roles: t.union([t.object, t.undefined]),
   hunts: t.union([t.array(t.string), t.undefined]),
   profile: t.type({
     operating: t.boolean,

--- a/imports/server/api/resources/users.ts
+++ b/imports/server/api/resources/users.ts
@@ -4,7 +4,6 @@ import { Meteor } from 'meteor/meteor';
 import express from 'express';
 import MeteorUsers from '../../../lib/models/meteor_users';
 import Profiles from '../../../lib/models/profiles';
-import { deprecatedUserMayMakeOperator } from '../../../lib/permission_stubs';
 import { ProfileType } from '../../../lib/schemas/profile';
 
 // eslint-disable-next-line new-cap
@@ -37,14 +36,12 @@ const ACTIVE_THRESHOLD = 365 * 24 * 60 * 60 * 1000;
 const renderUser = function renderUser(user: Meteor.User, profile: ProfileType) {
   const active = user.lastLogin &&
           Date.now() - user.lastLogin.getTime() < ACTIVE_THRESHOLD;
-  const operator = deprecatedUserMayMakeOperator(user._id);
 
   return {
     _id: user._id,
     primaryEmail: user.emails && user.emails[0].address,
     googleAccount: profile.googleAccount,
     active,
-    operator,
   };
 };
 

--- a/imports/server/api_keys.ts
+++ b/imports/server/api_keys.ts
@@ -2,12 +2,12 @@ import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
 import Ansible from '../ansible';
-import isAdmin from '../lib/is-admin';
+import { userIdIsAdmin } from '../lib/is-admin';
 import APIKeys from './models/api_keys';
 import Locks from './models/lock';
 
 const userForKeyOperation = function userForKeyOperation(currentUser: string, forUser?: string) {
-  const canOverrideUser = isAdmin(currentUser);
+  const canOverrideUser = userIdIsAdmin(currentUser);
 
   if (forUser && !canOverrideUser) {
     throw new Meteor.Error(403, 'Only server admins can fetch other users\' keys');

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -7,7 +7,7 @@ import Hunts from '../lib/models/hunts';
 import MeteorUsers from '../lib/models/meteor_users';
 import Profiles from '../lib/models/profiles';
 import Puzzles from '../lib/models/puzzles';
-import { userMayUpdateGuessesForHunt, deprecatedIsActiveOperator } from '../lib/permission_stubs';
+import { userMayUpdateGuessesForHunt, deprecatedIsOperator } from '../lib/permission_stubs';
 import { GuessType } from '../lib/schemas/guess';
 import { HuntType } from '../lib/schemas/hunt';
 import { PuzzleType } from '../lib/schemas/puzzle';
@@ -138,7 +138,7 @@ class PendingGuessWatcher {
 Meteor.publish('pendingGuesses', function () {
   check(this.userId, String);
 
-  if (!deprecatedIsActiveOperator(this.userId)) {
+  if (!deprecatedIsOperator(this.userId)) {
     throw new Meteor.Error(401, 'Must be active operator to subscribe to pendingGuesses');
   }
 

--- a/imports/server/hunts.ts
+++ b/imports/server/hunts.ts
@@ -10,6 +10,7 @@ import MeteorUsers from '../lib/models/meteor_users';
 import Profiles from '../lib/models/profiles';
 import Settings from '../lib/models/settings';
 import {
+  addUserToRole,
   checkAdmin,
   userMayAddUsersToHunt,
   userMayBulkAddToHunt,
@@ -112,6 +113,7 @@ Meteor.methods({
     check(value, HuntShape);
 
     const huntId = Hunts.insert(value);
+    addUserToRole(this.userId, huntId, 'operator');
 
     Meteor.defer(() => {
       // Sync discord roles

--- a/imports/server/migrations/37-role-reorganization.ts
+++ b/imports/server/migrations/37-role-reorganization.ts
@@ -1,14 +1,45 @@
 import { Meteor } from 'meteor/meteor';
 import { Migrations } from 'meteor/percolate:migrations';
-import { addUserToRole, removeUserFromRole } from '../../lib/permission_stubs';
+import { GLOBAL_SCOPE } from '../../lib/is-admin';
 
 Migrations.add({
   version: 37,
   name: 'Reorganize roles and eliminate inactiveOperator',
   up() {
-    Meteor.users.find({ roles: 'inactiveOperator' }).forEach((user) => {
-      addUserToRole(user._id, 'operator');
-      removeUserFromRole(user._id, 'inactiveOperator');
+    // Casts necessary to account for schema changes
+
+    Meteor.users.find({ roles: 'inactiveOperator' } as any).forEach((user) => {
+      Meteor.users.update(user._id, {
+        $push: { roles: 'operator' },
+      } as any, {
+        validate: false,
+        filter: false,
+      } as any);
+      Meteor.users.update(user._id, {
+        $pull: { roles: 'inactiveOperator' },
+      } as any, {
+        validate: false,
+        filter: false,
+      } as any);
+    });
+
+    Meteor.users.find({ roles: { $type: 'array' } }).forEach((user) => {
+      const newRoles: Record<string, string[]> = {};
+      (user.roles as unknown as string[]).forEach((role) => {
+        if (role === 'operator') {
+          user.hunts?.forEach((huntId) => {
+            newRoles[huntId] ||= [];
+            newRoles[huntId].push('operator');
+          });
+        } else {
+          newRoles[GLOBAL_SCOPE] ||= [];
+          newRoles[GLOBAL_SCOPE].push(role);
+        }
+      });
+
+      Meteor.users.update(user._id, {
+        $set: { roles: newRoles },
+      }, { validate: false } as any);
     });
   },
 });

--- a/imports/server/migrations/37-role-reorganization.ts
+++ b/imports/server/migrations/37-role-reorganization.ts
@@ -1,0 +1,14 @@
+import { Meteor } from 'meteor/meteor';
+import { Migrations } from 'meteor/percolate:migrations';
+import { addUserToRole, removeUserFromRole } from '../../lib/permission_stubs';
+
+Migrations.add({
+  version: 37,
+  name: 'Reorganize roles and eliminate inactiveOperator',
+  up() {
+    Meteor.users.find({ roles: 'inactiveOperator' }).forEach((user) => {
+      addUserToRole(user._id, 'operator');
+      removeUserFromRole(user._id, 'inactiveOperator');
+    });
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -35,3 +35,4 @@ import './33-index-profile-dingwords';
 import './34-mediasoup-indexes';
 import './35-folder-permissions-indexes';
 import './36-call-history-indexes';
+import './37-role-reorganization';

--- a/imports/server/models/api_keys.ts
+++ b/imports/server/models/api_keys.ts
@@ -1,4 +1,4 @@
-import isAdmin from '../../lib/is-admin';
+import { userIdIsAdmin } from '../../lib/is-admin';
 import Base from '../../lib/models/base';
 import APIKeySchema, { APIKeyType } from '../schemas/api_key';
 
@@ -6,7 +6,7 @@ const APIKeys = new Base<APIKeyType>('api_keys');
 APIKeys.attachSchema(APIKeySchema);
 APIKeys.publish((userId, q) => {
   // Server admins can access all API keys
-  if (isAdmin(userId)) {
+  if (userIdIsAdmin(userId)) {
     return q;
   }
 

--- a/imports/server/operator.ts
+++ b/imports/server/operator.ts
@@ -2,23 +2,52 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import Ansible from '../ansible';
 import {
-  deprecatedUserMayMakeOperator,
   addUserToRole,
+  removeUserFromRole,
+  userMayMakeOperatorForHunt,
 } from '../lib/permission_stubs';
 
 Meteor.methods({
-  makeOperator(targetUserId: unknown) {
+  makeOperatorForHunt(targetUserId: unknown, huntId: string) {
     check(this.userId, String);
     check(targetUserId, String);
+    check(huntId, String);
 
-    if (!deprecatedUserMayMakeOperator(this.userId)) {
+    if (!userMayMakeOperatorForHunt(this.userId, huntId)) {
       throw new Meteor.Error(401, 'Must be operator or inactive operator to make operator');
+    }
+
+    const targetUser = Meteor.users.findOne(targetUserId);
+    if (!targetUser) {
+      throw new Meteor.Error(404, 'User not found');
     }
 
     if (this.userId !== targetUserId) {
       Ansible.log('Promoting user to operator', { user: targetUserId, promoter: this.userId });
     }
 
-    addUserToRole(targetUserId, 'operator');
+    addUserToRole(targetUserId, huntId, 'operator');
+  },
+
+  demoteOperatorForHunt(targetUserId: unknown, huntId: string) {
+    check(this.userId, String);
+    check(targetUserId, String);
+    check(huntId, String);
+
+    if (!userMayMakeOperatorForHunt(this.userId, huntId)) {
+      throw new Meteor.Error(401, 'Must be operator or inactive operator to demote operator');
+    }
+
+    const targetUser = Meteor.users.findOne(targetUserId);
+    if (!targetUser) {
+      throw new Meteor.Error(404, 'User not found');
+    }
+
+    if (this.userId === targetUserId) {
+      throw new Meteor.Error(400, 'Cannot demote yourself');
+    }
+
+    Ansible.log('Demoting user from operator', { user: targetUserId, demoter: this.userId });
+    removeUserFromRole(targetUserId, huntId, 'operator');
   },
 });

--- a/imports/server/operator.ts
+++ b/imports/server/operator.ts
@@ -4,21 +4,9 @@ import Ansible from '../ansible';
 import {
   deprecatedUserMayMakeOperator,
   addUserToRole,
-  removeUserFromRole,
 } from '../lib/permission_stubs';
 
 Meteor.methods({
-  // Temporarily de-op yourself
-  stopOperating() {
-    check(this.userId, String);
-    if (!deprecatedUserMayMakeOperator(this.userId)) {
-      throw new Meteor.Error(401, 'Must be operator or inactive operator to stop operating');
-    }
-
-    addUserToRole(this.userId, 'inactiveOperator');
-    removeUserFromRole(this.userId, 'operator');
-  },
-
   makeOperator(targetUserId: unknown) {
     check(this.userId, String);
     check(targetUserId, String);
@@ -32,7 +20,5 @@ Meteor.methods({
     }
 
     addUserToRole(targetUserId, 'operator');
-    // This may be a noop
-    removeUserFromRole(targetUserId, 'inactiveOperator');
   },
 });

--- a/imports/server/setup.ts
+++ b/imports/server/setup.ts
@@ -9,13 +9,14 @@ import { ServiceConfiguration } from 'meteor/service-configuration';
 import { _ } from 'meteor/underscore';
 import Ansible from '../ansible';
 import { API_BASE } from '../lib/discord';
+import { GLOBAL_SCOPE } from '../lib/is-admin';
 import Documents from '../lib/models/documents';
 import Hunts from '../lib/models/hunts';
 import MeteorUsers from '../lib/models/meteor_users';
 import Puzzles from '../lib/models/puzzles';
 import Settings from '../lib/models/settings';
 import {
-  addUserToRoles,
+  addUserToRole,
   userMayConfigureGdrive,
   userMayConfigureGoogleOAuth,
   userMayConfigureDiscordOAuth,
@@ -57,7 +58,7 @@ Meteor.methods({
     }
 
     const firstUserId = Accounts.createUser({ email, password });
-    addUserToRoles(firstUserId, ['admin', 'operator']);
+    addUserToRole(firstUserId, GLOBAL_SCOPE, 'admin');
   },
 
   setupGoogleOAuthClient(clientId: unknown, secret: unknown) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -908,6 +908,15 @@
       "integrity": "sha512-uO4CD2ELOjw8tasUrAhvnn2W4A0ZECOvMjCivJr4gA9pGgjv+qxKWY9GLTMVEK8ej85BxQOocUyE7hImmSQYcg==",
       "dev": true
     },
+    "@types/use-persisted-state": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/use-persisted-state/-/use-persisted-state-0.3.0.tgz",
+      "integrity": "sha512-ZT98QuckR95qM7W97lGVqc7fFS9TT6f3txp7R40fl0zxa5BLm3GG7j0i51G12h8DkoJxFAf2oQyYKU99h0pxFA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/warning": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.0.tgz",
@@ -1109,6 +1118,11 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "@use-it/event-listener": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@use-it/event-listener/-/event-listener-0.1.7.tgz",
+      "integrity": "sha512-hgfExDzUU9uTRTPDCpw2s9jWTxcxmpJya3fK5ADpf5VDpSy8WYwY/kh28XE0tUcbsljeP8wfan48QvAQTSSa3Q=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -7245,6 +7259,14 @@
       "integrity": "sha512-d2TEuG6nSLKQLAfW3By8mKr8HurOlTkul0sOpxbClIv4SQ4iOd7BYr7VIzdbktUCnv7dua/60xzd8igMU6jmyw==",
       "requires": {
         "use-isomorphic-layout-effect": "^1.0.0"
+      }
+    },
+    "use-persisted-state": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/use-persisted-state/-/use-persisted-state-0.3.3.tgz",
+      "integrity": "sha512-pCNlvYC8+XjRxwnIut4teGC9f2p9aD88R8OGseQGZa2dvqG/h1vEGk1vRE1IZG0Vf161UDpn+NlW4+UGubQflQ==",
+      "requires": {
+        "@use-it/event-listener": "^0.1.2"
       }
     },
     "util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "simpl-schema": "^1.12.0",
     "stacktrace-js": "^2.0.2",
     "styled-components": "^5.3.1",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "use-persisted-state": "^0.3.3"
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",
@@ -77,6 +78,7 @@
     "@types/react-router-bootstrap": "^0.24.5",
     "@types/simpl-schema": "^1.12.0",
     "@types/styled-components": "^5.1.20",
+    "@types/use-persisted-state": "^0.3.0",
     "@types/ws": "^8.2.2",
     "@typescript-eslint/eslint-plugin": "^5.9.1",
     "@typescript-eslint/parser": "^5.9.1",

--- a/types/user.d.ts
+++ b/types/user.d.ts
@@ -3,7 +3,7 @@ declare module 'meteor/meteor' {
     interface User {
       lastLogin?: Date;
       hunts?: string[];
-      roles?: string[];
+      roles?: Record<string, string[]>; // scope -> roles
     }
   }
 }


### PR DESCRIPTION
Implements the design in #618.

Fixes #212, #599, #618.

Biggest UI change is to the profile list page:

<img width="1008" alt="Screen Shot 2022-01-18 at 12 03 46 AM" src="https://user-images.githubusercontent.com/28167/149895561-a1a0fa33-40a7-4707-af67-c618a0a3ea94.png">
<img width="1008" alt="Screen Shot 2022-01-18 at 12 04 09 AM" src="https://user-images.githubusercontent.com/28167/149895631-5bf42d1f-ca3b-46f4-851c-dbc8c9595444.png">
<img width="1008" alt="Screen Shot 2022-01-18 at 12 04 20 AM" src="https://user-images.githubusercontent.com/28167/149895654-3b9eb13d-06d9-4ec7-8e68-eb745261da49.png">

The page also supports searching by role (if you have access to role data, which requires you be an operator/admin):

<img width="1008" alt="Screen Shot 2022-01-18 at 12 08 54 AM" src="https://user-images.githubusercontent.com/28167/149896318-ccba7114-18cf-4c91-adcd-2425ea16e63d.png">


There's also a new button on the puzzle list page to toggle operator UI status:

<img width="250" alt="Screen Shot 2022-01-17 at 11 53 03 PM" src="https://user-images.githubusercontent.com/28167/149893936-416ad5ed-2383-4cfa-9759-a33733e0d816.png">
<img width="223" alt="Screen Shot 2022-01-17 at 11 53 15 PM" src="https://user-images.githubusercontent.com/28167/149893953-7206ae4c-d40c-4643-aabb-f4e54567129a.png">

This doesn't address #230, which can make toggling the operator UI potentially difficult, but it does peek out just enough that you can grab it.x

<img width="410" alt="Screen Shot 2022-01-17 at 11 54 42 PM" src="https://user-images.githubusercontent.com/28167/149894179-dc4e7c6a-15ab-4adc-a11b-c3a8decf43c6.png">

