### PR TITLE
Keep previous `answers` value on Puzzles update

### DIFF
--- a/imports/lib/schemas/Puzzle.ts
+++ b/imports/lib/schemas/Puzzle.ts
@@ -36,7 +36,7 @@ const PuzzleFieldsOverrides: Overrides<t.TypeOf<typeof PuzzleFields>> = {
         return this.value.map((x) => answerify(x));
       }
 
-      return [];
+      return undefined;
     },
   },
   replacedBy: {


### PR DESCRIPTION
c3ffbee79cc53ea2eb184a8f99c76e0cc4ffa4af seems to have introduced a
regression in which every subsequent update to a `Puzzle` that does not
specify an explicit value for `answers` winds up causing `answers` to
be set to `[]`, stripping the denormalized answer values, which leads
PuzzleListPage to render it as unsolved (since PuzzleListPage relies on
the denormed `answers` rather than `Guess`es.

The real purpose of this `autoValue` implementation is to uppercase all
the answers.  We do not rely on it to backfill `answers: []` in the
event a caller did not provide that key.  To that end, we should return
`undefined` rather than `[]` from our `autoValue` implementation.

We can also take this opportunity to remove the support for converting a
single string value into an array.  Migrations 20 and 21 have backfilled
arrays in all extent databases, so we can make the behavior tighter,
throwing at runtime if code uses the interface incorrectly rather than
silently changing data shape.

Doing so reveals that the `AutoValueFlatten` from `typedSchemas` appears
to no longer be needed, and produces issues around the type of the
`this` argument passed to the `autoValue` function if we want to have
`answers` be treated always as an array of strings rather than possibly
a single string value.  So this patch simply removes AutoValueFlatten,
both on the argument and the return value side of our `autoValue` type
signature.

Fixes #943.