### PR TITLE
Better relative time helpers

### DIFF
--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -186,7 +186,6 @@ const ChatPeople = ({
     let interval: number | undefined;
     if (recentVoiceActivity) {
       const formatter = () => relativeTimeFormat(recentVoiceActivity, {
-        complete: false,
         minimumUnit: Meteor.isDevelopment ? 'second' : 'minute',
       });
       setVoiceActivityRelative(formatter());

--- a/imports/client/components/PuzzleActivity.tsx
+++ b/imports/client/components/PuzzleActivity.tsx
@@ -12,7 +12,7 @@ import Tooltip from 'react-bootstrap/Tooltip';
 import styled, { css } from 'styled-components';
 import { RECENT_ACTIVITY_TIME_WINDOW_MS } from '../../lib/config/webrtc';
 import CallHistories from '../../lib/models/mediasoup/CallHistories';
-import relativeTimeFormat, { terseRelativeTimeFormat } from '../../lib/relativeTimeFormat';
+import relativeTimeFormat from '../../lib/relativeTimeFormat';
 import { SubscriberCounters } from '../subscribers';
 import { mediaBreakpointDown } from './styling/responsive';
 
@@ -87,7 +87,7 @@ const PuzzleActivity = ({ huntId, puzzleId, unlockTime }: PuzzleActivityProps) =
       }
       return undefined;
     };
-    const unlockTimeFormatter = () => terseRelativeTimeFormat(unlockTime, { minimumUnit: 'minute', maxElements: 2 });
+    const unlockTimeFormatter = () => relativeTimeFormat(unlockTime, { terse: true, minimumUnit: 'minute', maxElements: 2 });
     setUnlockTimeRelative(unlockTimeFormatter());
     if (callLastActive) {
       setLastActiveRecent(Date.now() - callLastActive.getTime() < RECENTLY_ACTIVE_INTERVAL);

--- a/imports/client/components/RelativeTime.tsx
+++ b/imports/client/components/RelativeTime.tsx
@@ -1,0 +1,29 @@
+import { Meteor } from 'meteor/meteor';
+import React, { useEffect, useState } from 'react';
+import { complete, RelativeTimeFormatOpts } from '../../lib/relativeTimeFormat';
+
+const RelativeTime = ({
+  date, minimumUnit, maxElements, terse, now,
+}: {
+  date: Date,
+} & RelativeTimeFormatOpts) => {
+  const [formatted, setFormatted] = useState(complete(date, {
+    minimumUnit, maxElements, terse, now,
+  }));
+
+  useEffect(() => {
+    const timeout = Meteor.setTimeout(() => {
+      setFormatted(complete(date, {
+        minimumUnit, maxElements, terse, now,
+      }));
+    }, formatted.millisUntilChange);
+
+    return () => {
+      Meteor.clearTimeout(timeout);
+    };
+  }, [date, formatted.millisUntilChange, maxElements, minimumUnit, now, terse]);
+
+  return <span>{formatted.formatted}</span>;
+};
+
+export default RelativeTime;

--- a/imports/client/components/RelativeTime.tsx
+++ b/imports/client/components/RelativeTime.tsx
@@ -21,7 +21,18 @@ const RelativeTime = ({
     return () => {
       Meteor.clearTimeout(timeout);
     };
-  }, [date, formatted.millisUntilChange, maxElements, minimumUnit, now, terse]);
+  }, [
+    date,
+    formatted.millisUntilChange,
+    maxElements,
+    minimumUnit,
+    now,
+    terse,
+    // Note that we explicitly include formatted.formatted here so that we set a
+    // new timeout if the formatted string changes but (by change) the
+    // millisUntilChange does not.
+    formatted.formatted,
+  ]);
 
   return <span>{formatted.formatted}</span>;
 };

