### PR TITLE
Rework forms to limit width and put buttons right

### DIFF
--- a/imports/client/components/ActionButtonRow.tsx
+++ b/imports/client/components/ActionButtonRow.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+const ActionButtonRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+`;
+
+export default ActionButtonRow;

--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -6,6 +6,7 @@ import { ServiceConfiguration } from 'meteor/service-configuration';
 import React, { useCallback, useMemo, useState } from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
+import Container from 'react-bootstrap/Container';
 import FormCheck from 'react-bootstrap/FormCheck';
 import FormControl, { FormControlProps } from 'react-bootstrap/FormControl';
 import FormGroup from 'react-bootstrap/FormGroup';
@@ -14,6 +15,7 @@ import FormText from 'react-bootstrap/FormText';
 import Flags from '../../Flags';
 import TeamName from '../TeamName';
 import { requestDiscordCredential } from '../discord';
+import ActionButtonRow from './ActionButtonRow';
 import AudioConfig from './AudioConfig';
 import Avatar from './Avatar';
 
@@ -334,7 +336,7 @@ const OwnProfilePage = ({ initialUser }: { initialUser: Meteor.User }) => {
 
   const shouldDisableForm = (submitState === 'submitting');
   return (
-    <div>
+    <Container>
       <h1>Account information</h1>
       <Avatar {...initialUser} size={64} />
       <FormGroup>
@@ -426,19 +428,21 @@ const OwnProfilePage = ({ initialUser }: { initialUser: Meteor.User }) => {
         </FormText>
       </FormGroup>
 
-      <FormGroup>
-        <Button
-          type="submit"
-          variant="primary"
-          disabled={shouldDisableForm}
-          onClick={handleSaveForm}
-        >
-          Save
-        </Button>
-      </FormGroup>
+      <ActionButtonRow>
+        <FormGroup>
+          <Button
+            type="submit"
+            variant="primary"
+            disabled={shouldDisableForm}
+            onClick={handleSaveForm}
+          >
+            Save
+          </Button>
+        </FormGroup>
+      </ActionButtonRow>
 
       <AudioConfig />
-    </div>
+    </Container>
   );
 };
 

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -23,6 +23,11 @@ import { SettingType } from '../../lib/schemas/Setting';
 import { DiscordGuildType } from '../discord';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 import lookupUrl from '../lookupUrl';
+import ActionButtonRow from './ActionButtonRow';
+
+const PageContainer = styled.div`
+  max-width: 800px;
+`;
 
 const Section = styled.section`
   margin-bottom: 24px;
@@ -38,6 +43,11 @@ const SectionHeader = styled.h1`
   align-items: center;
   justify-content: space-between;
   min-height: 48px;
+  // Note: keep in sync with App's margin computation
+  margin-left: calc(-1 * max(env(safe-area-inset-left, 0px), 15px));
+  margin-right: calc(-1 * max(env(safe-area-inset-right, 0px), 15px));
+  padding-left: max(env(safe-area-inset-left, 0px), 15px);
+  padding-right: 4px;
 `;
 
 const SectionHeaderLabel = styled.span`
@@ -48,14 +58,13 @@ const SectionHeaderButtons = styled.span`
   flex: 0 0 auto;
   button {
     margin-left: 8px;
-    margin-bottom: 8px;
   }
 `;
 
 const Subsection = styled.div`
