### PR TITLE
Drop the gain node for mute/unmute

### DIFF
--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -102,11 +102,11 @@ const JoiningCall = ({ details }: { details?: string }) => {
 type ProducerCallback = ({ id }: { id: string }) => void;
 
 const ProducerManager = ({
-  muted,
+  paused,
   track,
   transport,
 }: {
-  muted: boolean;
+  paused: boolean;
   track: MediaStreamTrack;
   transport: types.Transport;
 }) => {
@@ -126,14 +126,18 @@ const ProducerManager = ({
   const producerServerCallback = useRef<ProducerCallback>();
 
   useEffect(() => {
-    if (producer && muted !== producer.paused) {
-      producer[muted ? 'pause' : 'resume']();
+    if (producer && paused !== producer.paused) {
+      if (paused) {
+        producer.pause();
+      } else {
+        producer.resume();
+      }
       mediasoupSetProducerPaused.call({
         mediasoupProducerId: producer.id,
-        paused: muted,
+        paused,
       });
     }
-  }, [muted, producer]);
+  }, [paused, producer]);
 
   const onProduce = useCallback((
     { kind, rtpParameters, appData }: {
@@ -270,7 +274,7 @@ const ProducerBox = ({
         {tracks.map((track) => (
           <ProducerManager
             key={track.id}
-            muted={muted}
+            paused={muted || deafened}
             track={track}
             transport={transport}
           />


### PR DESCRIPTION
> Given mediasoup-client's native support for pausing/unpausing the producer, I think this is superfluous (and additionally, may be triggering bad behavior from Safari).
> 
> This addressed #603 in my testing.

FWIW, ^ was what I wrote in January when I pulled this commit together. I'm not sure why I didn't submit it for merging at the time, and I can no longer remember what I did to reproduce the issue "in my testing," or if I was even able to.

In any case, I think this change is worst-case harmless, as mediasoup-client _will_ stop sending data when a producer is paused (if you want to see how it threads through, [the `Producer` emits an event](https://github.com/versatica/mediasoup-client/blob/v3/src/Producer.ts#L329-L340) which [is caught by the transport](https://github.com/versatica/mediasoup-client/blob/v3/src/Transport.ts#L1134-L1141) which [replaces the track in the `RTCRtpSender`](https://github.com/versatica/mediasoup-client/blob/d510a4d3e8a76a67f4b6ef1a1287c1a308ee3c38/src/handlers/Chrome74.ts#L504-L509). That method [by spec accepts `null` and stops transmission](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack))

My intuition is to land this as it might help and even if it doesn't help cleans up the code a bit.