### PR TITLE
Update to React 18 and enable StrictMode

### DIFF
--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -238,9 +238,11 @@ const GuessMessage = React.memo(({
         <StyledNotificationActionBar>
           <StyledNotificationActionItem>
             <OverlayTrigger placement="top" overlay={copyTooltip}>
-              <CopyToClipboard text={guess.guess}>
-                <button type="button" aria-label="Copy"><FontAwesomeIcon icon={faCopy} /></button>
-              </CopyToClipboard>
+              {({ ref, ...triggerHandler }) => (
+                <CopyToClipboard text={guess.guess} {...triggerHandler}>
+                  <button ref={ref} type="button" aria-label="Copy"><FontAwesomeIcon icon={faCopy} /></button>
+                </CopyToClipboard>
+              )}
             </OverlayTrigger>
           </StyledNotificationActionItem>
           <StyledNotificationActionItem>

--- a/imports/client/hooks/breadcrumb.tsx
+++ b/imports/client/hooks/breadcrumb.tsx
@@ -3,7 +3,6 @@ import { Random } from 'meteor/random';
 import React, {
   useCallback, useContext, useEffect, useMemo, useRef, useState,
 } from 'react';
-import useImmediateEffect from './useImmediateEffect';
 
 type Crumb = {
   path: string;
@@ -23,18 +22,16 @@ type BreadcrumbSubscribeHandle = {
 type BreadcrumbSubscribeCallback = (crumbs: CrumbWithId[]) => void;
 
 type BreadcrumbContextType = {
-  addCrumb: (crumb: Crumb) => CrumbId;
+  addCrumb: (path: string, title: string) => CrumbId;
   removeCrumb: (crumbId: CrumbId) => void;
-  updateCrumb: (crumbId: CrumbId, crumb: Crumb) => void;
-  flushUpdates: () => void;
+  updateCrumb: (crumbId: CrumbId, path: string, title: string) => void;
   subscribe: (listener: BreadcrumbSubscribeCallback) => BreadcrumbSubscribeHandle;
 }
 
 const defaultCallbacks: BreadcrumbContextType = {
-  addCrumb: (_crumb: Crumb) => { return Random.id(); },
+  addCrumb: (_path: string, _title: string) => { return Random.id(); },
   removeCrumb: (_crumbId: CrumbId) => { /* noop */ },
-  updateCrumb: (_crumbId: CrumbId, _crumb: Crumb) => { /* noop */ },
-  flushUpdates: () => { /* noop */ },
+  updateCrumb: (_crumbId: CrumbId, _path: string, _title: string) => { /* noop */ },
   subscribe: (_listener: BreadcrumbSubscribeCallback) => {
     return {
       unsubscribe() {
@@ -46,32 +43,26 @@ const defaultCallbacks: BreadcrumbContextType = {
 
 const BreadcrumbContext = React.createContext<BreadcrumbContextType>(defaultCallbacks);
 
+const byPathLength = (c1: CrumbWithId, c2: CrumbWithId) => {
+  return c1.path.length - c2.path.length;
+};
+
 const BreadcrumbsProvider = ({ children }: { children: React.ReactNode }) => {
   const crumbsRef = useRef<CrumbWithId[]>([]);
   const listenersRef = useRef<((crumbs: CrumbWithId[]) => void)[]>([]);
 
-  const flushUpdates = useCallback(() => {
-    listenersRef.current.forEach((listener) => listener(crumbsRef.current));
-  }, []);
-
-  const addCrumb = useCallback((crumb: Crumb) => {
+  const addCrumb = useCallback((path: string, title: string) => {
     // Generate a new crumb ID, as this is a new crumb
     const crumbId = Random.id();
     const crumbWithId = {
       id: crumbId,
-      title: crumb.title,
-      path: crumb.path,
+      path,
+      title,
     };
-    // console.log(`added crumb ${crumbId} title: ${crumb.title} path: ${crumb.path}`);
+    // console.log(`added crumb ${crumbId} title: ${title} path: ${path}`);
     crumbsRef.current = [...crumbsRef.current, crumbWithId];
-
-    // We need to defer the breadcrumb update flushes until we're no longer
-    // rendering other components, since `addCrumb` gets called on initial
-    // render.  `useBreadcrumb` calls `addCrumb` immediately, and triggers a
-    // flush to run during effect time.  So we don't dispatch the listeners,
-    // and instead rely on the caller to call `flushUpdates()` later, once we're
-    // into the effects phase.
-
+    crumbsRef.current.sort(byPathLength);
+    listenersRef.current.forEach((listener) => listener(crumbsRef.current));
     return crumbId;
   }, []);
 
@@ -87,25 +78,26 @@ const BreadcrumbsProvider = ({ children }: { children: React.ReactNode }) => {
     const beforeRemoved = prevCrumbs.slice(0, crumbIndex);
     const afterRemoved = prevCrumbs.slice(crumbIndex + 1, prevCrumbs.length);
     crumbsRef.current = beforeRemoved.concat(afterRemoved);
-    // removeCrumb runs in the useEffect cleanup phase, so it's safe to dispatch listeners
+    crumbsRef.current.sort(byPathLength);
     listenersRef.current.forEach((listener) => listener(crumbsRef.current));
   }, []);
 
-  const updateCrumb = useCallback((crumbId: CrumbId, crumb: Crumb) => {
-    // console.log(`updating crumb ${crumbId} to title: ${crumb.title} path: ${crumb.path}`);
+  const updateCrumb = useCallback((crumbId: CrumbId, path: string, title: string) => {
+    // console.log(`updating crumb ${crumbId} to title: ${title} path: ${path}`);
     const prevCrumbs = crumbsRef.current;
     const crumbIndex = prevCrumbs.findIndex((c) => c.id === crumbId);
     const newCrumbWithId = {
       id: crumbId,
-      title: crumb.title,
-      path: crumb.path,
+      path,
+      title,
     };
 
     const beforeUpdated = prevCrumbs.slice(0, crumbIndex);
     const afterUpdated = prevCrumbs.slice(crumbIndex + 1, prevCrumbs.length);
     crumbsRef.current = beforeUpdated.concat([newCrumbWithId]).concat(afterUpdated);
+    crumbsRef.current.sort(byPathLength);
 
-    // updateCrumb is run from an effect phase, so we can immediately dispatch listeners.
+    // console.log(`updating ${listenersRef.current.length} subscribers`);
     listenersRef.current.forEach((listener) => listener(crumbsRef.current));
   }, []);
 
@@ -125,9 +117,8 @@ const BreadcrumbsProvider = ({ children }: { children: React.ReactNode }) => {
     addCrumb,
     removeCrumb,
     updateCrumb,
-    flushUpdates,
     subscribe,
-  }), [addCrumb, removeCrumb, updateCrumb, flushUpdates, subscribe]);
+  }), [addCrumb, removeCrumb, updateCrumb, subscribe]);
 
   return (
     <BreadcrumbContext.Provider value={providerCallbacks}>
@@ -137,60 +128,46 @@ const BreadcrumbsProvider = ({ children }: { children: React.ReactNode }) => {
 };
 
 function useBreadcrumb(crumb: Crumb): void {
+  // console.log("useBreadcrumb(", crumb, ")");
   const ctx = useContext<BreadcrumbContextType>(BreadcrumbContext);
   const crumbId = useRef<string | null>(null);
-  const firstRender = useRef<boolean>(true);
 
   const {
-    addCrumb, removeCrumb, updateCrumb, flushUpdates,
+    addCrumb, removeCrumb, updateCrumb,
   } = ctx;
 
-  useImmediateEffect(() => {
-    crumbId.current = addCrumb(crumb);
-    // console.log(`mount ${crumbId.current}`);
+  useEffect(() => {
+    if (crumbId.current === null) {
+      crumbId.current = addCrumb(crumb.path, crumb.title);
+    } else {
+      updateCrumb(crumbId.current, crumb.path, crumb.title);
+    }
+  }, [addCrumb, updateCrumb, crumb.path, crumb.title]);
 
+  useEffect(() => {
     return () => {
       if (crumbId.current) {
-        // console.log(`unmount ${crumbId.current}`);
         removeCrumb(crumbId.current);
         crumbId.current = null;
       }
     };
-  }, []);
-
-  useEffect(() => {
-    if (firstRender.current) {
-      firstRender.current = false;
-      // On first render, trigger a flush of the crumbs, since `addCrumb` has
-      // to run immediately (to preserve breadcrumb mount order), but the
-      // setState it will trigger can't run during the render phase.
-      flushUpdates();
-    }
-  }, [flushUpdates]);
-
-  useEffect(() => {
-    if (crumbId.current) {
-      // console.log(`update ${crumbId.current}`);
-      updateCrumb(crumbId.current, crumb);
-    }
-  }, [updateCrumb, crumb]);
+  }, [removeCrumb]);
 }
 
 const useBreadcrumbItems = () => {
   const subscriptionRef = useRef<BreadcrumbSubscribeHandle | undefined>(undefined);
   const [crumbs, setCrumbs] = useState<CrumbWithId[]>([]);
   const ctx = useContext(BreadcrumbContext);
-  useImmediateEffect(() => {
-    subscriptionRef.current = ctx.subscribe(setCrumbs);
-  }, []);
+  const { subscribe } = ctx;
 
   useEffect(() => {
+    subscriptionRef.current = subscribe(setCrumbs);
     return () => {
       if (subscriptionRef.current) {
         subscriptionRef.current.unsubscribe();
       }
     };
-  }, []);
+  }, [subscribe]);
 
   return crumbs;
 };

--- a/imports/client/main.tsx
+++ b/imports/client/main.tsx
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { createGlobalStyle } from 'styled-components';
 import Routes from './components/Routes';
@@ -28,15 +28,17 @@ Meteor.startup(() => {
   const container = document.createElement('div');
   container.className = 'jolly-roger';
   document.body.appendChild(container);
-  ReactDOM.render(
+  const root = createRoot(container);
+  root.render(
     <>
       <Reset />
       {!Meteor.isAppTest && (
-        <BrowserRouter>
-          <Routes />
-        </BrowserRouter>
+        <React.StrictMode>
+          <BrowserRouter>
+            <Routes />
+          </BrowserRouter>
+        </React.StrictMode>
       )}
-    </>,
-    container
+    </>
   );
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2001,9 +2001,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
-      "integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.17.1.tgz",
+      "integrity": "sha512-KnH2MnJUzmFNPW6RIKfd+zf2Wue8mEKX0M3cpX6aKl5ZXrJM1/c/Pc8c2xDNYQCnJO48Sm5ITbMXgqTr3h4jxQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -2053,25 +2053,14 @@
       }
     },
     "@testing-library/react": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz",
-      "integrity": "sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.3.0.tgz",
+      "integrity": "sha512-DB79aA426+deFgGSjnf5grczDPiL4taK3hFaa+M5q7q20Kcve9eQottOG5kZ74KEr55v0tU2CQormSSDK87zYQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "<18.0.0"
-      },
-      "dependencies": {
-        "@types/react-dom": {
-          "version": "17.0.15",
-          "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.15.tgz",
-          "integrity": "sha512-Tr9VU9DvNoHDWlmecmcsE5ZZiUkYx+nKBzum4Oxe1K0yJVyBlfbq7H3eXjxXqJczBKqPGq3EgfTru4MgKb9+Yw==",
-          "dev": true,
-          "requires": {
-            "@types/react": "^17"
-          }
-        }
+        "@testing-library/dom": "^8.5.0",
+        "@types/react-dom": "^18.0.0"
       }
     },
     "@types/aria-query": {
@@ -3724,9 +3713,9 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.13.tgz",
-      "integrity": "sha512-R305kwb5CcMDIpSHUnLyIAp7SrSPBx6F0VfQFB3M75xVMHhXJJIdePYgbPPh1o57vCHNu5QztokWUPsLjWzFqw==",
+      "version": "0.5.14",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
+      "integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
       "dev": true
     },
     "dom-helpers": {
@@ -6748,7 +6737,7 @@
     "lz-string": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
-      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
       "dev": true
     },
     "make-dir": {
@@ -8834,12 +8823,11 @@
       }
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-bootstrap": {
@@ -8931,13 +8919,12 @@
       }
     },
     "react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.0"
       }
     },
     "react-error-boundary": {
@@ -9317,12 +9304,11 @@
       }
     },
     "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "sdp-transform": {

--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "monocle-ts": "^2.3.13",
     "mustache": "^4.2.0",
     "newtype-ts": "^0.3.5",
-    "react": "^17.0.2",
+    "react": "^18.2.0",
     "react-bootstrap": "^2.5.0",
     "react-copy-to-clipboard": "^5.1.0",
-    "react-dom": "^17.0.2",
+    "react-dom": "^18.2.0",
     "react-error-boundary": "^3.1.4",
     "react-router-bootstrap": "^0.26.2",
     "react-router-dom": "^6.2.1",
@@ -60,7 +60,7 @@
     "use-persisted-state": "^0.3.3"
   },
   "devDependencies": {
-    "@testing-library/react": "^12.1.5",
+    "@testing-library/react": "^13.3.0",
     "@types/chai": "^4.3.4",
     "@types/dompurify": "^2.4.0",
     "@types/element-resize-detector": "^1.1.3",

--- a/tests/acceptance/authentication.tsx
+++ b/tests/acceptance/authentication.tsx
@@ -57,8 +57,8 @@ if (Meteor.isClient) {
       });
 
       it('redirects to the create-first-user page', async function () {
+        render(<TestApp />);
         await act(async () => {
-          render(<TestApp />);
           await stabilize();
         });
         assert.equal(location.current?.pathname, '/create-first-user');
@@ -72,8 +72,8 @@ if (Meteor.isClient) {
       });
 
       it('redirects to the login page', async function () {
+        render(<TestApp />);
         await act(async () => {
-          render(<TestApp />);
           await stabilize();
         });
         assert.equal(location.current?.pathname, '/login', 'redirects to login from root');
@@ -95,8 +95,8 @@ if (Meteor.isClient) {
       });
 
       it('redirects away from the login page', async function () {
+        render(<TestApp />);
         await act(async () => {
-          render(<TestApp />);
           await stabilize();
           (navigate.current!)('/login');
           await stabilize();
@@ -105,8 +105,8 @@ if (Meteor.isClient) {
       });
 
       it('does not redirect away from an authenticated page', async function () {
+        render(<TestApp />);
         await act(async () => {
-          render(<TestApp />);
           await stabilize();
           (navigate.current!)('/hunts');
           await stabilize();

--- a/tests/acceptance/smoke.tsx
+++ b/tests/acceptance/smoke.tsx
@@ -141,8 +141,8 @@ if (Meteor.isClient) {
             this.skip();
           }
 
+          render(<TestApp />);
           await act(async () => {
-            render(<TestApp />);
             await stabilize();
             navigate.current!(url);
             await stabilize();
@@ -163,8 +163,8 @@ if (Meteor.isClient) {
             this.skip();
           }
 
+          render(<TestApp />);
           await act(async () => {
-            render(<TestApp />);
             await stabilize();
             navigate.current!(url);
             await stabilize();


### PR DESCRIPTION
React 18 introduces a new root API which replaces `ReactDOM.render` as discussed in https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis .  Switching to the new root API enables concurrent mode.

Concurrent mode introduces some potentially surprising observable behaviors, which `<StrictMode>` is designed to help developers catch.  Most notably, in concurrent mode, React may call a render function, `setState()`, or reducer dispatch function multiple times during a single update cycle.  Code which relies on a 1-to-1 mapping between `render()` and effect calls will likely break, as will code which performs side-effects in `render()` or in a reducer (including within a `setState` function body).  More about what StrictMode does can be found at https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-strict-mode which I recommend reading.

Fortunately, the hairiest of our unsafe reliance on `render()` producing side effects got cleaned up in the call state rewrite from #1023.  The only remaining instance of odd behavior I was able to observe with StrictMode was in breadcrumbs, which...has always been a bit of a problem child, regardless of the implementation. 
 Since the original design that tries to keep track of the topological order of the breadcrumbs in the render tree seems just utterly hopeless, I gave up on that approach and switched to a strategy of sorting breadcrumbs by url path length, since our URLs get longer as they get more detailed and our breadcrumbs follow the same hierarchy as our URLs.

There were a couple other things that enabling `<StrictMode>` warned about, which were pretty straightforward to resolve:

* invalid DOM hierarchies (particularly: `<button>` as a child of another `<button>` all over the accordions on RTCDebugPage)
* use of findDOMNode in react-bootstrap, when `<OverlayTrigger>`'s immediate child is not a DOM node

Recommended review order:

* read the two React docs links from above to understand the implications of `<StrictMode>` and concurrent rendering going forward
* read this PR commit-by-commit