-  &:not(:last-child) {
-    border-bottom: 1px solid #ccc;
-    padding-bottom: 16px;
+  &:not(:first-child) {
+    border-top: 1px solid #ccc;
+    padding-top: 16px;
     margin-bottom: 16px;
   }
 `;
@@ -179,9 +188,11 @@ const GoogleOAuthForm = ({ isConfigured, initialClientId }: {
           placeholder={secretPlaceholder}
         />
       </FormGroup>
-      <Button variant="primary" type="submit" disabled={shouldDisableForm} onSubmit={onSubmitOauthConfiguration}>
-        Save
-      </Button>
+      <ActionButtonRow>
+        <Button variant="primary" type="submit" disabled={shouldDisableForm} onSubmit={onSubmitOauthConfiguration}>
+          Save
+        </Button>
+      </ActionButtonRow>
     </form>
   );
 };
@@ -311,7 +322,9 @@ const GoogleDriveRootForm = ({ initialRootId }: { initialRootId?: string }) => {
           onChange={onRootIdChange}
         />
       </FormGroup>
-      <Button variant="primary" onClick={saveRootId} disabled={shouldDisableForm}>Save</Button>
+      <ActionButtonRow>
+        <Button variant="primary" onClick={saveRootId} disabled={shouldDisableForm}>Save</Button>
+      </ActionButtonRow>
       <FormGroup>
         <FormLabel htmlFor="jr-setup-edit-google-drive-reorganize">
           Changing this setting does not automatically reorganize any existing
@@ -416,8 +429,30 @@ const GoogleDriveTemplateForm = ({ initialDocTemplate, initialSpreadsheetTemplat
           onChange={onDocTemplateChange}
         />
       </FormGroup>
-      <Button variant="primary" onClick={saveTemplates} disabled={shouldDisableForm}>Save</Button>
+      <ActionButtonRow>
+        <Button variant="primary" onClick={saveTemplates} disabled={shouldDisableForm}>Save</Button>
+      </ActionButtonRow>
     </div>
+  );
+};
+
+const FeatureToggle = ({ enabled, onToggleEnabled }: {
+  enabled: boolean;
+  onToggleEnabled: React.MouseEventHandler<HTMLElement>;
+}) => {
+  const firstButtonLabel = enabled ? 'Enabled' : 'Enable';
+  const secondButtonLabel = enabled ? 'Disable' : 'Disabled';
+  const firstButtonVariant = enabled ? 'secondary-outline' : 'secondary';
+  const secondButtonVariant = enabled ? 'secondary' : 'secondary-outline';
+  return (
+    <>
+      <Button variant={firstButtonVariant} disabled={enabled} onClick={onToggleEnabled}>
+        {firstButtonLabel}
+      </Button>
+      <Button variant={secondButtonVariant} disabled={!enabled} onClick={onToggleEnabled}>
+        {secondButtonLabel}
+      </Button>
+    </>
   );
 };
 
@@ -449,8 +484,6 @@ const GoogleIntegrationSection = () => {
     Meteor.call('clearGdriveCreds');
   }, []);
 
-  const firstButtonLabel = enabled ? 'Enabled' : 'Enable';
-  const secondButtonLabel = enabled ? 'Disable' : 'Disabled';
   const clientId = (oauthSettings && oauthSettings.clientId) || '';
 
   let stepsDone = 0;
@@ -486,12 +519,7 @@ const GoogleIntegrationSection = () => {
           {comp}
         </Badge>
         <SectionHeaderButtons>
-          <Button variant="light" disabled={enabled} onClick={onToggleEnabled}>
-            {firstButtonLabel}
-          </Button>
-          <Button variant="light" disabled={!enabled} onClick={onToggleEnabled}>
-            {secondButtonLabel}
-          </Button>
+          <FeatureToggle enabled={enabled} onToggleEnabled={onToggleEnabled} />
         </SectionHeaderButtons>
       </SectionHeader>
       <p>
@@ -911,7 +939,9 @@ const EmailConfigForm = ({ initialConfig }: {
           </ul>
         </FormText>
       </FormGroup>
-      <Button variant="primary" onClick={saveConfig} disabled={shouldDisableForm}>Save</Button>
+      <ActionButtonRow>
+        <Button variant="primary" onClick={saveConfig} disabled={shouldDisableForm}>Save</Button>
+      </ActionButtonRow>
     </div>
   );
 };
@@ -1052,7 +1082,9 @@ const DiscordOAuthForm = ({ oauthSettings }: {
             onChange={onClientSecretChange}
           />
         </FormGroup>
-        <Button variant="primary" type="submit" onClick={onSubmitOauthConfiguration} disabled={shouldDisableForm}>Save</Button>
+        <ActionButtonRow>
+          <Button variant="primary" type="submit" onClick={onSubmitOauthConfiguration} disabled={shouldDisableForm}>Save</Button>
+        </ActionButtonRow>
       </form>
     </div>
   );
@@ -1113,7 +1145,9 @@ const DiscordBotForm = ({ botToken: initialBotToken }: { botToken?: string }) =>
             onChange={onBotTokenChange}
           />
         </FormGroup>
-        <Button variant="primary" type="submit" onClick={onSubmitBotToken} disabled={shouldDisableForm}>Save</Button>
+        <ActionButtonRow>
+          <Button variant="primary" type="submit" onClick={onSubmitBotToken} disabled={shouldDisableForm}>Save</Button>
+        </ActionButtonRow>
       </form>
     </div>
   );
@@ -1195,7 +1229,9 @@ const DiscordGuildForm = ({ guild: initialGuild }: {
             })}
           </FormControl>
         </FormGroup>
-        <Button variant="primary" type="submit" onClick={onSaveGuild} disabled={shouldDisableForm}>Save</Button>
+        <ActionButtonRow>
+          <Button variant="primary" type="submit" onClick={onSaveGuild} disabled={shouldDisableForm}>Save</Button>
+        </ActionButtonRow>
       </form>
     </div>
   );
@@ -1219,9 +1255,6 @@ const DiscordIntegrationSection = () => {
     Meteor.call('setFeatureFlag', 'disable.discord', ffValue);
   }, [enabled]);
 
-  const firstButtonLabel = enabled ? 'Enabled' : 'Enable';
-  const secondButtonLabel = enabled ? 'Disable' : 'Disabled';
-
   const configured = !!oauthSettings;
   const headerBadgeVariant = configured ? 'success' : 'warning';
   const clientId = oauthSettings && oauthSettings.appId;
@@ -1243,12 +1276,7 @@ const DiscordIntegrationSection = () => {
         </Badge>
         {configured && (
         <SectionHeaderButtons>
-          <Button variant="light" disabled={enabled} onClick={onToggleEnabled}>
-            {firstButtonLabel}
-          </Button>
-          <Button variant="light" disabled={!enabled} onClick={onToggleEnabled}>
-            {secondButtonLabel}
-          </Button>
+          <FeatureToggle enabled={enabled} onToggleEnabled={onToggleEnabled} />
         </SectionHeaderButtons>
         )}
       </SectionHeader>
@@ -1405,7 +1433,9 @@ const BrandingTeamName = () => {
             onChange={onTeamNameChange}
           />
         </FormGroup>
-        <Button variant="primary" type="submit" onClick={onSubmit} disabled={shouldDisableForm}>Save</Button>
+        <ActionButtonRow>
+          <Button variant="primary" type="submit" onClick={onSubmit} disabled={shouldDisableForm}>Save</Button>
+        </ActionButtonRow>
       </form>
     </div>
   );
@@ -1597,7 +1627,10 @@ const CircuitBreakerRow = styled.div`
   align-items: baseline;
   justify-content: space-between;
   margin-bottom: 8px;
-  background: #eee;
+  background: #eef;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  padding-right: 4px;
 `;
 
 const CircuitBreakerLabel = styled.div`
@@ -1636,8 +1669,6 @@ const CircuitBreakerControl = ({
 
   // Is the feature that this circuit breaker disables currently available?
   const featureIsEnabled = !featureDisabled;
-  const firstButtonLabel = featureIsEnabled ? 'Enabled' : 'Enable';
-  const secondButtonLabel = featureIsEnabled ? 'Disable' : 'Disabled';
 
   return (
     <CircuitBreaker>
@@ -1646,12 +1677,7 @@ const CircuitBreakerControl = ({
           {title}
         </CircuitBreakerLabel>
         <CircuitBreakerButtons>
-          <Button variant="light" disabled={featureIsEnabled} onClick={onChangeCb}>
-            {firstButtonLabel}
-          </Button>
-          <Button variant="light" disabled={!featureIsEnabled} onClick={onChangeCb}>
-            {secondButtonLabel}
-          </Button>
+          <FeatureToggle enabled={featureIsEnabled} onToggleEnabled={onChangeCb} />
         </CircuitBreakerButtons>
       </CircuitBreakerRow>
       <div className="circuit-breaker-description">
@@ -1807,13 +1833,13 @@ const SetupPage = () => {
   }
 
   return (
-    <div>
+    <PageContainer>
       <GoogleIntegrationSection />
       <EmailConfigSection />
       <DiscordIntegrationSection />
       <BrandingSection />
       <CircuitBreakerSection />
-    </div>
+    </PageContainer>
   );
 };
 


### PR DESCRIPTION
Save buttons feel like they should always be at the bottom right of the
form they're modifying.  To keep them from getting lost, we should limit
the max-width of forms.

Large amounts of text (like that on the SetupPage) is also easier to
read when slightly narrower, and there's less of an argument for
information density on that page vs the PuzzleListPage, so I limited the
width of the content of each section..

I also took the opportunity to slightly tweak the design on SetupPage,
making the section headers fill the full width, making the toggle button
pairs into a reusable component, and adjusting some padding to avoid
buttons right on the edge of their containing element.