### PR TITLE
Use ValidateShape for TypedMethod calls

### DIFF
--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -137,7 +137,7 @@ const Puzzle = React.memo(({
     callback: (error?: Error) => void
   ) => {
     Ansible.log('Updating puzzle properties', { puzzle: puzzle._id, user: Meteor.userId(), state });
-    const { huntId: _huntId, ...rest } = state;
+    const { huntId: _huntId, docType: _docType, ...rest } = state;
     updatePuzzle.call({ puzzleId: puzzle._id, ...rest }, callback);
   }, [puzzle._id]);
 

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -668,7 +668,7 @@ const PuzzlePageMetadata = ({
     callback: (err?: Error) => void
   ) => {
     Ansible.log('Updating puzzle properties', { puzzle: puzzleId, user: Meteor.userId(), state });
-    const { huntId: _huntId, ...rest } = state;
+    const { huntId: _huntId, docType: _docType, ...rest } = state;
     updatePuzzle.call({ puzzleId, ...rest }, callback);
   }, [puzzleId]);
 

--- a/imports/lib/ValidateShape.ts
+++ b/imports/lib/ValidateShape.ts
@@ -1,0 +1,4 @@
+type ValidateShape<T, Shape> =
+  Shape & { [K in keyof T]: K extends keyof Shape ? T[K] : never };
+
+export default ValidateShape;

--- a/imports/methods/TypedMethod.ts
+++ b/imports/methods/TypedMethod.ts
@@ -1,6 +1,7 @@
 import { check } from 'meteor/check';
 import { EJSONable, EJSONableProperty } from 'meteor/ejson';
 import { Meteor } from 'meteor/meteor';
+import ValidateShape from '../lib/ValidateShape';
 
 type TypedMethodParam = EJSONable | EJSONableProperty;
 type TypedMethodArgs = Record<string, TypedMethodParam> | void;
@@ -18,14 +19,14 @@ type TypedMethodCallback<Return extends TypedMethodParam | void> =
       error: Error extends true ? Meteor.Error : undefined,
       result: Error extends false ? Return : undefined,
     ) => void;
-type TypedMethodCallArgs<Arg extends TypedMethodArgs, Return extends TypedMethodParam | void> =
+type TypedMethodCallArgs<T, Arg extends TypedMethodArgs, Return extends TypedMethodParam | void> =
   Arg extends void ?
     ([TypedMethodCallback<Return>] | []) :
-    ([Arg, TypedMethodCallback<Return>] | [Arg]);
-type TypedMethodCallPromiseArgs<Arg extends TypedMethodArgs> =
+    ([ValidateShape<T, Arg>, TypedMethodCallback<Return>] | [Arg]);
+type TypedMethodCallPromiseArgs<T, Arg extends TypedMethodArgs> =
   Arg extends void ?
     [] :
-    [Arg];
+    [ValidateShape<T, Arg>];
 
 const voidValidator = () => { /* noop */ };
 
@@ -101,11 +102,11 @@ export default class TypedMethod<
     return result;
   }
 
-  call(...args: TypedMethodCallArgs<Args, Return>): void {
+  call<T>(...args: TypedMethodCallArgs<T, Args, Return>): void {
     return Meteor.call(this.name, ...args);
   }
 
-  callPromise(...args: TypedMethodCallPromiseArgs<Args>): Promise<Return> {
+  callPromise<T>(...args: TypedMethodCallPromiseArgs<T, Args>): Promise<Return> {
     return Meteor.callPromise(this.name, ...args);
   }
 }

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -4,6 +4,7 @@ import { Meteor } from 'meteor/meteor';
 import './unit/imports/lib/calendarTimeFormat';
 import './unit/imports/lib/puzzle-sort-and-group';
 import './unit/imports/lib/relativeTimeFormat';
+import './unit/imports/lib/ValidateShape';
 
 if (Meteor.isServer) {
   require('./unit/imports/server/MigrationRegistry');

--- a/tests/unit/imports/lib/ValidateShape.ts
+++ b/tests/unit/imports/lib/ValidateShape.ts
@@ -1,0 +1,37 @@
+import ValidateShape from '../../../../imports/lib/ValidateShape';
+
+function validatedCall<T>(_arg: ValidateShape<T, {
+  a: number;
+  b: number;
+  c?: number;
+}>): void {
+  /* dummy function for type checking */
+}
+
+describe('ValidateShape', () => {
+  it('rejects extra parameters', () => {
+    const arg = {
+      a: 1, b: 2, c: 3, d: 4,
+    };
+    // @ts-expect-error extra parameter
+    validatedCall(arg);
+    const arg2 = {
+      a: 1, b: 2, d: 3,
+    };
+    // @ts-expect-error extra parameter
+    validatedCall(arg2);
+  });
+
+  it('rejects missing parameters', () => {
+    const arg = { a: 1 };
+    // @ts-expect-error missing parameter
+    validatedCall(arg);
+  });
+
+  it('accepts valid parameters', () => {
+    const arg = { a: 1, b: 2 };
+    validatedCall(arg);
+    const arg2 = { a: 1, b: 2, c: 3 };
+    validatedCall(arg2);
+  });
+});


### PR DESCRIPTION
Since we generally require exact object matching when validating
TypedMethod arguments, we don't want to accidentally accept extra fields
in the argument type. By using ValidateShape, we can catch this at the
type level.