### PR TITLE
Use $and for query constraints instead of mutation

### DIFF
--- a/imports/lib/models/folder_permissions.ts
+++ b/imports/lib/models/folder_permissions.ts
@@ -3,8 +3,8 @@ import Base from './base';
 
 const FolderPermissions = new Base<FolderPermissionType>('folder_perms');
 FolderPermissions.attachSchema(FolderPermissionSchema);
-FolderPermissions.publish((userId, q) => {
-  return { ...q, user: userId };
+FolderPermissions.publish((userId) => {
+  return { user: userId };
 });
 
 export default FolderPermissions;

--- a/imports/lib/models/mediasoup/call_histories.ts
+++ b/imports/lib/models/mediasoup/call_histories.ts
@@ -24,7 +24,14 @@ if (Meteor.isServer) {
       return [];
     }
 
-    return CallHistories.find(huntsMatchingCurrentUser(this.userId, q), opts);
+    const query = {
+      $and: [
+        q,
+        huntsMatchingCurrentUser(this.userId),
+      ],
+    };
+
+    return CallHistories.find(query, opts);
   });
 }
 

--- a/imports/lib/models/pending_announcements.ts
+++ b/imports/lib/models/pending_announcements.ts
@@ -3,10 +3,10 @@ import Base from './base';
 
 const PendingAnnouncements = new Base<PendingAnnouncementType>('pending_announcements');
 PendingAnnouncements.attachSchema(PendingAnnouncementSchema);
-PendingAnnouncements.publish((userId, q) => {
+PendingAnnouncements.publish((userId) => {
   // It's sufficient to use the user property for filtering here; we
   // don't need to pay attention to the hunt ID
-  return { ...q, user: userId };
+  return { user: userId };
 });
 
 export default PendingAnnouncements;

--- a/imports/model-helpers.ts
+++ b/imports/model-helpers.ts
@@ -16,44 +16,24 @@ interface HuntModel {
 
 const huntsMatchingCurrentUser = function <T extends HuntModel> (
   userId: string,
-  origQuery: Mongo.Query<T>,
 ): Mongo.Query<T> {
-  // Adds a filter to the query to only show results from hunts that the user is a member of.
-  // Assumes the collection being published has a field named `hunt` of type String containing the
-  // _id of a document from the Hunts collection.
-  // The caller binds `this` to be the one provided to the function of Meteor.publish(), so
-  // this.userId is available.
+  // Returns an additional query filter to only show results from hunts that the
+  // user is a member of. Assumes the collection being published has a field
+  // named `hunt` of type String containing the _id of a document from the Hunts
+  // collection.
   //
-  // As a note: this will not re-publish if the user's hunt membership
-  // changes, so use it carefully (basically, use it when you already
-  // know the user is a member of the hunt in question).
+  // As a note: this will not re-publish if the user's hunt membership changes,
+  // so use it carefully (basically, use it when you already know the user is a
+  // member of the hunt in question).
   const u = MeteorUsers.findOne(userId);
   if (!u) {
     throw new Meteor.Error(401, 'Unauthenticated');
   }
-  const q = { ...origQuery };
-  let huntList: T['hunt'][];
 
-  if (q.hunt) {
-    if (q.hunt instanceof RegExp) {
-      // stop your shenanigans
-      huntList = u.hunts || [];
-    } else if (typeof q.hunt === 'object') {
-      // if q.hunt is still an object, then it must be a FieldExpression
-      huntList = _.intersection(u.hunts || [], q.hunt.$in || []);
-    } else {
-      // otherwise it's a string
-      huntList = _.intersection(u.hunts || [], [q.hunt]);
-    }
-  } else {
-    huntList = u.hunts || [];
-  }
-
-  // typescript comes so close to being able to infer this, but seems to
-  // struggle with the generic constraint + Mongo.Flatten
-  q.hunt = <Mongo.FieldExpression<Mongo.Flatten<T['hunt']>>>{ $in: huntList };
-
-  return q;
+  // Typescript comes close to getting this right. It seems to be able to tell
+  // that T['hunt'] must be a string, but can't infer that
+  // Mongo.Flatten<T['hunt']> must also be a string.
+  return { hunt: { $in: u.hunts } } as Mongo.Query<T>;
 };
 
 const guessURL = function (hunt: HuntType, puzzle: PuzzleType): string {

--- a/imports/server/models/api_keys.ts
+++ b/imports/server/models/api_keys.ts
@@ -1,15 +1,12 @@
-import { userIdIsAdmin } from '../../lib/is-admin';
 import Base from '../../lib/models/base';
+import { checkAdmin } from '../../lib/permission_stubs';
 import APIKeySchema, { APIKeyType } from '../schemas/api_key';
 
 const APIKeys = new Base<APIKeyType>('api_keys');
 APIKeys.attachSchema(APIKeySchema);
-APIKeys.publish((userId, q) => {
+APIKeys.publish((userId) => {
   // Server admins can access all API keys
-  if (userIdIsAdmin(userId)) {
-    return q;
-  }
-
+  checkAdmin(userId);
   return undefined;
 });
 


### PR DESCRIPTION
Previously, for publishing data, when the client sent us a query filter,
we would mutate it in order to add a constraint on (e.g.) hunt
membership. However, we can instead use Mongo's built in $and operator
to specify a separate query term that documents must satisfy. This is
much more straightforward and less error prone.

(I also specifically verified that Mongo's query planner is able to
handle this case - if, e.g., you have one $and branch that specifies
hunt: $in, and another that specifies hunt: $eq, it will merge those and
create a single set of index bounds on the $eq value.)

Fixes #604.

(It's also worth noting that Meteor's docs [specifically recommend](https://guide.meteor.com/security.html#:~:text=raise%20performance%20issues.-,Passing%20in%20a%20filter,-%3A%20If%20you%20want) this approach)