### PR TITLE
Upgrade to TypeScript 4.7

### DIFF
--- a/imports/client/hooks/persisted-state.ts
+++ b/imports/client/hooks/persisted-state.ts
@@ -29,7 +29,7 @@ export type PuzzleListState = {
 export const usePuzzleListState = createPersistedState<Record<string /* huntId */, PuzzleListState>>('puzzleListView');
 
 const defaultPuzzleListState = () => {
-  return { displayMode: 'group', showSolved: true, collapseGroups: {} } as const;
+  return { displayMode: 'group', showSolved: true, collapseGroups: {} } as PuzzleListState;
 };
 export const useHuntPuzzleListState = (huntId: string) => {
   const [puzzleListView, setPuzzleListView] = usePuzzleListState();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1688,7 +1688,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
     "buffer-equal-constant-time": {
@@ -4601,30 +4601,30 @@
       "resolved": "https://registry.npmjs.org/meteor-node-stubs/-/meteor-node-stubs-1.2.3.tgz",
       "integrity": "sha512-2kyYFh45428+q8EjydBhyHqPO30CG09yQ6xRNHMJSiFLqHaVoRJE1tWr7QrBKstjy8HkNH4UuKSp5S11HeZv/w==",
       "requires": {
-        "assert": "*",
-        "browserify-zlib": "*",
-        "buffer": "*",
-        "console-browserify": "*",
-        "constants-browserify": "*",
-        "crypto-browserify": "*",
-        "domain-browser": "*",
+        "assert": "^2.0.0",
+        "browserify-zlib": "^0.2.0",
+        "buffer": "^5.7.1",
+        "console-browserify": "^1.2.0",
+        "constants-browserify": "^1.0.0",
+        "crypto-browserify": "^3.12.0",
+        "domain-browser": "^4.19.0",
         "elliptic": "^6.5.4",
-        "events": "*",
-        "https-browserify": "*",
-        "os-browserify": "*",
-        "path-browserify": "*",
-        "process": "*",
-        "punycode": "*",
-        "querystring-es3": "*",
-        "readable-stream": "*",
-        "stream-browserify": "*",
-        "stream-http": "*",
-        "string_decoder": "*",
-        "timers-browserify": "*",
-        "tty-browserify": "*",
-        "url": "*",
-        "util": "*",
-        "vm-browserify": "*"
+        "events": "^3.3.0",
+        "https-browserify": "^1.0.0",
+        "os-browserify": "^0.3.0",
+        "path-browserify": "^1.0.0",
+        "process": "^0.11.10",
+        "punycode": "^1.4.1",
+        "querystring-es3": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "stream-browserify": "^3.0.0",
+        "stream-http": "^3.2.0",
+        "string_decoder": "^1.3.0",
+        "timers-browserify": "^2.0.12",
+        "tty-browserify": "0.0.1",
+        "url": "^0.11.0",
+        "util": "^0.12.4",
+        "vm-browserify": "^1.1.2"
       },
       "dependencies": {
         "asn1.js": {
@@ -7098,9 +7098,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "eslint-plugin-react-hooks": "^4.5.0",
     "mocha": "^10.0.0",
     "puppeteer": "^14.1.1",
-    "typescript": "^4.6.4"
+    "typescript": "^4.7.2"
   },
   "meteor": {
     "mainModule": {


### PR DESCRIPTION
This is almost completely uneventful, but is newly strict about indexed
access to an empty object, so tweak a cast slightly.

~(Also requires taking some updates to the TypeScript/ESLint integration to pick up versions that are compatible with TS 4.7)~ Bah I thought my working copy was up to date but apparently it was not.

Supersedes #861