### PR TITLE
Experiment with using ValidatedMethod

### DIFF
--- a/imports/client/components/AnnouncementsPage.tsx
+++ b/imports/client/components/AnnouncementsPage.tsx
@@ -11,6 +11,7 @@ import Announcements from '../../lib/models/Announcements';
 import { indexedDisplayNames } from '../../lib/models/MeteorUsers';
 import { userMayAddAnnouncementToHunt } from '../../lib/permission_stubs';
 import { AnnouncementType } from '../../lib/schemas/Announcement';
+import postAnnouncement from '../../methods/postAnnouncement';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 import useSubscribeDisplayNames from '../hooks/useSubscribeDisplayNames';
 import markdown from '../markdown';
@@ -50,10 +51,10 @@ const AnnouncementForm = ({ huntId }: { huntId: string }) => {
     setMessage(event.target.value);
   }, []);
 
-  const postAnnouncement = useCallback(() => {
+  const postAnnouncementCb = useCallback(() => {
     if (message) {
       setSubmitState(AnnouncementFormSubmitState.SUBMITTING);
-      Meteor.call('postAnnouncement', huntId, message, (error?: Error) => {
+      postAnnouncement.call({ huntId, message }, (error) => {
         if (error) {
           setErrorMessage(error.message);
           setSubmitState(AnnouncementFormSubmitState.FAILED);
@@ -78,7 +79,7 @@ const AnnouncementForm = ({ huntId }: { huntId: string }) => {
       <div className="button-row">
         <Button
           variant="primary"
-          onClick={postAnnouncement}
+          onClick={postAnnouncementCb}
           disabled={submitState === 'submitting'}
         >
           Send

--- a/imports/methods/TypedMethod.ts
+++ b/imports/methods/TypedMethod.ts
@@ -1,0 +1,75 @@
+import { check } from 'meteor/check';
+import { EJSONable, EJSONableProperty } from 'meteor/ejson';
+import { Meteor } from 'meteor/meteor';
+
+type TypedMethodParam = EJSONable | EJSONableProperty
+type TypedMethodArgs = Record<string, TypedMethodParam>;
+type TypedMethodValidator<Arg extends TypedMethodArgs> =
+  (this: Meteor.MethodThisType, arg0: unknown) =>
+    Arg;
+type TypedMethodRun<Arg extends TypedMethodArgs, Return extends TypedMethodParam | void> =
+  (this: Meteor.MethodThisType, arg0: Arg) => Return;
+
+export default class TypedMethod<
+  Args extends TypedMethodArgs,
+  Return extends TypedMethodParam | void,
+> {
+  name: string;
+
+  definition?: {
+    validate: TypedMethodValidator<Args>,
+    run: TypedMethodRun<Args, Return>,
+  };
+
+  constructor(name: string) {
+    check(name, String);
+
+    this.name = name;
+  }
+
+  define({ validate, run }: {
+    validate: TypedMethodValidator<Args>,
+    run: TypedMethodRun<Args, Return>,
+  }) {
+    if (this.definition) {
+      throw new Error(`TypedMethod ${this.name} has already been defined`);
+    }
+
+    this.definition = { validate, run };
+
+    /* eslint-disable-next-line @typescript-eslint/no-this-alias -- we need to
+       capture both the TypedMethod object (so we can find the implementation)
+       and the method invocation context (for things like userId) */
+    const self = this;
+    Meteor.methods({
+      /* eslint-disable-next-line meteor/audit-argument-checks -- because we're
+        wrapping the method call, the eslint check can't tell what's going on,
+        but the actual Meteor audit-argument-checks package will still fire if
+        we don't use check methods. */
+      [this.name](arg0: Args) {
+        self.execute(this, arg0);
+      },
+    });
+  }
+
+  execute(context: Meteor.MethodThisType, arg0: Args): Return {
+    if (!this.definition) {
+      throw new Error(`TypedMethod ${this.name} has not been defined`);
+    }
+
+    const validatedArgs = this.definition.validate.bind(context)(arg0);
+    const result = this.definition.run.bind(context)(validatedArgs);
+    return result;
+  }
+
+  call(
+    arg0: Args,
+    callback?: (error: Meteor.Error, result: Return) => void,
+  ): void {
+    return Meteor.call(this.name, arg0, callback);
+  }
+
+  callPromise(arg0: Args): Promise<Return> {
+    return Meteor.callPromise(this.name, arg0);
+  }
+}

--- a/imports/methods/postAnnouncement.ts
+++ b/imports/methods/postAnnouncement.ts
@@ -1,0 +1,5 @@
+import TypedMethod from './TypedMethod';
+
+export default new TypedMethod<{ huntId: string, message: string }, void>(
+  'Announcements.methods.post'
+);

--- a/imports/server/announcements.ts
+++ b/imports/server/announcements.ts
@@ -1,37 +1,11 @@
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
-import Ansible from '../Ansible';
 import Announcements from '../lib/models/Announcements';
 import MeteorUsers from '../lib/models/MeteorUsers';
 import PendingAnnouncements from '../lib/models/PendingAnnouncements';
-import { userMayAddAnnouncementToHunt } from '../lib/permission_stubs';
 import JoinPublisher from './JoinPublisher';
 
 Meteor.methods({
-  postAnnouncement(huntId: unknown, message: unknown) {
-    check(this.userId, String);
-    check(huntId, String);
-    check(message, String);
-
-    if (!userMayAddAnnouncementToHunt(this.userId, huntId)) {
-      throw new Meteor.Error(401, `User ${this.userId} may not create annoucements for hunt ${huntId}`);
-    }
-
-    Ansible.log('Creating an announcement', { user: this.userId, hunt: huntId, message });
-    const id = Announcements.insert({
-      hunt: huntId,
-      message,
-    });
-
-    MeteorUsers.find({ hunts: huntId }).forEach((user) => {
-      PendingAnnouncements.insert({
-        hunt: huntId,
-        announcement: id,
-        user: user._id,
-      });
-    });
-  },
-
   dismissPendingAnnouncement(pendingAnnouncementId: unknown) {
     check(this.userId, String);
     check(pendingAnnouncementId, String);

--- a/imports/server/methods/postAnnouncement.ts
+++ b/imports/server/methods/postAnnouncement.ts
@@ -1,0 +1,40 @@
+import { check } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+import Ansible from '../../Ansible';
+import Announcements from '../../lib/models/Announcements';
+import MeteorUsers from '../../lib/models/MeteorUsers';
+import PendingAnnouncements from '../../lib/models/PendingAnnouncements';
+import { userMayAddAnnouncementToHunt } from '../../lib/permission_stubs';
+import postAnnouncement from '../../methods/postAnnouncement';
+
+postAnnouncement.define({
+  validate(arg: unknown) {
+    check(this.userId, String);
+    check(arg, {
+      huntId: String,
+      message: String,
+    });
+
+    return arg;
+  },
+
+  run({ huntId, message }) {
+    if (!userMayAddAnnouncementToHunt(this.userId, huntId)) {
+      throw new Meteor.Error(401, `User ${this.userId} may not create announcements for hunt ${huntId}`);
+    }
+
+    Ansible.log('Creating an announcement', { user: this.userId, hunt: huntId, message });
+    const id = Announcements.insert({
+      hunt: huntId,
+      message,
+    });
+
+    MeteorUsers.find({ hunts: huntId }).forEach((user) => {
+      PendingAnnouncements.insert({
+        hunt: huntId,
+        announcement: id,
+        user: user._id,
+      });
+    });
+  },
+});

--- a/server/main.ts
+++ b/server/main.ts
@@ -5,6 +5,9 @@ import '../imports/lib/config/accounts';
 // Register migrations
 import '../imports/server/migrations/all';
 
+// Import methods
+import '../imports/server/methods/postAnnouncement';
+
 // Other stuff in the server folder
 import '../imports/server/accounts';
 import '../imports/server/announcements';


### PR DESCRIPTION
@zarvox I'm curious if you think this is a good idea. If so I'll work on converting the rest of our methods.

mdg:validated-method gives us a handful of affordances that are missing in our current method declaration setup, and I think they're probably worth adopting. Most useful for us is that methods can be invoked as functions with named arguments and types on arguments and return values instead of as strings with unknown positional arguments.

There are some drawbacks - we lose some typechecker-enforced assurances about argument validation. Our previous house style declared the types of all method arguments as `unknown` and relied on `check` functions to make type assertions. There's no similar construct here - we can still declare the arguments to `validate` as type `unknown`, and we can rely on `audit-argument-checks` to make sure we're not using parameters without some form of validation, but nothing connects the `check` functions we call in `validate` against the types we declare in `run`, so it's possible we could get the types wrong.

(We could call our `check`s in the `run` function, but then the declared type when calling the function would be `unknown`, and I think that's worse.)

In practice I think the overall utility is high enough to be worth that risk.