### PR TITLE
Tweak puzzle activity monitor

### DIFF
--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -71,8 +71,12 @@ const PuzzleTitleColumn = styled(PuzzleColumn)`
 `;
 
 const PuzzleActivityColumn = styled(PuzzleColumn)`
-  width: 120px;
+  width: 11rem;
   text-align: right;
+  // Push to take whole row in narrow views
+  ${mediaBreakpointDown('xs')`
+    flex: 0 0 100%;
+  `}
 `;
 
 const PuzzleLinkColumn = styled(PuzzleColumn)`

--- a/imports/client/components/PuzzleActivity.tsx
+++ b/imports/client/components/PuzzleActivity.tsx
@@ -14,18 +14,48 @@ import { RECENT_ACTIVITY_TIME_WINDOW_MS } from '../../lib/config/webrtc';
 import CallHistories from '../../lib/models/mediasoup/CallHistories';
 import relativeTimeFormat, { terseRelativeTimeFormat } from '../../lib/relativeTimeFormat';
 import { SubscriberCounters } from '../subscribers';
+import { mediaBreakpointDown } from './styling/responsive';
 
-const PuzzleActivitySpan = styled.span`
+const PuzzleActivityItems = styled.span`
   font-size: 14px;
   color: #666666;
+  display: flex;
+  justify-content: flex-end;
+
+  ${mediaBreakpointDown('xs')`
+    justify-content: flex-start;
+  `}
 `;
 
-const LastActiveSpan = styled.span`
-  display: inline-block;
-  text-align: left;
-  width: 1em;
-  margin-left: 2px;
-  margin-right: 2px;
+const PuzzleActivityItem = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  text-align: right;
+  margin: 0 0 0 0.5rem;
+
+  span {
+    margin-right: 0.25rem;
+  }
+
+  ${mediaBreakpointDown('xs')`
+    justify-content: flex-start;
+    margin-left: 0.125rem;
+  `}
+`;
+
+const PuzzleOpenTime = styled(PuzzleActivityItem)`
+  min-width: 4.66rem;
+`;
+
+const PuzzleViewerActivity = styled(PuzzleActivityItem)`
+  min-width: 2.66rem;
+`;
+
+const LastActiveCall = styled(PuzzleActivityItem)`
+  width: 1rem;
+  margin: 0 0.25rem 0 0.66rem;
+  justify-content: flex-start;
 `;
 
 interface PuzzleActivityProps {
@@ -111,27 +141,27 @@ const PuzzleActivity = ({ huntId, puzzleId, unlockTime }: PuzzleActivityProps) =
   );
 
   return (
-    <PuzzleActivitySpan>
+    <PuzzleActivityItems>
       <OverlayTrigger placement="top" overlay={unlockTooltip}>
-        <span>
+        <PuzzleOpenTime>
+          <span>{unlockTimeRelative}</span>
           <FontAwesomeIcon icon={faDoorOpen} />
-          {' '}
-          {unlockTimeRelative}
-        </span>
-      </OverlayTrigger>
-      <OverlayTrigger placement="top" overlay={audioTooltip}>
-        <LastActiveSpan>
-          <FontAwesomeIcon icon={icon} />
-        </LastActiveSpan>
+        </PuzzleOpenTime>
       </OverlayTrigger>
       <OverlayTrigger placement="top" overlay={countTooltip}>
-        <span>
+        <PuzzleViewerActivity>
+          <span>{viewCount}</span>
           <FontAwesomeIcon icon={faEye} />
-          {' '}
-          {viewCount}
-        </span>
+        </PuzzleViewerActivity>
       </OverlayTrigger>
-    </PuzzleActivitySpan>
+      <OverlayTrigger placement="top" overlay={audioTooltip}>
+        <LastActiveCall>
+          {callLastActive && (
+            <FontAwesomeIcon icon={icon} />
+          )}
+        </LastActiveCall>
+      </OverlayTrigger>
+    </PuzzleActivityItems>
   );
 };
 


### PR DESCRIPTION
Increased the spacing between activity monitor items a little bit, and adjusted the column width so it wouldn't overflow.

Moved the call activity icon to the third position, and hid it if there's never been a call.

In the audio icon's previous (second) position, it was a choice of either having the margin between the items look unbalanced (as the differing volume icons change width quite a bit) or having activity elements move as values change. Neither of those seemed like a good idea. By moving it third, we only have to worry about the icon's left margin relative to the other icons and can reserve a fixed width for the icon to appear in if it is absent. Plus it makes it easier to differentiate puzzles with calls from puzzles without at a glance!