--- a/imports/lib/relativeTimeFormat.ts
+++ b/imports/lib/relativeTimeFormat.ts
@@ -50,13 +50,13 @@ export function terseRelativeTimeFormat(d: Date, opts: {
 }
 
 export default function relativeTimeFormat(d: Date, opts: {
-  complete?: boolean,
   minimumUnit?: 'second' | 'minute' | 'hour' | 'day' | 'year',
+  maxElements?: number,
   now?: Date,
 } = {}) {
   const {
-    complete = false,
     minimumUnit = 'seconds',
+    maxElements = 1,
     now = new Date(),
   } = opts;
   const diff = now.getTime() - d.getTime();
@@ -79,15 +79,14 @@ export default function relativeTimeFormat(d: Date, opts: {
     if (minimumUnit === singular) {
       stop = true;
     }
+    if (maxElements > 0 && terms.length >= maxElements) {
+      stop = true;
+    }
   });
 
   if (terms.length === 0) {
     return 'just now';
   }
 
-  if (complete) {
-    return `${terms.join(', ')}${relative}`;
-  }
-
-  return `${terms[0]}${relative}`;
+  return `${terms.join(', ')}${relative}`;
 }

--- a/tests/unit/imports/lib/relativeTimeFormat.ts
+++ b/tests/unit/imports/lib/relativeTimeFormat.ts
@@ -4,43 +4,43 @@ import relativeTimeFormat from '../../../../imports/lib/relativeTimeFormat';
 describe('relativeTimeFormat', function () {
   it('formats correctly with single item', function () {
     const now = new Date(Date.UTC(2022, 1, 10, 21, 55, 10));
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 9)), { complete: false, now }), '1 second ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 8)), { complete: false, now }), '2 seconds ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 11)), { complete: false, now }), '59 seconds ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 10)), { complete: false, now }), '1 minute ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 40)), { complete: false, now }), '1 minute ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 10)), { complete: false, now }), '2 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 11)), { complete: false, now }), '59 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 10)), { complete: false, now }), '1 hour ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 25, 10)), { complete: false, now }), '1 hour ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 19, 55, 10)), { complete: false, now }), '2 hours ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 9)), { now }), '1 second ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 8)), { now }), '2 seconds ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 11)), { now }), '59 seconds ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 10)), { now }), '1 minute ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 40)), { now }), '1 minute ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 10)), { now }), '2 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 11)), { now }), '59 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 10)), { now }), '1 hour ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 25, 10)), { now }), '1 hour ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 19, 55, 10)), { now }), '2 hours ago');
   });
 
   it('formats correctly with multiple items', function () {
     const now = new Date(Date.UTC(2022, 1, 10, 21, 55, 10));
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 9)), { complete: true, now }), '1 second ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 8)), { complete: true, now }), '2 seconds ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 11)), { complete: true, now }), '59 seconds ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 10)), { complete: true, now }), '1 minute ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 40)), { complete: true, now }), '1 minute, 30 seconds ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 10)), { complete: true, now }), '2 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 11)), { complete: true, now }), '59 minutes, 59 seconds ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 10)), { complete: true, now }), '1 hour ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 25, 10)), { complete: true, now }), '1 hour, 30 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 19, 55, 10)), { complete: true, now }), '2 hours ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 9)), { maxElements: -1, now }), '1 second ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 8)), { maxElements: -1, now }), '2 seconds ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 11)), { maxElements: -1, now }), '59 seconds ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 10)), { maxElements: -1, now }), '1 minute ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 40)), { maxElements: -1, now }), '1 minute, 30 seconds ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 10)), { maxElements: -1, now }), '2 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 11)), { maxElements: -1, now }), '59 minutes, 59 seconds ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 10)), { maxElements: -1, now }), '1 hour ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 25, 10)), { maxElements: -1, now }), '1 hour, 30 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 19, 55, 10)), { maxElements: -1, now }), '2 hours ago');
 
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2020, 7, 1, 18, 20, 40)), { complete: true, now }), '1 year, 193 days, 3 hours, 34 minutes, 30 seconds ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2020, 7, 1, 18, 20, 40)), { maxElements: -1, now }), '1 year, 193 days, 3 hours, 34 minutes, 30 seconds ago');
   });
 
   it('formats correctly with a minimum unit', function () {
     const now = new Date(Date.UTC(2022, 1, 10, 21, 55, 10));
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 40)), { complete: true, minimumUnit: 'minute', now }), '1 minute ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 10)), { complete: true, minimumUnit: 'minute', now }), '2 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 11)), { complete: true, minimumUnit: 'minute', now }), '59 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 10)), { complete: true, minimumUnit: 'minute', now }), '1 hour ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 25, 10)), { complete: true, minimumUnit: 'minute', now }), '1 hour, 30 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 19, 55, 10)), { complete: true, minimumUnit: 'minute', now }), '2 hours ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 40)), { maxElements: -1, minimumUnit: 'minute', now }), '1 minute ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 10)), { maxElements: -1, minimumUnit: 'minute', now }), '2 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 11)), { maxElements: -1, minimumUnit: 'minute', now }), '59 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 10)), { maxElements: -1, minimumUnit: 'minute', now }), '1 hour ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 25, 10)), { maxElements: -1, minimumUnit: 'minute', now }), '1 hour, 30 minutes ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 19, 55, 10)), { maxElements: -1, minimumUnit: 'minute', now }), '2 hours ago');
 
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2020, 7, 1, 18, 20, 40)), { complete: true, minimumUnit: 'day', now }), '1 year, 193 days ago');
+    assert.equal(relativeTimeFormat(new Date(Date.UTC(2020, 7, 1, 18, 20, 40)), { maxElements: -1, minimumUnit: 'day', now }), '1 year, 193 days ago');
   });
 });

