### PR TITLE
Upgrade to TypeScript 4.8.4

### DIFF
--- a/imports/server/migrations/dropIndex.ts
+++ b/imports/server/migrations/dropIndex.ts
@@ -1,7 +1,11 @@
 import { Mongo } from 'meteor/mongo';
 import { Promise as MeteorPromise } from 'meteor/promise';
 
-function dropIndex<T>(
+interface Document {
+  [key: string]: any;
+}
+
+function dropIndex<T extends Document>(
   model: Mongo.Collection<T>,
   index: string
 ): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1966,22 +1966,6 @@
         "dequal": "^2.0.2"
       }
     },
-    "@restart/ui": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.3.1.tgz",
-      "integrity": "sha512-MYvMs2eeZTHu2dBJHOXKx72vxzEZeWbZx2z1QjeXq62iYjpjIyukBC2ZEy8x+sb9Gl0AiOiHkPXrl1wn95aOGQ==",
-      "requires": {
-        "@babel/runtime": "^7.18.3",
-        "@popperjs/core": "^2.11.5",
-        "@react-aria/ssr": "^3.2.0",
-        "@restart/hooks": "^0.4.7",
-        "@types/warning": "^3.0.0",
-        "dequal": "^2.0.2",
-        "dom-helpers": "^5.2.0",
-        "uncontrollable": "^7.2.1",
-        "warning": "^4.0.3"
-      }
-    },
     "@testing-library/dom": {
       "version": "8.13.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
@@ -8925,6 +8909,22 @@
         "warning": "^4.0.3"
       },
       "dependencies": {
+        "@restart/ui": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.4.0.tgz",
+          "integrity": "sha512-5dDj5uDzUgK1iijWPRg6AnxjkHM04XhTQDJirM1h/8tIc7KyLtF9YyjcCpNEn259hPMXswpkfXKNgiag0skPFg==",
+          "requires": {
+            "@babel/runtime": "^7.18.3",
+            "@popperjs/core": "^2.11.5",
+            "@react-aria/ssr": "^3.2.0",
+            "@restart/hooks": "^0.4.7",
+            "@types/warning": "^3.0.0",
+            "dequal": "^2.0.2",
+            "dom-helpers": "^5.2.0",
+            "uncontrollable": "^7.2.1",
+            "warning": "^4.0.3"
+          }
+        },
         "dom-helpers": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
@@ -10257,9 +10257,9 @@
       }
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-processor-styled-components": "^1.10.0",
     "stylelint-scss": "^4.1.0",
-    "typescript": "^4.7.4"
+    "typescript": "^4.8.4"
   },
   "meteor": {
     "mainModule": {


### PR DESCRIPTION
This requires two fixes to account for TypeScript 4.8 being stricter about generic functions. If you take a generic parameter and pass it to a generic function, your generic needs to be as strict as the declaration of the function.

For our `dropIndex` function, this is a semi-easy fix, although it's hard to get at the `Document` type in the upstream mongodb library without declaring an otherwise unnecessary dependency, so we just copy-paste it here (it's fairly simple).

For `@restart/ui`, we need to manually override `react-bootstrap`'s dependency for the time being, which is done by manually editing `package-lock.json` and then letting `npm` clean it up. (With NPM 8, this is natively supported, but Meteor isn't there yet.)