### PR TITLE
Allow overriding more env vars in run script

### DIFF
--- a/scripts/run_jolly_roger.sh
+++ b/scripts/run_jolly_roger.sh
@@ -4,14 +4,18 @@ set -e
 
 PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games"
 
-# We only have one proxy
-export HTTP_FORWARDED_COUNT=1
+if [ -z "${HTTP_FORWARDED_COUNT+set}" ]; then
+    # We generally expect to have one proxy
+    export HTTP_FORWARDED_COUNT=1
+fi
 
-# If we have less than 500M of memory, we don't have enough to run more than 1
-# worker
-MEMORY_KB="$(awk '$1=="MemTotal:" {print $2}' /proc/meminfo)"
-if [ "$MEMORY_KB" -gt 512000 ]; then
-    export CLUSTER_WORKERS_COUNT=auto
+if [ -z "${CLUSTER_WORKERS_COUNT+set}" ]; then
+    # If we have less than 500M of memory, we don't have enough to run more
+    # than 1 worker
+    MEMORY_KB="$(awk '$1=="MemTotal:" {print $2}' /proc/meminfo)"
+    if [ "$MEMORY_KB" -gt 512000 ]; then
+        export CLUSTER_WORKERS_COUNT=auto
+    fi
 fi
 
 if [ -z "${MONGO_URL+set}" ]; then


### PR DESCRIPTION
I have a VM that has too much RAM to not get opted into auto-clustering, but I also run mongo on it and it has too few resources to handle the write load of a bunch of backends, so I'd like to be able to explicitly opt out of auto-clustering via setting an environment variable on the docker instance.

I decided it was probably appropriate to allow a server operator to override the `HTTP_FORWARDED_COUNT` for their deployment too, so that's here as well.