--- a/tests/unit/imports/lib/relativeTimeFormat.ts
+++ b/tests/unit/imports/lib/relativeTimeFormat.ts
@@ -1,46 +1,56 @@
 import { assert } from 'chai';
-import relativeTimeFormat from '../../../../imports/lib/relativeTimeFormat';
+import { complete, RelativeTimeFormatOpts } from '../../../../imports/lib/relativeTimeFormat';
+
+const verifyFormat = (date: Date, now: Date, opts: Omit<RelativeTimeFormatOpts, 'now'>, expected: string) => {
+  const { formatted, millisUntilChange } = complete(date, { ...opts, now });
+  assert.equal(formatted, expected);
+  assert.notEqual(millisUntilChange, 0, 'millisUntilChange should never be zero');
+  const justBefore = new Date(now.getTime() + millisUntilChange - 1);
+  assert.equal(complete(date, { ...opts, now: justBefore }).formatted, expected);
+  const justAfter = new Date(now.getTime() + millisUntilChange);
+  assert.notEqual(complete(justAfter, { ...opts, now: justAfter }).formatted, expected);
+};
 
 describe('relativeTimeFormat', function () {
   it('formats correctly with single item', function () {
     const now = new Date(Date.UTC(2022, 1, 10, 21, 55, 10));
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 9)), { now }), '1 second ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 8)), { now }), '2 seconds ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 11)), { now }), '59 seconds ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 10)), { now }), '1 minute ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 40)), { now }), '1 minute ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 10)), { now }), '2 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 11)), { now }), '59 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 10)), { now }), '1 hour ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 25, 10)), { now }), '1 hour ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 19, 55, 10)), { now }), '2 hours ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 9)), now, {}, '1 second ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 8)), now, {}, '2 seconds ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 11)), now, {}, '59 seconds ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 10)), now, {}, '1 minute ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 40)), now, {}, '1 minute ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 10)), now, {}, '2 minutes ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 11)), now, {}, '59 minutes ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 10)), now, {}, '1 hour ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 20, 25, 10)), now, {}, '1 hour ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 19, 55, 10)), now, {}, '2 hours ago');
   });
 
   it('formats correctly with multiple items', function () {
     const now = new Date(Date.UTC(2022, 1, 10, 21, 55, 10));
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 9)), { maxElements: -1, now }), '1 second ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 8)), { maxElements: -1, now }), '2 seconds ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 11)), { maxElements: -1, now }), '59 seconds ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 10)), { maxElements: -1, now }), '1 minute ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 40)), { maxElements: -1, now }), '1 minute, 30 seconds ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 10)), { maxElements: -1, now }), '2 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 11)), { maxElements: -1, now }), '59 minutes, 59 seconds ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 10)), { maxElements: -1, now }), '1 hour ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 25, 10)), { maxElements: -1, now }), '1 hour, 30 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 19, 55, 10)), { maxElements: -1, now }), '2 hours ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 9)), now, { maxElements: -1 }, '1 second ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 55, 8)), now, { maxElements: -1 }, '2 seconds ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 11)), now, { maxElements: -1 }, '59 seconds ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 54, 10)), now, { maxElements: -1 }, '1 minute ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 40)), now, { maxElements: -1 }, '1 minute, 30 seconds ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 10)), now, { maxElements: -1 }, '2 minutes ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 11)), now, { maxElements: -1 }, '59 minutes, 59 seconds ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 10)), now, { maxElements: -1 }, '1 hour ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 20, 25, 10)), now, { maxElements: -1 }, '1 hour, 30 minutes ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 19, 55, 10)), now, { maxElements: -1 }, '2 hours ago');
 
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2020, 7, 1, 18, 20, 40)), { maxElements: -1, now }), '1 year, 193 days, 3 hours, 34 minutes, 30 seconds ago');
+    verifyFormat(new Date(Date.UTC(2020, 7, 1, 18, 20, 40)), now, { maxElements: -1 }, '1 year, 193 days, 3 hours, 34 minutes, 30 seconds ago');
   });
 
   it('formats correctly with a minimum unit', function () {
     const now = new Date(Date.UTC(2022, 1, 10, 21, 55, 10));
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 40)), { maxElements: -1, minimumUnit: 'minute', now }), '1 minute ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 10)), { maxElements: -1, minimumUnit: 'minute', now }), '2 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 11)), { maxElements: -1, minimumUnit: 'minute', now }), '59 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 10)), { maxElements: -1, minimumUnit: 'minute', now }), '1 hour ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 20, 25, 10)), { maxElements: -1, minimumUnit: 'minute', now }), '1 hour, 30 minutes ago');
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2022, 1, 10, 19, 55, 10)), { maxElements: -1, minimumUnit: 'minute', now }), '2 hours ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 40)), now, { maxElements: -1, minimumUnit: 'minute' }, '1 minute ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 21, 53, 10)), now, { maxElements: -1, minimumUnit: 'minute' }, '2 minutes ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 11)), now, { maxElements: -1, minimumUnit: 'minute' }, '59 minutes ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 20, 55, 10)), now, { maxElements: -1, minimumUnit: 'minute' }, '1 hour ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 20, 25, 10)), now, { maxElements: -1, minimumUnit: 'minute' }, '1 hour, 30 minutes ago');
+    verifyFormat(new Date(Date.UTC(2022, 1, 10, 19, 55, 10)), now, { maxElements: -1, minimumUnit: 'minute' }, '2 hours ago');
 
