### PR TITLE
Install and configure zodern:types

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -38,3 +38,4 @@ deanius:promise
 hot-module-replacement@0.5.1
 zodern:standard-minifier-js
 fetch@0.1.1
+zodern:types

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -93,3 +93,4 @@ xolvio:cleaner@0.4.0
 zodern:caching-minifier@0.4.0
 zodern:minifier-js@4.1.0
 zodern:standard-minifier-js@4.1.1
+zodern:types@1.0.9

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:types": "tsc --noEmit",
     "lint:js": "eslint --format gha --ext js,jsx,ts,tsx .",
     "lint:css": "stylelint '**/*.tsx'",
-    "lint": "npm-run-all --parallel lint:*",
+    "lint": "meteor lint && npm-run-all --parallel lint:*",
     "test": "TEST_BROWSER_DRIVER=puppeteer meteor test --full-app --once --driver-package meteortesting:mocha"
   },
   "dependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,10 +26,17 @@
     "resolveJsonModule": true,
     "types": ["node", "mocha"],
     "esModuleInterop": true,
-    "preserveSymlinks": true
+    "preserveSymlinks": true,
+    "paths": {
+      "meteor/*": [
+        "node_modules/@types/meteor/*",
+        ".meteor/local/types/packages.d.ts"
+      ]
+    }
   },
   "exclude": [
-    "./.meteor/**",
+    "./.meteor/local/build/**",
+    "./.meteor/local/bundler-cache/**",
     "./packages/**"
   ]
 }


### PR DESCRIPTION
This package is designed to allow for Meteor packages to ship their own types. At this point, I don't think there are any packages that use it, so it's effectively a noop change, but in theory it might see adoption in the future, which would allow us to reduce our dependence on adding our own ambient type declarations for Meteor libraries.