### PR TITLE
Add a basic smoke test that all routes work

### DIFF
--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -5,7 +5,7 @@ import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
 import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
 import {
-  Navigate, Route, Routes, useNavigate, useParams,
+  Outlet, useNavigate, useParams,
 } from 'react-router-dom';
 import Hunts from '../../lib/models/Hunts';
 import { userMayAddUsersToHunt, userMayUpdateHunt } from '../../lib/permission_stubs';
@@ -13,13 +13,7 @@ import { HuntType } from '../../lib/schemas/Hunt';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 import useDocumentTitle from '../hooks/useDocumentTitle';
 import markdown from '../markdown';
-import AnnouncementsPage from './AnnouncementsPage';
 import CelebrationCenter from './CelebrationCenter';
-import FirehosePage from './FirehosePage';
-import GuessQueuePage from './GuessQueuePage';
-import HuntProfileListPage from './HuntProfileListPage';
-import PuzzleListPage from './PuzzleListPage';
-import PuzzlePage from './PuzzlePage';
 
 const HuntDeletedError = React.memo(({ hunt, canUndestroy }: {
   hunt: HuntType;
@@ -164,15 +158,7 @@ const HuntApp = React.memo(() => {
     }
 
     return (
-      <Routes>
-        <Route path="announcements" element={<AnnouncementsPage />} />
-        <Route path="firehose" element={<FirehosePage />} />
-        <Route path="guesses" element={<GuessQueuePage />} />
-        <Route path="hunters/*" element={<HuntProfileListPage />} />
-        <Route path="puzzles/:puzzleId" element={<PuzzlePage />} />
-        <Route path="puzzles" element={<PuzzleListPage />} />
-        <Route path="" element={<Navigate to="puzzles" replace />} />
-      </Routes>
+      <Outlet />
     );
   }, [
     loading, member, hunt, canUndestroy, canJoin,

--- a/imports/client/components/HuntProfileListPage.tsx
+++ b/imports/client/components/HuntProfileListPage.tsx
@@ -1,16 +1,13 @@
 import { Meteor } from 'meteor/meteor';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import React from 'react';
-import {
-  Route, Routes, useParams,
-} from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import {
   listAllRolesForHunt, userMayAddUsersToHunt, userMayMakeOperatorForHunt, userMayUseDiscordBotAPIs,
 } from '../../lib/permission_stubs';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 import ProfileList from './ProfileList';
-import UserInvitePage from './UserInvitePage';
 
 const HuntProfileListPage = () => {
   const huntId = useParams<'huntId'>().huntId!;
@@ -49,22 +46,14 @@ const HuntProfileListPage = () => {
   }
 
   return (
-    <Routes>
-      <Route path="invite" element={<UserInvitePage />} />
-      <Route
-        path=""
-        element={(
-          <ProfileList
-            users={users}
-            roles={roles}
-            huntId={huntId}
-            canInvite={canInvite}
-            canSyncDiscord={canSyncDiscord}
-            canMakeOperator={canMakeOperator}
-          />
-        )}
-      />
-    </Routes>
+    <ProfileList
+      users={users}
+      roles={roles}
+      huntId={huntId}
+      canInvite={canInvite}
+      canSyncDiscord={canSyncDiscord}
+      canMakeOperator={canMakeOperator}
+    />
   );
 };
 

--- a/imports/client/components/Routes.tsx
+++ b/imports/client/components/Routes.tsx
@@ -1,17 +1,24 @@
 import React, { Suspense } from 'react';
-import { Route, Routes as ReactRouterRoutes } from 'react-router-dom';
+import { Navigate, Route, Routes as ReactRouterRoutes } from 'react-router-dom';
 import { BreadcrumbsProvider } from '../hooks/breadcrumb';
 import useDocumentTitle from '../hooks/useDocumentTitle';
 import AllProfileListPage from './AllProfileListPage';
+import AnnouncementsPage from './AnnouncementsPage';
 import EnrollForm from './EnrollForm';
+import FirehosePage from './FirehosePage';
 import FirstUserForm from './FirstUserForm';
+import GuessQueuePage from './GuessQueuePage';
 import HuntApp from './HuntApp';
 import HuntListPage from './HuntListPage';
+import HuntProfileListPage from './HuntProfileListPage';
 import Loading from './Loading';
 import LoginForm from './LoginForm';
 import PasswordResetForm from './PasswordResetForm';
 import ProfilePage from './ProfilePage';
+import PuzzleListPage from './PuzzleListPage';
+import PuzzlePage from './PuzzlePage';
 import RootRedirector from './RootRedirector';
+import UserInvitePage from './UserInvitePage';
 import { AuthenticatedPage, UnauthenticatedPage } from './authentication';
 
 const SetupPage = React.lazy(() => import('./SetupPage'));
@@ -28,7 +35,16 @@ const Routes = React.memo(() => {
           <Route path="/" element={<RootRedirector />} />
 
           {/* Authenticated routes - if user not logged in, get redirected to /login */}
-          <Route path="/hunts/:huntId/*" element={<AuthenticatedPage><HuntApp /></AuthenticatedPage>} />
+          <Route path="/hunts/:huntId" element={<AuthenticatedPage><HuntApp /></AuthenticatedPage>}>
+            <Route path="announcements" element={<AnnouncementsPage />} />
+            <Route path="firehose" element={<FirehosePage />} />
+            <Route path="guesses" element={<GuessQueuePage />} />
+            <Route path="hunters" element={<HuntProfileListPage />} />
+            <Route path="hunters/invite" element={<UserInvitePage />} />
+            <Route path="puzzles/:puzzleId" element={<PuzzlePage />} />
+            <Route path="puzzles" element={<PuzzleListPage />} />
+            <Route path="" element={<Navigate to="puzzles" replace />} />
+          </Route>
           <Route path="/hunts" element={<AuthenticatedPage><HuntListPage /></AuthenticatedPage>} />
           <Route path="/users/:userId" element={<AuthenticatedPage><ProfilePage /></AuthenticatedPage>} />
           <Route path="/users" element={<AuthenticatedPage><AllProfileListPage /></AuthenticatedPage>} />

--- a/imports/client/main.tsx
+++ b/imports/client/main.tsx
@@ -30,9 +30,11 @@ Meteor.startup(() => {
   ReactDOM.render(
     <>
       <Reset />
-      <BrowserRouter>
-        <Routes />
-      </BrowserRouter>
+      {!Meteor.isAppTest && (
+        <BrowserRouter>
+          <Routes />
+        </BrowserRouter>
+      )}
     </>,
     container
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.16.7"
+      }
+    },
     "@babel/generator": {
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
@@ -164,6 +173,25 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
       "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+    },
+    "@babel/highlight": {
+      "version": "7.16.10",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+      "integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
+        }
+      }
     },
     "@babel/parser": {
       "version": "7.15.6",
@@ -549,6 +577,74 @@
       "requires": {
         "dequal": "^2.0.2"
       }
+    },
+    "@testing-library/dom": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.11.3.tgz",
+      "integrity": "sha512-9LId28I+lx70wUiZjLvi1DB/WT2zGOxUh46glrSNMaWVx849kKAluezVzZrXJfTKKoQTmEOutLes/bHg4Bj3aA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.4.4",
+        "pretty-format": "^27.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "aria-query": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+          "integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "@testing-library/react": {
+      "version": "12.1.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.2.tgz",
+      "integrity": "sha512-ihQiEOklNyHIpo2Y8FREkyD1QAea054U0MVbwH1m8N9TxeFz+KoJ9LkqoKqJlzx2JDm56DVwaJ1r36JYxZM05g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@testing-library/dom": "^8.0.0"
+      }
+    },
+    "@types/aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+      "dev": true
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -2091,6 +2187,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.10.tgz",
+      "integrity": "sha512-Xu9mD0UjrJisTmv7lmVSDMagQcU9R5hwAbxsaAE/35XPnPLJobbuREfV/rraiSaEj/UOvgrzQs66zyTWTlyd+g==",
+      "dev": true
     },
     "dom-helpers": {
       "version": "5.2.0",
@@ -4498,6 +4600,12 @@
         }
       }
     },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -6072,6 +6180,31 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "27.4.6",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.4.6.tgz",
+      "integrity": "sha512-NblstegA1y/RJW2VyML+3LlpFjzx62cUrtBIKIWDXEDkjNeleA7Od7nrzcs/VLQvAeV4CgSYhrN39DRN88Qi/g==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+          "dev": true
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        }
+      }
     },
     "prism-media": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "use-persisted-state": "^0.3.3"
   },
   "devDependencies": {
+    "@testing-library/react": "^12.1.2",
     "@types/chai": "^4.3.0",
     "@types/dompurify": "^2.3.3",
     "@types/element-resize-detector": "^1.1.3",

--- a/tests/acceptance/lib.ts
+++ b/tests/acceptance/lib.ts
@@ -1,14 +1,73 @@
+/* eslint-disable import/prefer-default-export */
 /* eslint-disable no-console */
+import { Accounts } from 'meteor/accounts-base';
+import { check } from 'meteor/check';
+import { DDP } from 'meteor/ddp';
 import { Meteor } from 'meteor/meteor';
 import { Migrations } from 'meteor/percolate:migrations';
+import { Tracker } from 'meteor/tracker';
 import { resetDatabase } from 'meteor/xolvio:cleaner';
+import { addUserToRole } from '../../imports/lib/permission_stubs';
+
+export const USER_EMAIL = 'jolly-roger@deathandmayhem.com';
+export const USER_PASSWORD = 'password';
 
 if (Meteor.isServer) {
   Meteor.methods({
     'test.resetDatabase': function () {
+      if (!Meteor.isAppTest) {
+        throw new Meteor.Error(500, 'This code must not run in production');
+      }
+
       resetDatabase();
+      Migrations.config({ log: false, logger: () => {} });
       Migrations.migrateTo('latest');
       console.log('Reset database');
     },
+
+    'test.authentication.createUser': function () {
+      if (!Meteor.isAppTest) {
+        throw new Meteor.Error(500, 'This code must not run in production');
+      }
+
+      Accounts.createUser({
+        email: USER_EMAIL,
+        password: USER_PASSWORD,
+      });
+      console.log('Created test user', { email: USER_EMAIL });
+    },
+
+    'test.authentication.addRole': function (scope, role) {
+      if (!Meteor.isAppTest) {
+        throw new Meteor.Error(500, 'This code must not run in production');
+      }
+
+      check(this.userId, String);
+      check(scope, String);
+      check(role, String);
+      addUserToRole(this.userId, scope, role);
+    },
   });
 }
+
+// waitForSubscriptions and afterFlush both taken from
+// https://guide.meteor.com/testing.html#full-app-integration-test
+
+const waitForSubscriptions = () => new Promise<void>((resolve) => {
+  const poll = Meteor.setInterval(() => {
+    // eslint-disable-next-line no-underscore-dangle
+    if (DDP._allSubscriptionsReady()) {
+      Meteor.clearInterval(poll);
+      resolve();
+    }
+  }, 200);
+});
+
+const afterFlush = () => new Promise<void>((resolve) => {
+  Tracker.afterFlush(resolve);
+});
+
+export const stabilize = async () => {
+  await waitForSubscriptions();
+  await afterFlush();
+};

--- a/tests/acceptance/smoke.tsx
+++ b/tests/acceptance/smoke.tsx
@@ -1,0 +1,142 @@
+/* eslint-disable no-console */
+import { Meteor } from 'meteor/meteor';
+import { act, render } from '@testing-library/react';
+import React from 'react';
+import {
+  Location,
+  MemoryRouter,
+  NavigateFunction,
+  Route,
+  RouteObject,
+  Routes as ReactRouterRoutes,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom';
+import fixtures from '../../imports/fixtures';
+import { GLOBAL_SCOPE } from '../../imports/lib/is-admin';
+import { stabilize, USER_EMAIL, USER_PASSWORD } from './lib';
+
+function enumeratePaths(routes: RouteObject[], prefix: string = '', acc: string[] = []): string[] {
+  routes.forEach((route) => {
+    if (route.children) {
+      enumeratePaths(route.children, `${prefix}${route.path}/`, acc);
+    }
+    acc.push(`${prefix}${route.path}`);
+  });
+  return acc;
+}
+
+if (Meteor.isClient) {
+  const Routes: typeof import('../../imports/client/components/Routes').default =
+    require('../../imports/client/components/Routes').default;
+  const { AuthenticatedRouteList, UnauthenticatedRouteList }: typeof import('../../imports/client/components/Routes') =
+    require('../../imports/client/components/Routes');
+
+  const location: React.MutableRefObject<Location | null> = { current: null };
+  const navigate: React.MutableRefObject<NavigateFunction | null> = { current: null };
+
+  const LocationCapture = () => {
+    location.current = useLocation();
+    navigate.current = useNavigate();
+    return null;
+  };
+
+  const TestApp = () => {
+    return (
+      <MemoryRouter>
+        <Routes />
+        <ReactRouterRoutes>
+          <Route path="*" element={<LocationCapture />} />
+        </ReactRouterRoutes>
+      </MemoryRouter>
+    );
+  };
+
+  const fixtureHunt = Object.keys(fixtures)[0];
+  const fixturePuzzle = fixtures[fixtureHunt].puzzles[0]._id;
+
+  describe('routes', function () {
+    before(async function () {
+      await Meteor.callPromise('test.resetDatabase');
+      await Meteor.callPromise('test.authentication.createUser');
+      await Meteor.wrapPromise(Meteor.loginWithPassword)(USER_EMAIL, USER_PASSWORD);
+      await Meteor.callPromise('test.authentication.addRole', GLOBAL_SCOPE, 'admin');
+      await Meteor.callPromise('createFixtureHunt');
+      await Meteor.callPromise('addToHunt', fixtureHunt, USER_EMAIL);
+      await Meteor.callPromise('test.authentication.addRole', fixtureHunt, 'operator');
+    });
+
+    afterEach(function () {
+      location.current = null;
+      navigate.current = null;
+    });
+
+    const substituteUrl = (path: string) => {
+      const substitutions = {
+        huntId: fixtureHunt,
+        puzzleId: fixturePuzzle,
+        userId: Meteor.userId()!,
+      };
+
+      const url = Object.entries(substitutions).reduce((acc, [k, v]) => acc.replace(`:${k}`, v), path);
+      const unreplaced = new Set([...url.matchAll(/:(\w+)/g)].map((m) => m[1]));
+      if (unreplaced.size > 0) {
+        if (unreplaced.has('token')) {
+          console.log('Ignoring route with :token parameter');
+          unreplaced.delete('token');
+        }
+        if (unreplaced.size === 0) {
+          console.log('Skipping route', path);
+          return undefined;
+        }
+        throw new Error(`Unknown parameters: ${[...unreplaced].join(', ')}`);
+      }
+
+      return url;
+    };
+
+    describe('which are authenticated', function () {
+      before(async function () {
+        await Meteor.wrapPromise(Meteor.loginWithPassword)(USER_EMAIL, USER_PASSWORD);
+      });
+
+      enumeratePaths(AuthenticatedRouteList).forEach((p) => {
+        it(`works for path ${p}`, async function () {
+          const url = substituteUrl(p);
+          if (!url) {
+            this.skip();
+          }
+
+          await act(async () => {
+            render(<TestApp />);
+            await stabilize();
+            navigate.current!(url);
+            await stabilize();
+          });
+        });
+      });
+    });
+
+    describe('which are unauthenticated', function () {
+      before(async function () {
+        await Meteor.wrapPromise(Meteor.logout);
+      });
+
+      enumeratePaths(UnauthenticatedRouteList).forEach((p) => {
+        it(`works for path ${p}`, async function () {
+          const url = substituteUrl(p);
+          if (!url) {
+            this.skip();
+          }
+
+          await act(async () => {
+            render(<TestApp />);
+            await stabilize();
+            navigate.current!(url);
+            await stabilize();
+          });
+        });
+      });
+    });
+  });
+}

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -1,3 +1,4 @@
 import './unit/imports/lib/calendarTimeFormat';
 import './unit/imports/lib/relativeTimeFormat';
 import './acceptance/authentication';
+import './acceptance/smoke';


### PR DESCRIPTION
I'm not entirely sure how useful this will prove to be, but it feels just a little bit better than having nothing at all. This introduces a test which enumerates all routes and attempts to load each of them (using fixture data to populate the substitutions). If loading the page throws an exception, that will cause the test to fail (even though our error boundary will display the exception, it still gets rethrown as an uncaught exception which mocha picks up on).

In order to support this, I needed to get our routes into a format that I could manipulate, so I first migrated all of our routes into the `Routes.tsx` file (which is relatively straightforward using react-router's concept of [outlets](https://reactrouter.com/docs/en/v6/api#outlet) for rendering nested routes); and I switched to using react-router's [`useRoutes`](https://reactrouter.com/docs/en/v6/api#useroutes), which takes route data in a structured format. I used this as an opportunity to cleanup some of the duplicated `<AuthenticatedRoute />` tags from the JSX configuration.