-    assert.equal(relativeTimeFormat(new Date(Date.UTC(2020, 7, 1, 18, 20, 40)), { maxElements: -1, minimumUnit: 'day', now }), '1 year, 193 days ago');
+    verifyFormat(new Date(Date.UTC(2020, 7, 1, 18, 20, 40)), now, { maxElements: -1, minimumUnit: 'day' }, '1 year, 193 days ago');
   });
 });


### PR DESCRIPTION
Was browsing through the code and remembered that I wanted to pull this together.

Previously `relativeTimeFormat` returned a static string, and any component that used it would need to set its own timers to re-render as it changed. Instead, this introduces a `RelativeTime` component which automatically re-renders whenever the output of `relativeTimeFormat` would change.

In order to support this, `relativeTimeFormat` now has a "complete" variant which additionally returns how long until the output would change (which is fairly easy to calculate, as we already have the "remainder" lying around). And to facilitate that change, I unified the "terse" and non-terse versions into a single method so that the logic could be shared. (Slightly confusing in the context of this PR, "complete" here is different than how we previously used that term with `relativeTimeFormat` - previously it indicated that the function would return a full breakdown across all sub-units of time. But once this is merged that shouldn't be a source of confusion going forward).

Since the code manipulations felt a little fiddly, I intentionally broke this into pretty fine-grained commits, which is likely the easiest way to review this.