### PR TITLE
Convert more styles from scss to styled-components

### DIFF
--- a/client/stylesheets/puzzle.scss
+++ b/client/stylesheets/puzzle.scss
@@ -3,8 +3,6 @@
 ////////////
 // Puzzle page styles
 
-$puzzle-page-padding: 8px;
-
 .puzzle-page {
   .Pane > * {
     position: absolute;
@@ -17,122 +15,6 @@ $puzzle-page-padding: 8px;
   &.narrow {
     display: flex;
     flex-direction: column;
-  }
-}
-
-.chatter-section {
-  flex: 0;
-  background-color: #ebd0e3;
-  font-size: 12px;
-  line-height: 12px;
-  padding: $puzzle-page-padding;
-
-  .av-actions {
-    display: flex;
-    flex-direction: row;
-    margin-bottom: $puzzle-page-padding;
-
-    .btn {
-      flex: 1;
-      padding-right: 2px;
-      padding-left: 2px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-
-      + .btn {
-        margin-left: $puzzle-page-padding;
-      }
-    }
-  }
-}
-
-.chatter-subsection {
-  margin-top: 4px;
-
-  header {
-    margin: 4px 0;
-    cursor: pointer;
-  }
-
-  .people-list {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-
-    &:not(:empty) {
-      margin: -4px -4px 0 0;
-    }
-
-    &.collapsed {
-      display: none;
-    }
-  }
-
-  .people-item {
-    flex: 0 0 auto;
-    width: 40px;
-    height: 40px;
-    background: white;
-    cursor: default;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-    margin: 4px 4px 0 0;
-
-    .icon {
-      font-size: 12px;
-      width: 16px;
-      height: 16px;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: $danger;
-      position: absolute;
-      right: 0px;
-
-      &.muted-icon {
-        top: 0px;
-      }
-
-      &.deafened-icon {
-        bottom: 0px;
-      }
-    }
-
-    .discord-avatar {
-      width: 100%;
-      height: 100%;
-    }
-
-    .initial {
-      z-index: 10;
-      text-transform: uppercase;
-      font-weight: bold;
-      font-size: 24px;
-      color: black;
-      line-height: 24px;
-    }
-
-    &.live .initial {
-      // white border around initial
-      // aids readability if the spectrum graph is high
-      text-shadow: -1px  1px 0 white,
-                    1px  1px 0 white,
-                    1px -1px 0 white,
-                   -1px -1px 0 white;
-    }
-  }
-}
-
-.chatter-tooltip {
-  // Force chatter tooltip overlay to get larger than the default
-  // react-bootstrap stylesheet permits.  We can only apply classes to the root
-  // tooltip <div>; the .tooltip-inner className is controlled by
-  // react-bootstrap/popper.
-  .tooltip-inner {
-    max-width: 300px;
   }
 }
 

--- a/imports/client/components/AudioConfig.tsx
+++ b/imports/client/components/AudioConfig.tsx
@@ -257,7 +257,6 @@ const AudioConfig = () => {
       </AudioSelfTest>
       <audio
         ref={audioRef}
-        className="audio-sink"
         autoPlay
         playsInline
         muted={!loopback}

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -4,11 +4,9 @@ import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown';
 import { faCaretRight } from '@fortawesome/free-solid-svg-icons/faCaretRight';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import classnames from 'classnames';
 import React, {
   ReactChild, useCallback, useEffect, useLayoutEffect, useState,
 } from 'react';
-import Button from 'react-bootstrap/Button';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
 import styled from 'styled-components';
@@ -25,6 +23,12 @@ import { Subscribers } from '../subscribers';
 import { trace } from '../tracing';
 import { PREFERRED_AUDIO_DEVICE_STORAGE_KEY } from './AudioConfig';
 import CallSection from './CallSection';
+import DiscordAvatarImg from './styling/DiscordAvatarImg';
+import {
+  AVActions, AVButton, ChatterSubsection, ChatterSubsectionHeader, InitialSpan, PeopleItemDiv,
+  PeopleListDiv,
+} from './styling/PeopleComponents';
+import { PuzzlePagePadding } from './styling/constants';
 
 const tabId = Random.id();
 
@@ -52,23 +56,22 @@ const ViewerPersonBox = ({
         </Tooltip>
       )}
     >
-      <div key={`viewer-${user}-${tab}`} className="people-item">
+      <PeopleItemDiv key={`viewer-${user}-${tab}`}>
         {discordAvatarUrl ? (
-          <img
+          <DiscordAvatarImg
             alt={`${name}'s Discord avatar`}
             src={discordAvatarUrl}
-            className="discord-avatar"
           />
         ) : (
-          <span className="initial">{name.slice(0, 1)}</span>
+          <InitialSpan live={false}>{name.slice(0, 1)}</InitialSpan>
         )}
         { children }
-      </div>
+      </PeopleItemDiv>
     </OverlayTrigger>
   );
 };
 
