### PR TITLE
Profile list/page fixes

### DIFF
--- a/imports/client/components/AllProfileListPage.tsx
+++ b/imports/client/components/AllProfileListPage.tsx
@@ -10,7 +10,10 @@ const AllProfileListPage = () => {
   const loading = profilesLoading();
 
   const users = useTracker(() => {
-    return loading ? [] : MeteorUsers.find({}, { sort: { 'profile.displayName': 1 } }).fetch();
+    return (loading ?
+      [] :
+      MeteorUsers.find({ profile: { $ne: undefined } }, { sort: { 'profile.displayName': 1 } }).fetch()
+    );
   }, [loading]);
 
   if (loading) {

--- a/imports/client/components/HuntProfileListPage.tsx
+++ b/imports/client/components/HuntProfileListPage.tsx
@@ -25,7 +25,7 @@ const HuntProfileListPage = () => {
     loading ?
       [] :
       MeteorUsers.find(
-        { hunts: huntId },
+        { hunts: huntId, profile: { $ne: undefined } },
         { sort: { displayName: 1 } },
       ).fetch()
   ), [huntId, loading]);

--- a/imports/client/components/OthersProfilePage.tsx
+++ b/imports/client/components/OthersProfilePage.tsx
@@ -22,12 +22,11 @@ const ProfileTable = styled.table`
 `;
 
 const OthersProfilePage = ({
-  user, huntMembership,
+  user,
 }: {
   user: Meteor.User;
-  huntMembership?: string[];
 }) => {
-  const showHuntList = (huntMembership?.length ?? 0) > 0;
+  const showHuntList = (user.hunts?.length ?? 0) > 0;
 
   const huntsLoading = useSubscribe(showHuntList ? 'mongo.hunts' : undefined, {});
   const loading = huntsLoading();
@@ -112,7 +111,7 @@ const OthersProfilePage = ({
                 {(
                   loading ?
                     'loading...' :
-                    huntMembership?.map((huntId) => (
+                    user.hunts?.map((huntId) => (
                       hunts[huntId]?.name ?? `Unknown hunt ${huntId}`
                     ))
                       .join(', ')

--- a/imports/client/components/ProfilePage.tsx
+++ b/imports/client/components/ProfilePage.tsx
@@ -13,8 +13,7 @@ const ProfilePage = ({ userId, isSelf }: { userId: string, isSelf: boolean }) =>
   const userInfoLoading = useSubscribe('userInfo', userId);
   const loading = userInfoLoading();
 
-  const user = useTracker(() => Meteor.user()!, []);
-  const hunts = useTracker(() => MeteorUsers.findOne(userId)?.hunts, [userId]);
+  const user = useTracker(() => MeteorUsers.findOne(userId)!, [userId]);
 
   useBreadcrumb({
     title: loading ? 'loading...' : (user.profile?.displayName ?? 'Profile settings'),
@@ -30,7 +29,6 @@ const ProfilePage = ({ userId, isSelf }: { userId: string, isSelf: boolean }) =>
   return (
     <OthersProfilePage
       user={user}
-      huntMembership={hunts}
     />
   );
 };


### PR DESCRIPTION
Don't show profiles for users with no profile, and don't always load
your own profile when viewing anyone's profile page.

There's still one outstanding bug which is that the `avatars` subscription doesn't seem to actually return any data. I haven't been able to figure out why, but these are bad enough that we should go ahead and land fixes while I investigate.