### PR TITLE
Remove punctuation from respaced presentation

### DIFF
--- a/imports/client/components/PuzzleAnswer.tsx
+++ b/imports/client/components/PuzzleAnswer.tsx
@@ -14,19 +14,27 @@ const PuzzleAnswerSegment = styled.span`
   }
 `;
 
+// Clean answers for presentation as blocks of characters.
+// To try to preserve unexpected content-ful special characters (such as emoji), only remove
+// non-alphanumeric characters expected in a sentence or title.
+function removePunctuation(answer: string) {
+  return answer.toUpperCase().replace(/[\s.?!,;:\-_()'\u2018\u2019"\u201C\u201D]+/gu, '');
+}
+
 const PuzzleAnswer = React.memo(({
   answer, className, respace = false, segmentSize = 5,
 }: {
   answer: string;
   className?: string;
-  // If respace is set, answers are formatted without spaces and grouped into segments of length
-  // segmentSize. If segmentSize is zero or negative, the effect is simply to strip spaces.
+  // If respace is set, answers are formatted without spaces and punctuation and grouped into
+  // segments of length segmentSize. If segmentSize is zero or negative, the effect is simply to
+  // strip spaces and punctuation.
   respace?: boolean;
   segmentSize?: number;
 }) => {
-  const respacedAnswer = respace ? answer.replace(/\s+/g, '') : answer;
-  let formattedAnswer: React.ReactNode = respacedAnswer;
+  let formattedAnswer: React.ReactNode = answer;
   if (respace && segmentSize > 0) {
+    const respacedAnswer = removePunctuation(answer);
     // Use Intl.Segmenter (stage 3 proposal) if available to properly segment grapheme clusters
     // Typescript is unaware of it, so there are a few any casts...
     let graphemes:string[];
@@ -54,3 +62,4 @@ const PuzzleAnswer = React.memo(({
 });
 
 export default PuzzleAnswer;
+export { removePunctuation };

--- a/imports/client/components/Tag.tsx
+++ b/imports/client/components/Tag.tsx
@@ -14,6 +14,7 @@ import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { PuzzleType } from '../../lib/schemas/Puzzle';
 import { TagType } from '../../lib/schemas/Tag';
+import { removePunctuation } from './PuzzleAnswer';
 import { sortPuzzlesByRelevanceWithinPuzzleGroup } from './RelatedPuzzleList';
 import RelatedPuzzleTable from './RelatedPuzzleTable';
 
@@ -254,8 +255,7 @@ const Tag = (props: TagProps) => {
       const missingCnt = minRowCnt > puzzle.answers.length ? minRowCnt - puzzle.answers.length : 0;
       const answers = puzzle.answers.concat(Array(missingCnt).fill(''));
       return answers.map((answer) => {
-        let formattedAnswer = answer.toUpperCase();
-        formattedAnswer = segmentAnswers ? formattedAnswer.replace(/\s+/g, '') : formattedAnswer;
+        const formattedAnswer = segmentAnswers ? removePunctuation(answer) : answer;
         return `${puzzle.title}\t${formattedAnswer}`;
       }).join('\n');
     }).join('\n');


### PR DESCRIPTION
Remove punctuation that one might find in a sentence or title from answers in respaced presentation. `.?!,;:-_()'"` are treated comparably to spaces. This is a deliberately short list, so that unexpected but contentful characters (such as emoji) aren't removed in the respaced presentation.

This is another step towards allowing our canonical answer stores to be as semantically meaningful as possible, without detracting from at-a-glance length comparison and indexing. An interface allowing operators to adjust answer spacing and punctuation was proposed in #600.

Closes #602

Canonical presentation (unchanged):
<img width="390" alt="canonical" src="https://user-images.githubusercontent.com/2136874/151742410-4fb321ca-706d-4e15-891e-eb6d842c9d4e.png">

Respaced presentation
<img width="390" alt="respaced" src="https://user-images.githubusercontent.com/2136874/151742419-6e0b565e-52b4-4b71-ba91-1541c183f998.png">