-const PeopleListHeader = styled.header`
+const PeopleListHeader = styled(ChatterSubsectionHeader)`
   padding-left: 1rem;
   text-indent: -1rem;
 `;
@@ -111,6 +114,14 @@ function stopTracks(stream: MediaStream | null | undefined) {
     });
   }
 }
+
+const ChatterSection = styled.section`
+  flex: 0;
+  background-color: #ebd0e3;
+  font-size: 12px;
+  line-height: 12px;
+  padding: ${PuzzlePagePadding};
+`;
 
 function participantState(explicitlyMuted: boolean, deafened: boolean) {
   if (deafened) {
@@ -479,10 +490,10 @@ const ChatPeople = ({
         const joinLabel = rtcViewers.length > 0 ? 'Join audio call' : 'Start audio call';
         return (
           <>
-            <div className="av-actions">
-              <Button variant="primary" size="sm" block onClick={joinCall}>{joinLabel}</Button>
-            </div>
-            <div className="chatter-subsection av-chatters">
+            <AVActions>
+              <AVButton variant="primary" size="sm" block onClick={joinCall}>{joinLabel}</AVButton>
+            </AVActions>
+            <ChatterSubsection>
               <PeopleListHeader onClick={toggleCallersExpanded}>
                 <FontAwesomeIcon fixedWidth icon={callersHeaderIcon} />
                 {`${rtcViewers.length} caller${rtcViewers.length !== 1 ? 's' : ''}`}
@@ -494,10 +505,10 @@ const ChatPeople = ({
                   </>
                 )}
               </PeopleListHeader>
-              <div className={classnames('people-list', { collapsed: !callersExpanded })}>
+              <PeopleListDiv collapsed={!callersExpanded}>
                 {rtcViewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}-${viewer.tab}`} {...viewer} />)}
-              </div>
-            </div>
+              </PeopleListDiv>
+            </ChatterSubsection>
           </>
         );
       }
