### PR TITLE
Allow dependabot to open more pending PRs at once

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 20
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
By default, Dependabot will only open a maximum of 5 simultaneous PRs, but given
how quickly the node ecosystem moves, it's often the case that updates are
stalled behind others, so let's try and unblock the flow a little.