### PR TITLE
Fix migrations (attempt 2)

### DIFF
--- a/imports/server/migrations/38-consolidate-profiles.ts
+++ b/imports/server/migrations/38-consolidate-profiles.ts
@@ -49,6 +49,7 @@ Migrations.add({
       }, {
         validate: false,
         clean: false,
+        filter: false,
       } as any);
     });
 


### PR DESCRIPTION
Apparently we also need `filter: false` to make collection2 not filter
out keys that the schema no longer declares.