### PR TITLE
Use eslint-formatter-gha in testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,3 +51,5 @@ jobs:
         cache-to: type=gha,mode=max # mode=max means cache intermediate images
         build-args: |
           GIT_REVISION=${{ github.sha }}
+          CI=true
+          GITHUB_ACTIONS=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,9 @@ EOF
 
 WORKDIR /app
 
+ARG CI=true
+ARG GITHUB_ACTIONS=
+
 # Install Meteor
 COPY .meteor/release /app/.meteor/release
 RUN <<EOF bash

--- a/imports/client/main.tsx
+++ b/imports/client/main.tsx
@@ -39,3 +39,4 @@ Meteor.startup(() => {
     container
   );
 });
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,24 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@actions/core": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==",
+      "dev": true,
+      "requires": {
+        "@actions/http-client": "^1.0.11"
+      }
+    },
+    "@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "dev": true,
+      "requires": {
+        "tunnel": "0.0.6"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -2726,6 +2744,64 @@
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.3"
+          }
+        }
+      }
+    },
+    "eslint-formatter-gha": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-gha/-/eslint-formatter-gha-1.4.1.tgz",
+      "integrity": "sha512-c2L/p4Xtnzlb3ascN4vERcXTMNPePedxZNRZcKG19DDpViBIG1WLMyMIeC2FSW7yGLBANZNb9N66sV2PDCdIqQ==",
+      "dev": true,
+      "requires": {
+        "@actions/core": "^1.2.6",
+        "eslint-formatter-json": "^8.0.0",
+        "eslint-formatter-stylish": "^8.0.0"
+      }
+    },
+    "eslint-formatter-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-json/-/eslint-formatter-json-8.3.0.tgz",
+      "integrity": "sha512-zMYHg0iA4AH534aUJyh7PR+f7xzAsd0kLEFzo4U3TN60l3zt5/7Ukbv2VmQcSl/bOFdOkhRhB9+U52plxp8o8Q==",
+      "dev": true
+    },
+    "eslint-formatter-stylish": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-stylish/-/eslint-formatter-stylish-8.3.0.tgz",
+      "integrity": "sha512-4QKzT/NPD6VjFDhdUHnp/6bRODXg2G44SCEC4tc8MMErBffHojbVzcje0H7ql7aJQ277OBGCpe8mjjiNmdCxBg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -7229,6 +7305,12 @@
       "requires": {
         "tslib": "^1.8.1"
       }
+    },
+    "tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true
     },
     "tweetnacl": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/deathandmayhem/jolly-roger"
   },
   "scripts": {
-    "lint": "tsc --noEmit && eslint --ext js,jsx,ts,tsx .",
+    "lint": "tsc --noEmit && eslint --format gha --ext js,jsx,ts,tsx .",
     "test": "TEST_BROWSER_DRIVER=puppeteer meteor test --full-app --once --driver-package meteortesting:mocha"
   },
   "dependencies": {
@@ -89,6 +89,7 @@
     "chai": "^4.3.6",
     "eslint": "^8.7.0",
     "eslint-config-airbnb": "^19.0.4",
+    "eslint-formatter-gha": "^1.4.1",
     "eslint-import-resolver-meteor": "^0.4.0",
     "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-eslint-comments": "^3.2.0",


### PR DESCRIPTION
eslint-formatter-gha detects if its running inside of a GitHub Action, and if so uses GitHub's [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions) to format the output in a way that results in annotating the diff. I introduced a trivial lint failure to verify that it threads through correctly, which I'll remove before merging, obviously.

Sadly, I wasn't able to find a similar plugin for `tsc`. It's rather difficult to search for anything involving "typescript output formatter" because inevitably you either find information about `tsc` outputting transpiled Javascript or people wanting to run `prettier` or similar on their TypeScript code. However, my conclusion on a quick skim of TypeScript's plugin architecture was that it doesn't actually allow you to modify the output format, so I think we may end up needing to, like, `sed` our way to success if we want to also incorporate this for type errors.

In any case, it seems likely to be enough work to defer it from this PR and reserve as a future improvement.