### PR TITLE
Store all puzzle list state in localStorage

### DIFF
--- a/imports/client/hooks/persisted-state.ts
+++ b/imports/client/hooks/persisted-state.ts
@@ -1,4 +1,4 @@
-import { SetStateAction } from 'react';
+import { SetStateAction, useCallback } from 'react';
 import createPersistedState from 'use-persisted-state';
 
 export type OperatorActionsHiddenState = Record<string /* huntId */, boolean>;
@@ -9,7 +9,7 @@ export const useOperatorActionsHiddenForHunt = (huntId: string) => {
   const [operatorActionsHidden, setOperatorActionsHidden] = useOperatorActionsHidden();
   return [
     operatorActionsHidden?.[huntId] ?? false,
-    (update: SetStateAction<boolean>) => {
+    useCallback((update: SetStateAction<boolean>) => {
       setOperatorActionsHidden((prevHidden) => {
         const newHidden = {
           ...prevHidden,
@@ -17,6 +17,97 @@ export const useOperatorActionsHiddenForHunt = (huntId: string) => {
         };
         return newHidden;
       });
-    },
+    }, [setOperatorActionsHidden, huntId]),
+  ] as const;
+};
+
+export type PuzzleListState = {
+  displayMode: 'group' | 'unlock';
+  showSolved: boolean;
+  collapseGroups: Record<string /* tag ID */, boolean>;
+}
+export const usePuzzleListState = createPersistedState<Record<string /* huntId */, PuzzleListState>>('puzzleListView');
+
+const defaultPuzzleListState = () => {
+  return { displayMode: 'group', showSolved: true, collapseGroups: {} } as const;
+};
+export const useHuntPuzzleListState = (huntId: string) => {
+  const [puzzleListView, setPuzzleListView] = usePuzzleListState();
+  return [
+    puzzleListView?.[huntId] ?? defaultPuzzleListState(),
+    useCallback((update: SetStateAction<PuzzleListState>) => {
+      setPuzzleListView((prevView) => {
+        const newView = {
+          ...prevView,
+          [huntId]: typeof update === 'function' ? update(prevView?.[huntId] ?? defaultPuzzleListState()) : update,
+        };
+        return newView;
+      });
+    }, [setPuzzleListView, huntId]),
+  ] as const;
+};
+
+export const useHuntPuzzleListDisplayMode = (huntId: string) => {
+  const [huntPuzzleListView, setHuntPuzzleListView] = useHuntPuzzleListState(huntId);
+  return [
+    huntPuzzleListView.displayMode,
+    useCallback((update: SetStateAction<'group' | 'unlock'>) => {
+      setHuntPuzzleListView((prevView) => {
+        const newView = {
+          ...prevView,
+          displayMode: typeof update === 'function' ? update(prevView.displayMode) : update,
+        };
+        return newView;
+      });
+    }, [setHuntPuzzleListView]),
+  ] as const;
+};
+
+export const useHuntPuzzleListShowSolved = (huntId: string) => {
+  const [huntPuzzleListView, setHuntPuzzleListView] = useHuntPuzzleListState(huntId);
+  return [
+    huntPuzzleListView.showSolved,
+    useCallback((update: SetStateAction<boolean>) => {
+      setHuntPuzzleListView((prevView) => {
+        const newView = {
+          ...prevView,
+          showSolved: typeof update === 'function' ? update(prevView.showSolved) : update,
+        };
+        return newView;
+      });
+    }, [setHuntPuzzleListView]),
+  ] as const;
+};
+
+export const useHuntPuzzleListCollapseGroups = (huntId: string) => {
+  const [huntPuzzleListView, setHuntPuzzleListView] = useHuntPuzzleListState(huntId);
+  return [
+    huntPuzzleListView.collapseGroups,
+    useCallback((update: SetStateAction<Record<string /* tag ID */, boolean>>) => {
+      setHuntPuzzleListView((prevView) => {
+        const newView = {
+          ...prevView,
+          collapseGroups: typeof update === 'function' ? update(prevView.collapseGroups) : update,
+        };
+        return newView;
+      });
+    }, [setHuntPuzzleListView]),
+  ] as const;
+};
+
+export const useHuntPuzzleListCollapseGroup = (huntId: string, tagId: string) => {
+  const [huntPuzzleListCollapseGroups, setHuntPuzzleListCollapseGroups] =
+    useHuntPuzzleListCollapseGroups(huntId);
+  return [
+    huntPuzzleListCollapseGroups[tagId] ?? false,
+    useCallback((update: SetStateAction<boolean>) => {
+      setHuntPuzzleListCollapseGroups((prevView) => {
+        const newView = {
+          ...prevView,
+          [tagId]: typeof update === 'function' ? update(prevView[tagId] ?? false) : update,
+        };
+        return newView;
+      });
+    }, [setHuntPuzzleListCollapseGroups, tagId]),
   ] as const;
 };


### PR DESCRIPTION
This includes the collapse/uncollapsed state of individual groups as
well as the group/unlock preference. In order to prevent proliferation
of localStorage keys, everything is switched to use-persisted-state and
grouped under a single key as a data structure.

To avoid confusion when searching, we ignore the collapse state of all
groups when showing any search results. And in order to avoid needing to
do a bunch of clicks, there's a new "expand all" button that will expand
any collapsed groups.

Fixes #595.