### PR TITLE
Force approval when getting Drive access

### DIFF
--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -229,6 +229,7 @@ const GoogleAuthorizeDriveClientForm = () => {
     Google.requestCredential({
       requestPermissions: ['email', 'https://www.googleapis.com/auth/drive'],
       requestOfflineToken: true,
+      forceApprovalPrompt: true,
     }, requestComplete);
     return false;
   }, [requestComplete]);


### PR DESCRIPTION
Without forcing an approval prompt, Google OAuth will only return a
refresh token the first time that you connect an application. If, for
whatever reason, you reconnect the application, Google will do a fast
no-prompt auth and won't return a refresh token, which is unfortunate
since that's the only credential we actually use.

By forcing the approval prompt, we ensure that we always get a refresh
token.