### PR TITLE
Fix migration 38 for servers that take migration 38 and 39 in one code update

### DIFF
--- a/imports/server/migrations/38-consolidate-profiles.ts
+++ b/imports/server/migrations/38-consolidate-profiles.ts
@@ -46,7 +46,10 @@ Migrations.add({
             dingwords,
           },
         },
-      });
+      }, {
+        validate: false,
+        clean: false,
+      } as any);
     });
 
     // Add indexes to match the old profiles model


### PR DESCRIPTION
If a server:

* has users with separate Profile objects (any server with users)
* has not applied migration 38 yet
* attempts to apply migration 38 with code built at current git HEAD

then it will fail:

```
Error: After filtering out keys not in the schema, your modifier is now empty
    at doValidate (packages/aldeed:collection2/collection2.js:431:11)
    at Collection.Mongo.Collection.<computed> [as update] (packages/aldeed:collection2/collection2.js:199:14)
    at imports/server/migrations/38-consolidate-profiles.ts:38:7
    at SynchronousCursor.forEach (packages/mongo/mongo_driver.js:1137:16)
    at Cursor.<computed> [as forEach] (packages/mongo/mongo_driver.js:923:44)
    at Object.up (imports/server/migrations/38-consolidate-profiles.ts:29:5)
    at migrate (packages/percolate:migrations/migrations_server.js:217:5)
    at Object.Migrations._migrateTo (packages/percolate:migrations/migrations_server.js:240:7)
    at Object.Migrations.migrateTo (packages/percolate:migrations/migrations_server.js:142:10)
    at imports/server/migrations-run.ts:4:22
    at Function.time (/built_app/bundle/programs/server/profile.js:273:30)
    at /built_app/bundle/programs/server/boot.js:415:15
    at /built_app/bundle/programs/server/boot.js:465:7
    at Function.run (/built_app/bundle/programs/server/profile.js:280:14)
    at /built_app/bundle/programs/server/boot.js:463:13
```

This is due to schema checking on the MeteorUsers.update() call, since
the keys being populated by migration 38 no longer exist in the schema
we've updated to flatten profile fields.  The solution is to apply the
commands exactly as given, bypassing the collection2 validation, as we
do in many other migrations (but missed here).