### PR TITLE
Move hunt creation/edit to a separate page

### DIFF
--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -104,8 +104,6 @@ const HuntMemberError = React.memo(({ hunt, canJoin }: {
 });
 
 const HuntApp = React.memo(() => {
-  useBreadcrumb({ title: 'Hunts', path: '/hunts' });
-
   const huntId = useParams<'huntId'>().huntId!;
 
   // Subscribe to deleted and non-deleted hunts separately so that we can reuse

--- a/imports/client/components/HuntListApp.tsx
+++ b/imports/client/components/HuntListApp.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import { useBreadcrumb } from '../hooks/breadcrumb';
+
+const HuntListApp = () => {
+  useBreadcrumb({ title: 'Hunts', path: '/hunts' });
+  return <Outlet />;
+};
+
+export default HuntListApp;

--- a/imports/client/components/Routes.tsx
+++ b/imports/client/components/Routes.tsx
@@ -9,6 +9,7 @@ import FirehosePage from './FirehosePage';
 import FirstUserForm from './FirstUserForm';
 import GuessQueuePage from './GuessQueuePage';
 import HuntApp from './HuntApp';
+import HuntListApp from './HuntListApp';
 import HuntListPage from './HuntListPage';
 import HuntProfileListPage from './HuntProfileListPage';
 import Loading from './Loading';
@@ -21,26 +22,35 @@ import RootRedirector from './RootRedirector';
 import UserInvitePage from './UserInvitePage';
 import { AuthenticatedPage, UnauthenticatedPage } from './authentication';
 
+const HuntEditPage = React.lazy(() => import('./HuntEditPage'));
 const SetupPage = React.lazy(() => import('./SetupPage'));
 const RTCDebugPage = React.lazy(() => import('./RTCDebugPage'));
 
 /* Authenticated routes - if user not logged in, get redirected to /login */
 export const AuthenticatedRouteList: RouteObject[] = [
   {
-    path: '/hunts/:huntId',
-    element: <HuntApp />,
+    path: '/hunts',
+    element: <HuntListApp />,
     children: [
-      { path: 'announcements', element: <AnnouncementsPage /> },
-      { path: 'firehose', element: <FirehosePage /> },
-      { path: 'guesses', element: <GuessQueuePage /> },
-      { path: 'hunters', element: <HuntProfileListPage /> },
-      { path: 'hunters/invite', element: <UserInvitePage /> },
-      { path: 'puzzles/:puzzleId', element: <PuzzlePage /> },
-      { path: 'puzzles', element: <PuzzleListPage /> },
-      { path: '', element: <Navigate to="puzzles" replace /> },
+      {
+        path: ':huntId',
+        element: <HuntApp />,
+        children: [
+          { path: 'announcements', element: <AnnouncementsPage /> },
+          { path: 'firehose', element: <FirehosePage /> },
+          { path: 'guesses', element: <GuessQueuePage /> },
+          { path: 'hunters', element: <HuntProfileListPage /> },
+          { path: 'hunters/invite', element: <UserInvitePage /> },
+          { path: 'puzzles/:puzzleId', element: <PuzzlePage /> },
+          { path: 'puzzles', element: <PuzzleListPage /> },
+          { path: 'edit', element: <HuntEditPage /> },
+          { path: '', element: <Navigate to="puzzles" replace /> },
+        ],
+      },
+      { path: 'new', element: <HuntEditPage /> },
+      { path: '', element: <HuntListPage /> },
     ],
   },
-  { path: '/hunts', element: <HuntListPage /> },
   { path: '/users/:userId', element: <ProfilePage /> },
   { path: '/users', element: <AllProfileListPage /> },
   { path: '/setup', element: <SetupPage /> },


### PR DESCRIPTION
As we add more hunt configuration, we're rapidly outgrowing what's
reasonable to put into a relatively small modal. Given that, push it to
a separate page.

This is mostly pure copy-paste of the old modal content, but with a few
changes - namely handling breadcrumbs and URL parameters (instead of
having a hunt passed in), and slight changes to the post-submit flow.
Instead of closing the modal, we take different behavior depending on
whether we're creating a new hunt or editing an existing one. For
creation, we redirect to the newly created hunt. For edits, we scroll to
the bottom of the page and display a banner confirming that the edit was
successful, with a back button to take you back to the hunt list.