### PR TITLE
Bump timeout on setup for smoke test

### DIFF
--- a/tests/acceptance/smoke.tsx
+++ b/tests/acceptance/smoke.tsx
@@ -56,6 +56,10 @@ if (Meteor.isClient) {
 
   describe('routes', function () {
     before(async function () {
+      // Bump timeout for setup hook. It shouldn't take this long, but we see
+      // timeouts in CI.
+      this.timeout(5000);
+
       await Meteor.callPromise('test.resetDatabase');
       await Meteor.callPromise('provisionFirstUser', USER_EMAIL, USER_PASSWORD);
       await Meteor.wrapPromise(Meteor.loginWithPassword)(USER_EMAIL, USER_PASSWORD);


### PR DESCRIPTION
Looks like we saw timeouts in some of the dependabot tests while creating fixtures:

```
#25 235.7 I20220131-15:12:46.167(0)?   routes
#25 235.8 I20220131-15:12:46.276(0)? Failed login attempt: user= email= ip=127.0.0.1 error="You've been logged out by the server. Please log in again."
#25 236.1 I20220131-15:12:46.564(0)? Reset database
#25 236.2 I20220131-15:12:46.647(0)? Reset database
#25 236.4 I20220131-15:12:46.938(0)? [Jykc5WEjn5etAsyTS] User logged in: email=jolly-roger@deathandmayhem.com user=Jykc5WEjn5etAsyTS ip=127.0.0.1
#25 237.7 I20220131-15:12:48.184(0)?     1) "before all" hook in "routes"
#25 237.7 I20220131-15:12:48.186(0)?   11 passing (5s)
#25 237.7 I20220131-15:12:48.187(0)?   1 failing
#25 237.7 I20220131-15:12:48.188(0)?   1) routes
#25 237.7 I20220131-15:12:48.189(0)?        "before all" hook in "routes":
#25 237.7 I20220131-15:12:48.190(0)?      Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```