### PR TITLE
Define our own Id, Email, and Url validation

### DIFF
--- a/imports/lib/schemas/Announcement.ts
+++ b/imports/lib/schemas/Announcement.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from './Base';
+import { Id } from './regexes';
 import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
 
 const AnnouncementFields = t.type({
@@ -10,7 +10,7 @@ const AnnouncementFields = t.type({
 
 const AnnouncementFieldsOverrides: Overrides<t.TypeOf<typeof AnnouncementFields>> = {
   hunt: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
 };
 

--- a/imports/lib/schemas/Base.ts
+++ b/imports/lib/schemas/Base.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
 import { date } from 'io-ts-types';
-import SimpleSchema from 'simpl-schema';
+import { Id } from './regexes';
 import { buildSchema, Overrides } from './typedSchemas';
 
 export const BaseCodec = t.type({
@@ -47,7 +47,7 @@ export const BaseOverrides: Overrides<BaseType> = {
     },
   },
   createdBy: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     autoValue() {
       if (this.isSet) {
         return undefined;
@@ -76,7 +76,7 @@ export const BaseOverrides: Overrides<BaseType> = {
     },
   },
   updatedBy: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyInsert: true,
     autoValue() {
       if (this.isSet) {

--- a/imports/lib/schemas/ChatMessage.ts
+++ b/imports/lib/schemas/ChatMessage.ts
@@ -1,7 +1,7 @@
 import * as t from 'io-ts';
 import { date } from 'io-ts-types';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from './Base';
+import { Id } from './regexes';
 import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
 
 const ChatMessageFields = t.type({
@@ -18,13 +18,13 @@ const ChatMessageFields = t.type({
 
 const ChatMessageFieldsOverrides: Overrides<t.TypeOf<typeof ChatMessageFields>> = {
   hunt: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   puzzle: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   sender: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
 };
 

--- a/imports/lib/schemas/ChatNotification.ts
+++ b/imports/lib/schemas/ChatNotification.ts
@@ -1,7 +1,7 @@
 import * as t from 'io-ts';
 import { date } from 'io-ts-types';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from './Base';
+import { Id } from './regexes';
 import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
 
 // A notification triggered by a chat message sent by a user.
@@ -25,16 +25,16 @@ const ChatNotificationFields = t.type({
 
 const ChatNotificationFieldsOverrides: Overrides<t.TypeOf<typeof ChatNotificationFields>> = {
   hunt: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   puzzle: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   user: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   sender: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
 };
 

--- a/imports/lib/schemas/Document.ts
+++ b/imports/lib/schemas/Document.ts
@@ -1,7 +1,7 @@
 /* eslint-disable filenames/match-exported */
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from './Base';
+import { Id } from './regexes';
 import { Overrides, inheritSchema, buildSchema } from './typedSchemas';
 
 // We can't represent tagged unions (or possible future tagged unions) in
@@ -39,10 +39,10 @@ const DocumentFields = t.type({
 
 const DocumentFieldsOverrides: Overrides<t.TypeOf<typeof DocumentFields>> = {
   hunt: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   puzzle: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
 };
 

--- a/imports/lib/schemas/FolderPermission.ts
+++ b/imports/lib/schemas/FolderPermission.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from './Base';
+import { Email, Id } from './regexes';
 import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
 
 const FolderPermissionFields = t.type({
@@ -12,10 +12,10 @@ const FolderPermissionFields = t.type({
 
 const FolderPermissionFieldsOverrides: Overrides<t.TypeOf<typeof FolderPermissionFields>> = {
   user: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   googleAccount: {
-    regEx: SimpleSchema.RegEx.Email,
+    regEx: Email,
   },
 };
 

--- a/imports/lib/schemas/Guess.ts
+++ b/imports/lib/schemas/Guess.ts
@@ -1,7 +1,7 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { answerify } from '../../model-helpers';
 import { BaseCodec, BaseOverrides } from './Base';
+import { Id } from './regexes';
 import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
 
 const GuessFields = t.type({
@@ -28,10 +28,10 @@ const GuessFields = t.type({
 
 const GuessFieldsOverrides: Overrides<t.TypeOf<typeof GuessFields>> = {
   hunt: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   puzzle: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   guess: {
     autoValue() {

--- a/imports/lib/schemas/Hunt.ts
+++ b/imports/lib/schemas/Hunt.ts
@@ -1,8 +1,8 @@
 import { Match } from 'meteor/check';
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from './Base';
 import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
+import { ValidUrl } from './validators';
 
 export const SavedDiscordObjectFields = t.type({
   id: t.string,
@@ -71,7 +71,7 @@ const HuntFieldsOverrides: Overrides<t.TypeOf<typeof HuntFields>> = {
     defaultValue: false,
   },
   homepageUrl: {
-    regEx: SimpleSchema.RegEx.Url,
+    custom: ValidUrl,
   },
 };
 

--- a/imports/lib/schemas/PendingAnnouncement.ts
+++ b/imports/lib/schemas/PendingAnnouncement.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from './Base';
+import { Id } from './regexes';
 import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
 
 const PendingAnnouncementFields = t.type({
@@ -11,13 +11,13 @@ const PendingAnnouncementFields = t.type({
 
 const PendingAnnouncementFieldsOverrides: Overrides<t.TypeOf<typeof PendingAnnouncementFields>> = {
   hunt: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   announcement: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   user: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
 };
 

--- a/imports/lib/schemas/Puzzle.ts
+++ b/imports/lib/schemas/Puzzle.ts
@@ -1,8 +1,9 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { answerify } from '../../model-helpers';
 import { BaseCodec, BaseOverrides } from './Base';
+import { Id } from './regexes';
 import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
+import { ValidUrl } from './validators';
 
 const PuzzleFields = t.type({
   hunt: t.string,
@@ -16,16 +17,16 @@ const PuzzleFields = t.type({
 
 const PuzzleFieldsOverrides: Overrides<t.TypeOf<typeof PuzzleFields>> = {
   hunt: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   tags: {
     defaultValue: [],
     array: {
-      regEx: SimpleSchema.RegEx.Id,
+      regEx: Id,
     },
   },
   url: {
-    regEx: SimpleSchema.RegEx.Url,
+    custom: ValidUrl,
   },
   answers: {
     autoValue() {
@@ -40,7 +41,7 @@ const PuzzleFieldsOverrides: Overrides<t.TypeOf<typeof PuzzleFields>> = {
     },
   },
   replacedBy: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
 };
 

--- a/imports/lib/schemas/Tag.ts
+++ b/imports/lib/schemas/Tag.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from './Base';
+import { Id } from './regexes';
 import { Overrides, buildSchema, inheritSchema } from './typedSchemas';
 
 const TagFields = t.type({
@@ -10,7 +10,7 @@ const TagFields = t.type({
 
 const TagFieldsOverrides: Overrides<t.TypeOf<typeof TagFields>> = {
   hunt: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
 };
 

--- a/imports/lib/schemas/User.ts
+++ b/imports/lib/schemas/User.ts
@@ -1,7 +1,7 @@
 import * as t from 'io-ts';
 import { date } from 'io-ts-types';
-import SimpleSchema from 'simpl-schema';
 import DiscordAccount from './DiscordAccount';
+import { Email, Id } from './regexes';
 import { Overrides, buildSchema } from './typedSchemas';
 
 declare module 'meteor/meteor' {
@@ -47,7 +47,7 @@ const UserOverrides: Overrides<t.TypeOf<typeof UserCodec>> = {
     array: {
       nested: {
         address: {
-          regEx: SimpleSchema.RegEx.Email,
+          regEx: Email,
         },
       },
     },
@@ -55,7 +55,7 @@ const UserOverrides: Overrides<t.TypeOf<typeof UserCodec>> = {
   hunts: {
     defaultValue: [],
     array: {
-      regEx: SimpleSchema.RegEx.Id,
+      regEx: Id,
     },
   },
 };

--- a/imports/lib/schemas/mediasoup/CallHistory.ts
+++ b/imports/lib/schemas/mediasoup/CallHistory.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
 import { date } from 'io-ts-types';
-import SimpleSchema from 'simpl-schema';
+import { Id } from '../regexes';
 import { Overrides, buildSchema } from '../typedSchemas';
 
 // Don't use the BaseCodec here - unlike most database objects, this isn't
@@ -14,10 +14,10 @@ const CallHistoryCodec = t.type({
 
 const CallHistoryOverrides: Overrides<t.TypeOf<typeof CallHistoryCodec>> = {
   hunt: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   call: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
 };
 

--- a/imports/lib/schemas/mediasoup/ConnectAck.ts
+++ b/imports/lib/schemas/mediasoup/ConnectAck.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from '../Base';
+import { Id } from '../regexes';
 import { Overrides, inheritSchema, buildSchema } from '../typedSchemas';
 
 const ConnectAckFields = t.type({
@@ -14,26 +14,26 @@ const ConnectAckFields = t.type({
 
 const ConnectAckFieldsOverrides: Overrides<t.TypeOf<typeof ConnectAckFields>> = {
   createdServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   call: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   peer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   transportRequest: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   direction: {
     denyUpdate: true,
   },
   transport: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
 };

--- a/imports/lib/schemas/mediasoup/ConnectRequest.ts
+++ b/imports/lib/schemas/mediasoup/ConnectRequest.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from '../Base';
+import { Id } from '../regexes';
 import { Overrides, inheritSchema, buildSchema } from '../typedSchemas';
 
 const ConnectRequestFields = t.type({
@@ -16,30 +16,30 @@ const ConnectRequestFields = t.type({
 
 const ConnectRequestFieldsOverrides: Overrides<t.TypeOf<typeof ConnectRequestFields>> = {
   createdServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   routedServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   call: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   peer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   transportRequest: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   direction: {
     denyUpdate: true,
   },
   transport: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   dtlsParameters: {

--- a/imports/lib/schemas/mediasoup/Consumer.ts
+++ b/imports/lib/schemas/mediasoup/Consumer.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from '../Base';
+import { Id } from '../regexes';
 import { Overrides, inheritSchema, buildSchema } from '../typedSchemas';
 
 const ConsumerFields = t.type({
@@ -19,19 +19,19 @@ const ConsumerFields = t.type({
 
 const ConsumerFieldsOverrides: Overrides<t.TypeOf<typeof ConsumerFields>> = {
   createdServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   call: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   peer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   transportRequest: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   transportId: {
@@ -40,7 +40,7 @@ const ConsumerFieldsOverrides: Overrides<t.TypeOf<typeof ConsumerFields>> = {
   },
 
   producerPeer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   consumerId: {

--- a/imports/lib/schemas/mediasoup/ConsumerAck.ts
+++ b/imports/lib/schemas/mediasoup/ConsumerAck.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from '../Base';
+import { Id } from '../regexes';
 import { Overrides, inheritSchema, buildSchema } from '../typedSchemas';
 
 const ConsumerAckFields = t.type({
@@ -15,27 +15,27 @@ const ConsumerAckFields = t.type({
 
 const ConsumerAckFieldsOverrides: Overrides<t.TypeOf<typeof ConsumerAckFields>> = {
   createdServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   routedServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   call: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   peer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   transportRequest: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   consumer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   producerId: {

--- a/imports/lib/schemas/mediasoup/Peer.ts
+++ b/imports/lib/schemas/mediasoup/Peer.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from '../Base';
+import { Id } from '../regexes';
 import { Overrides, inheritSchema, buildSchema } from '../typedSchemas';
 
 // Peer tracks room membership. When the first peer for a call is created,
@@ -16,19 +16,19 @@ const PeerFields = t.type({
 
 const PeerFieldsOverrides: Overrides<t.TypeOf<typeof PeerFields>> = {
   createdServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   hunt: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   call: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   tab: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
 };

--- a/imports/lib/schemas/mediasoup/ProducerClient.ts
+++ b/imports/lib/schemas/mediasoup/ProducerClient.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from '../Base';
+import { Id } from '../regexes';
 import { Overrides, inheritSchema, buildSchema } from '../typedSchemas';
 
 const ProducerClientFields = t.type({
@@ -19,27 +19,27 @@ const ProducerClientFields = t.type({
 
 const ProducerClientFieldsOverrides: Overrides<t.TypeOf<typeof ProducerClientFields>> = {
   createdServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   routedServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   call: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   peer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   transport: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   transportRequest: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   trackId: {

--- a/imports/lib/schemas/mediasoup/ProducerServer.ts
+++ b/imports/lib/schemas/mediasoup/ProducerServer.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from '../Base';
+import { Id } from '../regexes';
 import { Overrides, inheritSchema, buildSchema } from '../typedSchemas';
 
 const ProducerServerFields = t.type({
@@ -15,23 +15,23 @@ const ProducerServerFields = t.type({
 
 const ProducerServerFieldsOverrides: Overrides<t.TypeOf<typeof ProducerServerFields>> = {
   createdServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   call: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   peer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   transport: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   producerClient: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   trackId: {

--- a/imports/lib/schemas/mediasoup/Room.ts
+++ b/imports/lib/schemas/mediasoup/Room.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from '../Base';
+import { Id } from '../regexes';
 import { Overrides, inheritSchema, buildSchema } from '../typedSchemas';
 
 // Room tracks the server assignment for a room. Its presence triggers the
@@ -14,15 +14,15 @@ const RoomFields = t.type({
 
 const RoomFieldsOverrides: Overrides<t.TypeOf<typeof RoomFields>> = {
   hunt: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   call: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   routedServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
 };

--- a/imports/lib/schemas/mediasoup/Router.ts
+++ b/imports/lib/schemas/mediasoup/Router.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from '../Base';
+import { Id } from '../regexes';
 import { Overrides, buildSchema, inheritSchema } from '../typedSchemas';
 
 const RouterFields = t.type({
@@ -13,15 +13,15 @@ const RouterFields = t.type({
 
 const RouterFieldsOverrides: Overrides<t.TypeOf<typeof RouterFields>> = {
   hunt: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   call: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   createdServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   routerId: {

--- a/imports/lib/schemas/mediasoup/Transport.ts
+++ b/imports/lib/schemas/mediasoup/Transport.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from '../Base';
+import { Id } from '../regexes';
 import { Overrides, inheritSchema, buildSchema } from '../typedSchemas';
 
 const TransportFields = t.type({
@@ -20,19 +20,19 @@ const TransportFields = t.type({
 
 const TransportFieldsOverrides: Overrides<t.TypeOf<typeof TransportFields>> = {
   createdServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   call: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   peer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   transportRequest: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   direction: {

--- a/imports/lib/schemas/mediasoup/TransportRequest.ts
+++ b/imports/lib/schemas/mediasoup/TransportRequest.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from '../Base';
+import { Id } from '../regexes';
 import { Overrides, inheritSchema, buildSchema } from '../typedSchemas';
 
 const TransportRequestFields = t.type({
@@ -13,19 +13,19 @@ const TransportRequestFields = t.type({
 
 const TransportRequestFieldsOverrides: Overrides<t.TypeOf<typeof TransportRequestFields>> = {
   createdServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   routedServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   call: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   peer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
     denyUpdate: true,
   },
   rtpCapabilities: {

--- a/imports/lib/schemas/mediasoup/TransportState.ts
+++ b/imports/lib/schemas/mediasoup/TransportState.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from '../Base';
+import { Id } from '../regexes';
 import { Overrides, inheritSchema, buildSchema } from '../typedSchemas';
 
 // TransportState tracks the server-side state of a Transport object. None of
@@ -22,7 +22,7 @@ const TransportStateFields = t.type({
 // to think that prevents using them as the query term in an upsert
 const TransportStateFieldsOverrides: Overrides<t.TypeOf<typeof TransportStateFields>> = {
   createdServer: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   transportId: {
     regEx: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i,

--- a/imports/lib/schemas/regexes.ts
+++ b/imports/lib/schemas/regexes.ts
@@ -1,0 +1,6 @@
+// A Random.Id(), used by default as _id for Meteor collections
+export const Id = /^[23456789ABCDEFGHJKLMNPQRSTWXYZabcdefghijkmnopqrstuvwxyz]{17}$/;
+
+// An email address as described by
+// https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+export const Email = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;

--- a/imports/lib/schemas/typedSchemas.ts
+++ b/imports/lib/schemas/typedSchemas.ts
@@ -1,7 +1,7 @@
 import { Meteor } from 'meteor/meteor';
 import * as t from 'io-ts';
 import { date } from 'io-ts-types';
-import SimpleSchema, { SimpleSchemaDefinition } from 'simpl-schema';
+import SimpleSchema, { SchemaDefinition, SimpleSchemaDefinition } from 'simpl-schema';
 import { uint8Array } from './types';
 
 type NumberOverrides<T> = T extends number ? {
@@ -70,6 +70,7 @@ type AutoValueReturn<T> = undefined | T | AutoValueFlatten<T> | (T extends any[]
 type SharedOverrides<T> = {
   defaultValue?: NonNullable<T>;
   autoValue?: (this: AutoValueThis<T>) => AutoValueReturn<T>;
+  custom?: SchemaDefinition['custom'];
 
   // These fields are from collection2
   index?: boolean | 1 | -1;

--- a/imports/lib/schemas/validators.ts
+++ b/imports/lib/schemas/validators.ts
@@ -1,0 +1,15 @@
+import { SchemaDefinition } from 'simpl-schema';
+
+const ValidUrl: SchemaDefinition['custom'] = function () {
+  // Tests if a URL is valid by attempting to construct a URL object from it.
+  if (!this.isSet) return undefined;
+  try {
+    void (new URL(this.value));
+  } catch (err) {
+    return 'invalidUrl';
+  }
+  return undefined;
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { ValidUrl };

--- a/imports/server/schemas/APIKey.ts
+++ b/imports/server/schemas/APIKey.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
-import SimpleSchema from 'simpl-schema';
 import { BaseCodec, BaseOverrides } from '../../lib/schemas/Base';
+import { Id } from '../../lib/schemas/regexes';
 import { Overrides, buildSchema, inheritSchema } from '../../lib/schemas/typedSchemas';
 
 const APIKeyFields = t.type({
@@ -10,7 +10,7 @@ const APIKeyFields = t.type({
 
 const APIKeyFieldsOverrides: Overrides<t.TypeOf<typeof APIKeyFields>> = {
   user: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   key: {
     regEx: /^[A-Za-z0-9]{32}$/,

--- a/imports/server/schemas/Subscriber.ts
+++ b/imports/server/schemas/Subscriber.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
 import { date } from 'io-ts-types';
-import SimpleSchema from 'simpl-schema';
+import { Id } from '../../lib/schemas/regexes';
 import { Overrides, buildSchema } from '../../lib/schemas/typedSchemas';
 
 export const SubscriberCodec = t.type({
@@ -16,13 +16,13 @@ export type SubscriberType = t.TypeOf<typeof SubscriberCodec>;
 
 const SubscriberOverrides: Overrides<SubscriberType> = {
   server: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   connection: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   user: {
-    regEx: SimpleSchema.RegEx.Id,
+    regEx: Id,
   },
   createdAt: {
     autoValue() {


### PR DESCRIPTION
For a couple of reasons, `simpl-schema` upstream has removed their copy of these regexes in the latest version, which we'd like to be able to upgrade to.  To unblock taking that upgrade, instead of relying on `SimpleSchema.RegEx`, define our own equivalent regexes (for Id and Email) and a custom validator for Url that just attempts to construct a URL object (since that regex was vulnerable to regex DoS attacks).

Unblocks #1050.