### PR TITLE
Move profile fields to top-level of Meteor.User

### DIFF
--- a/imports/client/components/AllProfileListPage.tsx
+++ b/imports/client/components/AllProfileListPage.tsx
@@ -12,7 +12,7 @@ const AllProfileListPage = () => {
   const users = useTracker(() => {
     return (loading ?
       [] :
-      MeteorUsers.find({ profile: { $ne: undefined } }, { sort: { 'profile.displayName': 1 } }).fetch()
+      MeteorUsers.find({ displayName: { $ne: undefined } }, { sort: { displayName: 1 } }).fetch()
     );
   }, [loading]);
 

--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -156,7 +156,7 @@ const ErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
 const AppNavbar = () => {
   const userId = useTracker(() => Meteor.userId()!, []);
 
-  const displayName = useTracker(() => Meteor.user()?.profile?.displayName ?? '<no name given>', []);
+  const displayName = useTracker(() => Meteor.user()?.displayName ?? '<no name given>', []);
   const { brandSrc, brandSrc2x } = useTracker(() => {
     return {
       brandSrc: lookupUrl('brand.png'),

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -202,8 +202,8 @@ const ProducerBox = ({
   const { initial, discordAvatarUrl } = useTracker(() => {
     const user = Meteor.user()!;
     return {
-      initial: user.profile?.displayName.slice(0, 1) ?? 'U', // get it?  it's you
-      discordAvatarUrl: getAvatarCdnUrl(user.profile?.discordAccount),
+      initial: user.displayName?.slice(0, 1) ?? 'U', // get it?  it's you
+      discordAvatarUrl: getAvatarCdnUrl(user.discordAccount),
     };
   });
 
@@ -352,8 +352,8 @@ const PeerBox = ({
   const { name, discordAvatarUrl } = useTracker(() => {
     const user = MeteorUsers.findOne(peer.createdBy);
     return {
-      name: user?.profile?.displayName ?? 'no profile wat',
-      discordAvatarUrl: getAvatarCdnUrl(user?.profile?.discordAccount),
+      name: user?.displayName ?? 'no profile wat',
+      discordAvatarUrl: getAvatarCdnUrl(user?.discordAccount),
     };
   }, [peer.createdBy]);
 

--- a/imports/client/components/CelebrationCenter.tsx
+++ b/imports/client/components/CelebrationCenter.tsx
@@ -21,7 +21,7 @@ const CelebrationCenter = ({ huntId }: { huntId: string }) => {
   useSubscribe('mongo.puzzles', { hunt: huntId });
 
   const disabled = useTracker(() => Flags.active('disable.applause'), []);
-  const muted = useTracker(() => !!(Meteor.user()?.profile?.muteApplause), []);
+  const muted = useTracker(() => !!(Meteor.user()?.muteApplause), []);
 
   const onPuzzleSolved = useCallback((puzzle: PuzzleType, newAnswer: string) => {
     // Only celebrate if:

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -229,18 +229,18 @@ const ChatPeople = ({
       }
 
       const user = MeteorUsers.findOne(p.createdBy);
-      if (!user?.profile || !user.profile.displayName) {
+      if (!user || !user.displayName) {
         unknownCount += 1;
         return;
       }
 
-      const discordAvatarUrl = getAvatarCdnUrl(user.profile.discordAccount);
+      const discordAvatarUrl = getAvatarCdnUrl(user.discordAccount);
 
       // If the same user is joined twice (from two different tabs), dedupe in
       // the viewer listing. (We include both in rtcParticipants still.)
       rtcViewersAcc.push({
         user: user._id,
-        name: user.profile.displayName,
+        name: user.displayName,
         discordAvatarUrl,
         tab: p.tab,
       });
@@ -254,16 +254,16 @@ const ChatPeople = ({
       }
 
       const user = MeteorUsers.findOne(s.user);
-      if (!user?.profile || !user.profile.displayName) {
+      if (!user || !user.displayName) {
         unknownCount += 1;
         return;
       }
 
-      const discordAvatarUrl = getAvatarCdnUrl(user.profile.discordAccount);
+      const discordAvatarUrl = getAvatarCdnUrl(user.discordAccount);
 
       viewersAcc.push({
         user: s.user,
-        name: user.profile.displayName,
+        name: user.displayName,
         discordAvatarUrl,
         tab: undefined,
       });

--- a/imports/client/components/HuntProfileListPage.tsx
+++ b/imports/client/components/HuntProfileListPage.tsx
@@ -25,8 +25,8 @@ const HuntProfileListPage = () => {
     loading ?
       [] :
       MeteorUsers.find(
-        { hunts: huntId, profile: { $ne: undefined } },
-        { sort: { 'profile.displayName': 1 } },
+        { hunts: huntId, displayName: { $ne: undefined } },
+        { sort: { displayName: 1 } },
       ).fetch()
   ), [huntId, loading]);
 

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -466,8 +466,8 @@ const NotificationCenter = () => {
   const { hasOwnProfile, discordConfiguredByUser } = useTracker(() => {
     const user = Meteor.user()!;
     return {
-      hasOwnProfile: !!(user.profile?.displayName),
-      discordConfiguredByUser: !!(user.profile?.discordAccount),
+      hasOwnProfile: !!(user.displayName),
+      discordConfiguredByUser: !!(user.discordAccount),
     };
   }, []);
 

--- a/imports/client/components/OthersProfilePage.tsx
+++ b/imports/client/components/OthersProfilePage.tsx
@@ -32,8 +32,8 @@ const OthersProfilePage = ({
   const loading = huntsLoading();
   const hunts = useTracker(() => (loading ? {} : _.indexBy(Hunts.find().fetch(), '_id')), [loading]);
 
-  const discordAvatarUrl = getAvatarCdnUrl(user.profile?.discordAccount);
-  const discordAvatarUrlLarge = getAvatarCdnUrl(user.profile?.discordAccount, 256);
+  const discordAvatarUrl = getAvatarCdnUrl(user.discordAccount);
+  const discordAvatarUrlLarge = getAvatarCdnUrl(user.discordAccount, 256);
   return (
     <div>
       <h1>
@@ -53,7 +53,7 @@ const OthersProfilePage = ({
               )}
             >
               <img
-                alt={`${user.profile?.displayName}'s Discord avatar`}
+                alt={`${user.displayName}'s Discord avatar`}
                 src={discordAvatarUrl}
                 width={40}
                 height={40}
@@ -63,7 +63,7 @@ const OthersProfilePage = ({
             {' '}
           </>
         )}
-        {user.profile?.displayName ?? 'No display name'}
+        {user.displayName ?? 'No display name'}
       </h1>
 
       <ProfileTable>
@@ -83,8 +83,8 @@ const OthersProfilePage = ({
           <tr>
             <th>Phone</th>
             <td>
-              {user.profile?.phoneNumber ? (
-                <a href={`tel:${user.profile.phoneNumber}`}>{user.profile.phoneNumber}</a>
+              {user.phoneNumber ? (
+                <a href={`tel:${user.phoneNumber}`}>{user.phoneNumber}</a>
               ) : (
                 '(none)'
               )}
@@ -93,11 +93,11 @@ const OthersProfilePage = ({
           <tr>
             <th>Discord handle</th>
             <td>
-              {user.profile?.discordAccount ? (
-                <a href={`https://discord.com/users/${user.profile.discordAccount.id}`} target="_blank" rel="noreferrer">
-                  {user.profile.discordAccount.username}
+              {user.discordAccount ? (
+                <a href={`https://discord.com/users/${user.discordAccount.id}`} target="_blank" rel="noreferrer">
+                  {user.discordAccount.username}
                   #
-                  {user.profile.discordAccount.discriminator}
+                  {user.discordAccount.discriminator}
                 </a>
               ) : (
                 '(none)'

--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -75,7 +75,7 @@ const GoogleLinkBlock = ({ user }: { user: Meteor.User }) => {
       return <Button variant="primary" disabled>Google integration currently disabled</Button>;
     }
 
-    const text = (user.profile?.googleAccount) ?
+    const text = (user.googleAccount) ?
       'Link a different Google account' :
       'Link your Google account';
 
@@ -103,16 +103,16 @@ const GoogleLinkBlock = ({ user }: { user: Meteor.User }) => {
         </Alert>
       ) : undefined}
       <div>
-        {user.profile?.googleAccount ? (
+        {user.googleAccount ? (
           <div>
             Currently linked to
             {' '}
-            {user.profile.googleAccount}
+            {user.googleAccount}
           </div>
         ) : undefined}
         {linkButton()}
         {' '}
-        {user.profile?.googleAccount ? (
+        {user.googleAccount ? (
           <Button variant="danger" onClick={onUnlink}>
             Unlink
           </Button>
@@ -199,7 +199,7 @@ const DiscordLinkBlock = ({ user }: { user: Meteor.User }) => {
       return <Button variant="primary" disabled>Discord integration currently disabled</Button>;
     }
 
-    const text = (user.profile?.discordAccount) ?
+    const text = (user.discordAccount) ?
       'Link a different Discord account' :
       'Link your Discord account';
 
@@ -208,10 +208,10 @@ const DiscordLinkBlock = ({ user }: { user: Meteor.User }) => {
         {text}
       </Button>
     );
-  }, [state.state, discordDisabled, user.profile?.discordAccount, onLink]);
+  }, [state.state, discordDisabled, user.discordAccount, onLink]);
 
   const unlinkButton = useMemo(() => {
-    if (user.profile?.discordAccount) {
+    if (user.discordAccount) {
       return (
         <Button variant="danger" onClick={onUnlink}>
           Unlink
@@ -220,11 +220,11 @@ const DiscordLinkBlock = ({ user }: { user: Meteor.User }) => {
     }
 
     return null;
-  }, [user.profile?.discordAccount, onUnlink]);
+  }, [user.discordAccount, onUnlink]);
 
   const currentAccount = useMemo(() => {
-    if (user.profile?.discordAccount) {
-      const acct = user.profile?.discordAccount;
+    if (user.discordAccount) {
+      const acct = user.discordAccount;
       return (
         <div>
           Currently linked to
@@ -239,7 +239,7 @@ const DiscordLinkBlock = ({ user }: { user: Meteor.User }) => {
     }
 
     return null;
-  }, [user.profile?.discordAccount]);
+  }, [user.discordAccount]);
 
   if (!config) {
     return <div />;
@@ -283,12 +283,12 @@ enum OwnProfilePageSubmitState {
 }
 
 const OwnProfilePage = ({ initialUser }: { initialUser: Meteor.User }) => {
-  const [displayName, setDisplayName] = useState<string>(initialUser.profile?.displayName || '');
-  const [phoneNumber, setPhoneNumber] = useState<string>(initialUser.profile?.phoneNumber || '');
+  const [displayName, setDisplayName] = useState<string>(initialUser.displayName || '');
+  const [phoneNumber, setPhoneNumber] = useState<string>(initialUser.phoneNumber || '');
   const [muteApplause, setMuteApplause] =
-    useState<boolean>(initialUser.profile?.muteApplause || false);
-  const [dingwordsFlat, setDingwordsFlat] = useState<string>(initialUser.profile?.dingwords ?
-    initialUser.profile?.dingwords.join(',') : '');
+    useState<boolean>(initialUser.muteApplause || false);
+  const [dingwordsFlat, setDingwordsFlat] = useState<string>(initialUser.dingwords ?
+    initialUser.dingwords.join(',') : '');
   const [submitState, setSubmitState] =
     useState<OwnProfilePageSubmitState>(OwnProfilePageSubmitState.IDLE);
   const [submitError, setSubmitError] = useState<string>('');

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -93,7 +93,7 @@ const PromoteOperatorModal = React.forwardRef((
         <p>
           Are you sure you want to make
           {' '}
-          <strong>{user.profile!.displayName}</strong>
+          <strong>{user!.displayName}</strong>
           {' '}
           an operator?
         </p>
@@ -149,7 +149,7 @@ const DemoteOperatorModal = React.forwardRef((
         <p>
           Are you sure you want to demote
           {' '}
-          <strong>{user.profile!.displayName}</strong>
+          <strong>{user.displayName}</strong>
           ?
         </p>
         {error && (
@@ -277,12 +277,10 @@ const ProfileList = ({
     const isInteresting = (user: Meteor.User) => {
       for (let i = 0; i < toMatch.length; i++) {
         const searchKey = toMatch[i];
-        if (user.profile?.displayName?.toLowerCase().indexOf(searchKey) === -1 &&
-          user.emails?.every((e) => (
-            !e.verified || e.address.toLowerCase().indexOf(searchKey) === -1
-          )) &&
-          (user.profile?.phoneNumber?.toLowerCase().indexOf(searchKey) === -1) &&
-          (!user.profile?.discordAccount || `${user.profile.discordAccount.username.toLowerCase()}#${user.profile.discordAccount.discriminator}`.indexOf(searchKey) === -1) &&
+        if ((!user.displayName || user.displayName.toLowerCase().indexOf(searchKey) === -1) &&
+          user.emails?.every((e) => e.address.toLowerCase().indexOf(searchKey) === -1) &&
+          (!user.phoneNumber || user.phoneNumber?.toLowerCase().indexOf(searchKey) === -1) &&
+          (!user.discordAccount || `${user.discordAccount.username.toLowerCase()}#${user.discordAccount.discriminator}`.indexOf(searchKey) === -1) &&
           (!roles?.[user._id]?.some((role) => role.toLowerCase().indexOf(searchKey) !== -1))) {
           return false;
         }
@@ -387,8 +385,8 @@ const ProfileList = ({
       <ListGroup>
         {inviteToHuntItem}
         {matching.map((user) => {
-          const name = user.profile?.displayName ?? '<no name provided>';
-          const discordAvatarUrl = getAvatarCdnUrl(user.profile?.discordAccount);
+          const name = user.displayName ?? '<no name provided>';
+          const discordAvatarUrl = getAvatarCdnUrl(user.discordAccount);
           return (
             <ListGroupItem key={user._id} action as={Link} to={`/users/${user._id}`} className="p-1">
               <ListItemContainer>

--- a/imports/client/components/ProfilePage.tsx
+++ b/imports/client/components/ProfilePage.tsx
@@ -10,13 +10,14 @@ import OwnProfilePage from './OwnProfilePage';
 const ResolvedProfilePage = ({ userId, isSelf }: { userId: string, isSelf: boolean }) => {
   useBreadcrumb({ title: 'Users', path: '/users' });
 
+  const profileLoading = useSubscribe('profile', userId);
   const userInfoLoading = useSubscribe('userInfo', userId);
-  const loading = userInfoLoading();
+  const loading = profileLoading() || userInfoLoading();
 
   const user = useTracker(() => MeteorUsers.findOne(userId)!, [userId]);
 
   useBreadcrumb({
-    title: loading ? 'loading...' : (user.profile?.displayName ?? 'Profile settings'),
+    title: loading ? 'loading...' : (user.displayName ?? 'Profile settings'),
     path: `/users/${userId}`,
   });
 

--- a/imports/client/components/RTCDebugPage.tsx
+++ b/imports/client/components/RTCDebugPage.tsx
@@ -111,8 +111,8 @@ const CallDisplay = ({ call }: { call: string }) => {
 const UserDisplay = ({ userId }: { userId: string }) => {
   const user = useTracker(() => MeteorUsers.findOne(userId), [userId]);
   const discordAvatarUrl = useMemo(() => (
-    getAvatarCdnUrl(user?.profile?.discordAccount)
-  ), [user?.profile?.discordAccount]);
+    getAvatarCdnUrl(user?.discordAccount)
+  ), [user?.discordAccount]);
 
   return (
     <Link to={`/users/${userId}`} target="_blank">
@@ -125,7 +125,7 @@ const UserDisplay = ({ userId }: { userId: string }) => {
         />
       )}
       {' '}
-      {user?.profile?.displayName || 'Unknown'}
+      {user?.displayName || 'Unknown'}
     </Link>
   );
 };

--- a/imports/lib/models/MeteorUsers.ts
+++ b/imports/lib/models/MeteorUsers.ts
@@ -13,11 +13,11 @@ Meteor.users.deny({ update: () => true });
 
 export function indexedDisplayNames(): Record<string, string> {
   return Object.fromEntries(Meteor.users.find({
-    'profile.displayName': { $ne: null },
+    displayName: { $ne: undefined },
   }, {
-    fields: { 'profile.displayName': 1 },
+    fields: { displayName: 1 },
   })
-    .map((u) => [u._id, u.profile!.displayName]));
+    .map((u) => [u._id, u.displayName!]));
 }
 
 // Re-export Meteor.users. We should require this instead of using Meteor.users

--- a/imports/lib/schemas/User.ts
+++ b/imports/lib/schemas/User.ts
@@ -6,19 +6,16 @@ import { Overrides, buildSchema } from './typedSchemas';
 
 declare module 'meteor/meteor' {
   module Meteor {
-    interface UserProfile {
-      displayName: string;
+    interface User {
+      lastLogin?: Date;
+      hunts?: string[];
+      roles?: Record<string, string[]>; // scope -> roles
+      displayName?: string;
       googleAccount?: string;
       discordAccount?: t.TypeOf<typeof DiscordAccount>;
       phoneNumber?: string;
       muteApplause?: boolean;
       dingwords?: string[];
-    }
-
-    interface User {
-      lastLogin?: Date;
-      hunts?: string[];
-      roles?: Record<string, string[]>; // scope -> roles
     }
   }
 }
@@ -34,15 +31,15 @@ export const UserCodec = t.type({
   services: t.union([t.object, t.undefined]),
   roles: t.union([t.object, t.undefined]),
   hunts: t.union([t.array(t.string), t.undefined]),
-  profile: t.union([t.undefined, t.type({
-    displayName: t.string,
-    googleAccount: t.union([t.string, t.undefined]),
-    discordAccount: t.union([DiscordAccount, t.undefined]),
-    phoneNumber: t.union([t.string, t.undefined]),
-    muteApplause: t.union([t.boolean, t.undefined]),
-    dingwords: t.union([t.array(t.string), t.undefined]),
-  })]),
+  displayName: t.union([t.undefined, t.string]),
+  googleAccount: t.union([t.string, t.undefined]),
+  discordAccount: t.union([DiscordAccount, t.undefined]),
+  phoneNumber: t.union([t.string, t.undefined]),
+  muteApplause: t.union([t.boolean, t.undefined]),
+  dingwords: t.union([t.array(t.string), t.undefined]),
 });
+
+export type ProfileFields = 'displayName' | 'googleAccount' | 'discordAccount' | 'phoneNumber' | 'muteApplause' | 'dingwords';
 
 const UserOverrides: Overrides<t.TypeOf<typeof UserCodec>> = {
   username: {

--- a/imports/server/addUserToDiscordRole.ts
+++ b/imports/server/addUserToDiscordRole.ts
@@ -23,7 +23,7 @@ export default (userId: string, huntId: string) => {
   }
 
   const user = MeteorUsers.findOne(userId)!;
-  if (!user.profile?.discordAccount) {
+  if (!user.discordAccount) {
     Ansible.log('Can not add user to Discord role because user has not linked their Discord account', { userId, huntId });
     return;
   }
@@ -42,7 +42,7 @@ export default (userId: string, huntId: string) => {
 
   const discord = new DiscordBot(botToken);
   try {
-    MeteorPromise.await(discord.addUserToRole(user.profile.discordAccount.id, guild.id, roleId));
+    MeteorPromise.await(discord.addUserToRole(user.discordAccount.id, guild.id, roleId));
     Ansible.log('Successfully added user to Discord role', { userId, huntId, roleId });
   } catch (e) {
     Ansible.log('Error while adding user to Discord role', { err: (e instanceof Error ? e.message : e) });

--- a/imports/server/api/resources/users.ts
+++ b/imports/server/api/resources/users.ts
@@ -26,7 +26,7 @@ const renderUser = function renderUser(user: Meteor.User) {
   return {
     _id: user._id,
     primaryEmail: user.emails && user.emails[0].address,
-    googleAccount: user.profile?.googleAccount,
+    googleAccount: user.googleAccount,
     active,
   };
 };

--- a/imports/server/discordClientRefresher.ts
+++ b/imports/server/discordClientRefresher.ts
@@ -131,12 +131,12 @@ class DiscordClientRefresher {
 
             const updateUser = (u: Discord.User) => {
               MeteorUsers.update({
-                'profile.discordAccount.id': u.id,
+                'discordAccount.id': u.id,
               }, {
                 $set: {
-                  'profile.discordAccount.username': u.username,
-                  'profile.discordAccount.discriminator': u.discriminator,
-                  'profile.discordAccount.avatar': u.avatar,
+                  'discordAccount.username': u.username,
+                  'discordAccount.discriminator': u.discriminator,
+                  'discordAccount.avatar': u.avatar,
                 },
               }, {
                 multi: true,

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -234,7 +234,7 @@ Meteor.methods({
     });
 
     const user = MeteorUsers.findOne(this.userId)!;
-    const guesserDisplayName = user.profile?.displayName || '(no display name given)';
+    const guesserDisplayName = user.displayName || '(no display name given)';
     const message = `${guesserDisplayName} submitted guess "${guess}"`;
     sendChatMessage(puzzleId, message, undefined);
   },

--- a/imports/server/hooks/DingwordHooks.ts
+++ b/imports/server/hooks/DingwordHooks.ts
@@ -22,9 +22,9 @@ const DingwordHooks: Hookset = {
     // Find all users who are in this hunt with dingwords set.
     const huntMembers = MeteorUsers.find({
       hunts: chatMessage.hunt,
-      'profile.dingwords.0': { $exists: true },
+      'dingwords.0': { $exists: true },
     }, {
-      fields: { _id: 1, 'profile.dingwords': 1 },
+      fields: { _id: 1, dingwords: 1 },
     }).fetch();
 
     // For each user with dingwords, check if this message (normalized to
@@ -36,7 +36,7 @@ const DingwordHooks: Hookset = {
         return;
       }
 
-      const dingwords = u?.profile?.dingwords;
+      const dingwords = u.dingwords;
       if (dingwords) {
         for (let i = 0; i < dingwords.length; i++) {
           const dingword = dingwords[i];

--- a/imports/server/hooks/DiscordHooks.ts
+++ b/imports/server/hooks/DiscordHooks.ts
@@ -105,10 +105,10 @@ const DiscordHooks: Hookset = {
       } else {
         name = chatMessage.sender;
         const user = MeteorUsers.findOne(chatMessage.sender);
-        if (user?.profile?.discordAccount) {
-          name = user.profile.discordAccount.username;
-        } else if (user?.profile?.displayName) {
-          name = user.profile.displayName;
+        if (user?.discordAccount) {
+          name = user.discordAccount.username;
+        } else if (user?.displayName) {
+          name = user.displayName;
         }
       }
 

--- a/imports/server/hunts.ts
+++ b/imports/server/hunts.ts
@@ -234,7 +234,7 @@ Meteor.methods({
     } else {
       if (joineeUser._id !== this.userId) {
         const joinerUser = MeteorUsers.findOne(this.userId);
-        const joinerName = joinerUser?.profile?.displayName;
+        const joinerName = joinerUser!.displayName;
         const settingsDoc = Settings.findOne({ name: 'email.branding' });
         const subject = renderExistingJoinEmailSubject(settingsDoc, hunt);
         const text = renderExistingJoinEmail(settingsDoc, joineeUser, hunt, joinerName);
@@ -248,8 +248,8 @@ Meteor.methods({
 
       if (!Flags.active('disable.google') &&
         !Flags.active('disable.gdrive_permissions') &&
-        joineeUser.profile?.googleAccount) {
-        ensureHuntFolderPermission(huntId, joineeUser._id, joineeUser.profile.googleAccount);
+        joineeUser.googleAccount) {
+        ensureHuntFolderPermission(huntId, joineeUser._id, joineeUser.googleAccount);
       }
     }
   },

--- a/imports/server/migrations/38-consolidate-profiles.ts
+++ b/imports/server/migrations/38-consolidate-profiles.ts
@@ -6,7 +6,17 @@ import { UserCodec } from '../../lib/schemas/User';
 
 // Since the profiles model has been removed, we need to make our own collection
 // for this migration.
-const Profiles = new Mongo.Collection<{ _id: string } & t.TypeOf<typeof UserCodec>['profile']>('jr_profiles');
+const Profiles = new Mongo.Collection<
+  { _id: string } &
+  Pick<t.TypeOf<typeof UserCodec>,
+    'displayName' |
+    'googleAccount' |
+    'discordAccount' |
+    'phoneNumber' |
+    'muteApplause' |
+    'dingwords'
+  >
+>('jr_profiles');
 
 Migrations.add({
   version: 38,

--- a/imports/server/migrations/39-promote-profiles-to-toplevel.ts
+++ b/imports/server/migrations/39-promote-profiles-to-toplevel.ts
@@ -1,0 +1,41 @@
+import { Meteor } from 'meteor/meteor';
+import { Migrations } from 'meteor/percolate:migrations';
+import MeteorUsers from '../../lib/models/MeteorUsers';
+import dropIndex from './dropIndex';
+
+type LegacyProfile = Pick<Meteor.User, 'displayName' | 'googleAccount' | 'discordAccount' | 'phoneNumber' | 'muteApplause' | 'dingwords'>;
+
+Migrations.add({
+  version: 39,
+  name: 'Promote profile fields to user top-level',
+  up() {
+    MeteorUsers.find({ profile: { $ne: null as any } }).forEach((u) => {
+      const {
+        displayName, googleAccount, discordAccount, phoneNumber, muteApplause, dingwords,
+      } = u.profile as LegacyProfile;
+      MeteorUsers.update(u._id, {
+        $set: {
+          displayName,
+          googleAccount,
+          discordAccount,
+          phoneNumber,
+          muteApplause,
+          dingwords,
+        },
+      });
+      MeteorUsers.update(u._id, {
+        $unset: { profile: 1 },
+      }, {
+        validate: false, clean: false,
+      } as any);
+    });
+
+    // Fix indexes
+    MeteorUsers._ensureIndex({ displayName: 1 });
+    MeteorUsers._ensureIndex({ _id: 1, displayName: 1 });
+    MeteorUsers._ensureIndex({ _id: 1, dingwords: 1 });
+    dropIndex(MeteorUsers, 'profile.displayName_1');
+    dropIndex(MeteorUsers, '_id_1_profile.displayName_1');
+    dropIndex(MeteorUsers, '_id_1_profile.dingwords_1');
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -37,3 +37,4 @@ import './35-folder-permissions-indexes';
 import './36-call-history-indexes';
 import './37-role-reorganization';
 import './38-consolidate-profiles';
+import './39-promote-profiles-to-toplevel';

--- a/imports/server/profile.ts
+++ b/imports/server/profile.ts
@@ -26,10 +26,10 @@ Meteor.methods({
       _id: this.userId,
     }, {
       $set: {
-        'profile.displayName': newProfile.displayName,
-        'profile.phoneNumber': newProfile.phoneNumber,
-        'profile.muteApplause': newProfile.muteApplause,
-        'profile.dingwords': newProfile.dingwords,
+        displayName: newProfile.displayName,
+        phoneNumber: newProfile.phoneNumber,
+        muteApplause: newProfile.muteApplause,
+        dingwords: newProfile.dingwords,
       },
     });
   },
@@ -50,7 +50,7 @@ Meteor.methods({
       email,
     });
 
-    MeteorUsers.update(this.userId, { $set: { 'profile.googleAccount': email } });
+    MeteorUsers.update(this.userId, { $set: { googleAccount: email } });
 
     if (!Flags.active('disable.google') && !Flags.active('disable.gdrive_permissions')) {
       const hunts = Meteor.user()!.hunts;
@@ -62,7 +62,7 @@ Meteor.methods({
 
   unlinkUserGoogleAccount() {
     check(this.userId, String);
-    MeteorUsers.update(this.userId, { $unset: { 'profile.googleAccount': 1 } });
+    MeteorUsers.update(this.userId, { $unset: { googleAccount: 1 } });
   },
 
   linkUserDiscordAccount(key: unknown, secret: unknown) {
@@ -89,7 +89,7 @@ Meteor.methods({
     const userInfo = MeteorPromise.await(apiClient.retrieveUserInfo());
 
     // Save user's id, identifier, and avatar to their profile.
-    MeteorUsers.update(this.userId, { $set: { 'profile.discordAccount': userInfo } });
+    MeteorUsers.update(this.userId, { $set: { discordAccount: userInfo } });
 
     // Invite the user to the guild, if one is configured.
     const discordGuildDoc = Settings.findOne({ name: 'discord.guild' });
@@ -135,6 +135,6 @@ Meteor.methods({
     });
 
     // Remove display name from user's profile object.
-    MeteorUsers.update(this.userId, { $unset: { 'profile.discordAccount': 1 } });
+    MeteorUsers.update(this.userId, { $unset: { discordAccount: 1 } });
   },
 });

--- a/imports/server/puzzle.ts
+++ b/imports/server/puzzle.ts
@@ -314,8 +314,8 @@ Meteor.methods({
       return;
     }
 
-    if (user.profile?.googleAccount) {
-      ensureHuntFolderPermission(puzzle.hunt, this.userId, user.profile.googleAccount);
+    if (user.googleAccount) {
+      ensureHuntFolderPermission(puzzle.hunt, this.userId, user.googleAccount);
     }
   },
 });

--- a/types/meteor/accounts-base.ts
+++ b/types/meteor/accounts-base.ts
@@ -1,0 +1,7 @@
+import { Meteor } from 'meteor/meteor';
+
+declare module 'meteor/accounts-base' {
+  namespace Accounts {
+    function setDefaultPublishFields(fields: Partial<Record<keyof Meteor.User, 1 | 0>>): void;
+  }
+}


### PR DESCRIPTION
Meteor's support for merging different fields on the same object across
multiple subscriptions doesn't work for nested objects, meaning that a
subscription with `fields: {'profile.displayName': 1}` and a
subscription with `fields: {'profile.discordAccount': 1}` will clash,
only returning one of the two fields.

Given that this is a somewhat fundamental restriction on the current
Meteor DDP protocol, the easiest solution is to promote the fields from
the user profile to top-level themselves.