### PR TITLE
Fix users API endpoint lookup by google account

### DIFF
--- a/imports/server/api/resources/users.ts
+++ b/imports/server/api/resources/users.ts
@@ -13,7 +13,7 @@ function findUserByEmail(email: string): Meteor.User | undefined {
   // linked. Try both.
 
   return Accounts.findUserByEmail(email) ||
-    MeteorUsers.findOne({ 'profile.googleAccount': email });
+    MeteorUsers.findOne({ googleAccount: email });
 }
 
 // You are active if you've logged in in the last year


### PR DESCRIPTION
This query got overlooked when we exploded profile subfields onto the
user object directly.