### PR TITLE
Fix `updatePuzzle` callers

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -123,7 +123,7 @@
     "@typescript-eslint/no-unsafe-return": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/restrict-template-expressions": "off",
-    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
     "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/prefer-namespace-keyword": ["off"],
 

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -137,7 +137,8 @@ const Puzzle = React.memo(({
     callback: (error?: Error) => void
   ) => {
     Ansible.log('Updating puzzle properties', { puzzle: puzzle._id, user: Meteor.userId(), state });
-    updatePuzzle.call({ puzzleId: puzzle._id, ...state }, callback);
+    const { huntId: _huntId, ...rest } = state;
+    updatePuzzle.call({ puzzleId: puzzle._id, ...rest }, callback);
   }, [puzzle._id]);
 
   const onShowEditModal = useCallback(() => {

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -668,7 +668,8 @@ const PuzzlePageMetadata = ({
     callback: (err?: Error) => void
   ) => {
     Ansible.log('Updating puzzle properties', { puzzle: puzzleId, user: Meteor.userId(), state });
-    updatePuzzle.call({ puzzleId, ...state }, callback);
+    const { huntId: _huntId, ...rest } = state;
+    updatePuzzle.call({ puzzleId, ...rest }, callback);
   }, [puzzleId]);
 
   const showGuessModal = useCallback(() => {


### PR DESCRIPTION
Without this patch, attempting to update a puzzle from the puzzle edit
modal (either on the PuzzlePage or the PuzzleListPage) results in a 400
error.

These callsites were incorrectly passing the additional argument
`huntId`, which is included in `PuzzleModalFormSubmitPayload` but not
accepted by the `updatePuzzle` method.

It is not clear to me why the typechecker didn't complain about passing
an incompatible type here, but maybe that's because in a structural
types world the extra key is permitted.