### PR TITLE
Remove an old gitignore file

### DIFF
--- a/cloudformation/.gitignore
+++ b/cloudformation/.gitignore
@@ -1,1 +1,0 @@
-jolly-roger.json


### PR DESCRIPTION
This dates from before CloudFormation natively supported YAML and should
have been removed as part of 762ad183d09fb6a1284fe79c3829b124edf0f05b.