@@ -534,18 +545,18 @@ const ChatPeople = ({
   const totalViewers = viewers.length + unknown;
   const viewersHeaderIcon = viewersExpanded ? faCaretDown : faCaretRight;
   return (
-    <section className="chatter-section">
+    <ChatterSection>
       {!rtcDisabled && !puzzleDeleted && callersSubsection}
-      <div className="chatter-subsection non-av-viewers">
+      <ChatterSubsection>
         <PeopleListHeader onClick={toggleViewersExpanded}>
           <FontAwesomeIcon fixedWidth icon={viewersHeaderIcon} />
           {`${totalViewers} viewer${totalViewers !== 1 ? 's' : ''}`}
         </PeopleListHeader>
-        <div className={classnames('people-list', { collapsed: !viewersExpanded })}>
+        <PeopleListDiv collapsed={!viewersExpanded}>
           {viewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}`} {...viewer} />)}
-        </div>
-      </div>
-    </section>
+        </PeopleListDiv>
+      </ChatterSubsection>
+    </ChatterSection>
   );
 };
 

--- a/imports/client/components/Documents.tsx
+++ b/imports/client/components/Documents.tsx
@@ -79,7 +79,7 @@ const GoogleDocumentDisplay = ({ document, displayMode }: DocumentDisplayProps) 
           <a href={url} target="new">
             <FontAwesomeIcon fixedWidth icon={icon} />
             {' '}
-            <span className="link-label">{title}</span>
+            <span>{title}</span>
           </a>
         </StyledDeepLink>
       );

--- a/imports/client/components/LabelledRadioGroup.tsx
+++ b/imports/client/components/LabelledRadioGroup.tsx
@@ -8,7 +8,7 @@ const RadioHeader = styled.span`
 
 const RadioLabel = styled.label`
   display: block;
-  fontWeight: normal;
+  font-weight: normal;
 `;
 
 const Radio = styled.input`

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -724,7 +724,7 @@ const PuzzlePageMetadata = ({
   if (puzzle.expectedAnswerCount > 0) {
     guessButton = hasGuessQueue ? (
       <>
-        <Button variant="primary" size="sm" className="puzzle-metadata-guess-button" onClick={showGuessModal}>
+        <Button variant="primary" size="sm" onClick={showGuessModal}>
           <FontAwesomeIcon icon={faKey} />
           {' Guess '}
           <Badge variant="light">{numGuesses}</Badge>
@@ -739,7 +739,7 @@ const PuzzlePageMetadata = ({
       </>
     ) : (
       <>
-        <Button variant="primary" size="sm" className="puzzle-metadata-answer-button" onClick={showAnswerModal}>
+        <Button variant="primary" size="sm" onClick={showAnswerModal}>
           <FontAwesomeIcon icon={faKey} />
           {' Answer'}
         </Button>
@@ -971,7 +971,7 @@ const PuzzleGuessModal = React.forwardRef(({
 
       {guesses.length === 0 ? <div>No previous submissions.</div> : [
         <div key="label">Previous submissions:</div>,
-        <Table className="guess-history-table" key="table" bordered size="sm">
+        <Table key="table" bordered size="sm">
           <thead>
             <tr>
               <th>Guess</th>
@@ -983,7 +983,7 @@ const PuzzleGuessModal = React.forwardRef(({
           <tbody>
             {_.sortBy(guesses, 'createdAt').reverse().map((guess) => {
               return (
-                <tr key={guess._id} className={`guess-${guess.state}`}>
+                <tr key={guess._id}>
                   <AnswerTableCell>{guess.guess}</AnswerTableCell>
                   <td>{calendarTimeFormat(guess.createdAt)}</td>
                   <td>{displayNames[guess.createdBy]}</td>

--- a/imports/client/components/styling/DiscordAvatarImg.tsx
+++ b/imports/client/components/styling/DiscordAvatarImg.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components';
+
+export default styled.img`
+  width: 100%;
+  height: 100%;
+`;

--- a/imports/client/components/styling/PeopleComponents.tsx
+++ b/imports/client/components/styling/PeopleComponents.tsx
@@ -1,0 +1,75 @@
+import Button from 'react-bootstrap/Button';
+import styled, { css } from 'styled-components';
+import { PuzzlePagePadding } from './constants';
+
+export const ChatterSubsection = styled.div`
+  margin-top: 4px;
+`;
+
+export const ChatterSubsectionHeader = styled.header`
+  margin: 4px 0;
+  cursor: pointer;
+`;
+
+export const AVActions = styled.div`
+  display: flex;
+  flex-direction: row;
+  margin-bottom: ${PuzzlePagePadding};
+`;
+
+export const AVButton = styled(Button)`
+  flex: 1;
+  padding-right: 2px;
+  padding-left: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  & + & {
+    margin-left: ${PuzzlePagePadding};
+  }
+`;
+
+export const PeopleListDiv = styled.div<{ collapsed?: boolean }>`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+
+  &:not(:empty) {
+    margin: -4px -4px 0 0;
+  }
+
+  ${({ collapsed }) => collapsed && css`
+    display: none;
+  `}
+`;
+
+export const PeopleItemDiv = styled.div`
+  flex: 0 0 auto;
+  width: 40px;
+  height: 40px;
+  background: white;
+  cursor: default;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  margin: 4px 4px 0 0;
+`;
+
+export const InitialSpan = styled.span<{ live: boolean }>`
+  z-index: 10;
+  text-transform: uppercase;
+  font-weight: bold;
+  font-size: 24px;
+  color: black;
+  line-height: 24px;
+  ${({ live }) => live && css`
+    // white border around initial
+    // aids readability if the spectrum graph is high
+    text-shadow: -1px  1px 0 white,
+                  1px  1px 0 white,
+                  1px -1px 0 white,
+                 -1px -1px 0 white;
+  `}
+`;

--- a/imports/client/components/styling/constants.tsx
+++ b/imports/client/components/styling/constants.tsx
@@ -1,8 +1,10 @@
-import { Solvedness } from '../../../lib/solvedness';
+import type { Solvedness } from '../../../lib/solvedness';
 
 export const NavBarHeight = '50px';
 
 export const MonospaceFontFamily = '"Platform Emoji", "Source Code Pro", "Consolas", "Monaco", monospace, "Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji"';
+
+export const PuzzlePagePadding = '8px';
 
 export const SolvedPuzzleBackgroundColor = '#dfffdf';
 export const UnsolvedPuzzleBackgroundColor = '#f0f0f0';


### PR DESCRIPTION
This covers the rest of the chat + call participants sections, leaving
pretty much just the `SplitPanePlus`-related styles defined in
`puzzle.scss`.

This change should have no visible differences.