### PR TITLE
Update @types/use-persisted-state to 0.3.1

### DIFF
--- a/imports/client/hooks/persisted-state.ts
+++ b/imports/client/hooks/persisted-state.ts
@@ -1,17 +1,11 @@
-import { Dispatch, SetStateAction } from 'react';
+import { SetStateAction } from 'react';
 import createPersistedState from 'use-persisted-state';
 
 export type OperatorActionsHiddenState = Record<string /* huntId */, boolean>;
-export const useOperatorActionsHidden: () => [
-  OperatorActionsHiddenState | undefined,
-  Dispatch<SetStateAction<OperatorActionsHiddenState | undefined>>
-] =
-  createPersistedState('operatorActionsHidden');
+export const useOperatorActionsHidden =
+  createPersistedState<OperatorActionsHiddenState>('operatorActionsHidden');
 
-export const useOperatorActionsHiddenForHunt = (huntId: string): readonly [
-  boolean,
-  Dispatch<SetStateAction<boolean>>,
-] => {
+export const useOperatorActionsHiddenForHunt = (huntId: string) => {
   const [operatorActionsHidden, setOperatorActionsHidden] = useOperatorActionsHidden();
   return [
     operatorActionsHidden?.[huntId] ?? false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1005,9 +1005,9 @@
       "dev": true
     },
     "@types/use-persisted-state": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@types/use-persisted-state/-/use-persisted-state-0.3.0.tgz",
-      "integrity": "sha512-ZT98QuckR95qM7W97lGVqc7fFS9TT6f3txp7R40fl0zxa5BLm3GG7j0i51G12h8DkoJxFAf2oQyYKU99h0pxFA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@types/use-persisted-state/-/use-persisted-state-0.3.1.tgz",
+      "integrity": "sha512-GZtzdCPeR+KZfrzKrVLnbpRcHSCVDHaFCJ0QtkXDAmh5M+eUJqGquFtN+eUOvAMIjwLgTZ2zKq0/JL+e1/gf8g==",
       "dev": true,
       "requires": {
         "@types/react": "*"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@types/react-router-bootstrap": "^0.24.5",
     "@types/simpl-schema": "^1.12.0",
     "@types/styled-components": "^5.1.21",
-    "@types/use-persisted-state": "^0.3.0",
+    "@types/use-persisted-state": "^0.3.1",
     "@types/ws": "^8.2.2",
     "@typescript-eslint/eslint-plugin": "^5.10.1",
     "@typescript-eslint/parser": "^5.10.1",


### PR DESCRIPTION
(And drop some of our own type declarations meant to work around the older version.)

This replaces #667.