### PR TITLE
Take advantage of autopublish for some cleanup

### DIFF
--- a/imports/Flags.ts
+++ b/imports/Flags.ts
@@ -1,11 +1,6 @@
 import { Match, check } from 'meteor/check';
-import { Meteor } from 'meteor/meteor';
 import { SHA256 } from 'meteor/sha';
 import FeatureFlags from './lib/models/FeatureFlags';
-
-if (Meteor.isClient) {
-  Meteor.subscribe('mongo.featureflags');
-}
 
 const Flags = {
   active(name: unknown, shard?: unknown) {

--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -108,12 +108,11 @@ const HuntApp = React.memo(() => {
 
   const huntId = useParams<'huntId'>().huntId!;
 
-  const userLoading = useSubscribe('selfHuntMembership');
   // Subscribe to deleted and non-deleted hunts separately so that we can reuse
   // the non-deleted subscription
   const huntLoading = useSubscribe('mongo.hunts', { _id: huntId });
   const deletedHuntLoading = useSubscribe('mongo.hunts.deleted', { _id: huntId });
-  const loading = userLoading() || huntLoading() || deletedHuntLoading();
+  const loading = huntLoading() || deletedHuntLoading();
 
   const hunt = useTracker(() => Hunts.findOneAllowingDeleted(huntId), [huntId]);
   const {

--- a/imports/client/components/HuntListPage.tsx
+++ b/imports/client/components/HuntListPage.tsx
@@ -602,8 +602,7 @@ const Hunt = React.memo(({ hunt }: { hunt: HuntType }) => {
 const HuntListPage = () => {
   useBreadcrumb({ title: 'Hunts', path: '/hunts' });
   const huntsLoading = useSubscribe('mongo.hunts');
-  const myHuntsLoading = useSubscribe('selfHuntMembership');
-  const loading = huntsLoading() || myHuntsLoading();
+  const loading = huntsLoading();
 
   const hunts = useTracker(() => Hunts.find({}, { sort: { createdAt: -1 } }).fetch());
   const { canAdd, myHunts } = useTracker(() => {

--- a/imports/lib/models/FeatureFlags.ts
+++ b/imports/lib/models/FeatureFlags.ts
@@ -1,10 +1,13 @@
+import { Meteor } from 'meteor/meteor';
 import FeatureFlagSchema, { FeatureFlagType } from '../schemas/FeatureFlag';
 import Base from './Base';
 
 const FeatureFlags = new Base<FeatureFlagType>('featureflags');
 FeatureFlags.attachSchema(FeatureFlagSchema);
 
-// All feature flags are accessible
-FeatureFlags.publish();
+// All feature flags are always available on the client
+if (Meteor.isServer) {
+  Meteor.publish(null, () => FeatureFlags.find());
+}
 
 export default FeatureFlags;

--- a/imports/lib/permission_stubs.ts
+++ b/imports/lib/permission_stubs.ts
@@ -359,23 +359,3 @@ export function removeUserFromRoles(userId: string, scope: string, roles: string
     },
   });
 }
-
-if (Meteor.isServer) {
-  Meteor.publish('roles', function () {
-    if (!this.userId) {
-      return [];
-    }
-
-    return MeteorUsers.find({
-      _id: this.userId,
-    }, {
-      fields: {
-        roles: 1,
-      },
-    });
-  });
-}
-
-if (Meteor.isClient) {
-  Meteor.subscribe('roles');
-}

--- a/imports/server/users.ts
+++ b/imports/server/users.ts
@@ -20,15 +20,9 @@ const profileFields: Record<ProfileFields, 1> = {
 Accounts.setDefaultPublishFields({
   username: 1,
   emails: 1,
+  roles: 1,
+  hunts: 1,
   ...profileFields,
-});
-
-Meteor.publish('selfHuntMembership', function () {
-  if (!this.userId) {
-    return [];
-  }
-
-  return MeteorUsers.find(this.userId, { fields: { hunts: 1 } });
 });
 
 Meteor.publish('huntMembers', function (huntId: string) {


### PR DESCRIPTION
We're already auto-publishing fields on user, so we might as well skip
the explicit publishes we were using before. For feature flags, Meteor
will auto-publish to the client any subscription with a null name, so we
don't need an unconditional subscribe (because Meteor will do it for
us).