### PR TITLE
Remove `needs:*` tags when puzzle fully solved

### DIFF
--- a/imports/server/GlobalHooks.ts
+++ b/imports/server/GlobalHooks.ts
@@ -1,11 +1,13 @@
 import DingwordHooks from './hooks/DingwordHooks';
 import DiscordHooks from './hooks/DiscordHooks';
 import HooksRegistry from './hooks/HooksRegistry';
+import TagCleanupHooks from './hooks/TagCleanupHooks';
 
 // Instantiate the application-global hookset list.
 const GlobalHooks = new HooksRegistry();
 // Add all hooksets.
 GlobalHooks.addHookSet(DiscordHooks);
 GlobalHooks.addHookSet(DingwordHooks);
+GlobalHooks.addHookSet(TagCleanupHooks);
 
 export default GlobalHooks;

--- a/imports/server/hooks/TagCleanupHooks.ts
+++ b/imports/server/hooks/TagCleanupHooks.ts
@@ -1,0 +1,27 @@
+import Puzzles from '../../lib/models/Puzzles';
+import Tags from '../../lib/models/Tags';
+import Hookset from './Hookset';
+
+const TagCleanupHooks: Hookset = {
+  onPuzzleSolved(puzzleId: string) {
+    const puzzle = Puzzles.findOne(puzzleId);
+    if (!puzzle) return;
+
+    // If a puzzle is now fully solved, remove any `needs:*` tags from it.
+    if (puzzle.answers.length >= puzzle.expectedAnswerCount) {
+      const tags = Tags.find({ _id: { $in: puzzle.tags } }).fetch();
+
+      const needsTags = tags.filter((tag) => tag.name.startsWith('needs:'));
+      const needsTagsIds = needsTags.map((tag) => tag._id);
+      Puzzles.update({
+        _id: puzzleId,
+      }, {
+        $pullAll: {
+          tags: needsTagsIds,
+        },
+      });
+    }
+  },
+};
+
+export default TagCleanupHooks;


### PR DESCRIPTION
Once a puzzle is solved, it is very unlikely that `needs:` tags are
still relevant.  We can remove them automatically once the puzzle has as
many answers as `expectedAnswerCount`.

Fixes #608.