### PR TITLE
Remove all direct (and some indirect) uses of underscore

### DIFF
--- a/.meteor/packages
+++ b/.meteor/packages
@@ -30,7 +30,6 @@ fourseven:scss@4.15.0
 shell-server@0.5.0
 google-oauth@1.4.2
 dynamic-import@0.7.2
-underscore@1.0.10
 server-render@0.4.0
 typescript@4.5.4
 xolvio:cleaner

--- a/.meteor/packages
+++ b/.meteor/packages
@@ -32,7 +32,6 @@ google-oauth@1.4.2
 dynamic-import@0.7.2
 server-render@0.4.0
 typescript@4.5.4
-xolvio:cleaner
 hot-module-replacement@0.5.1
 zodern:standard-minifier-js
 fetch@0.1.1

--- a/.meteor/versions
+++ b/.meteor/versions
@@ -86,7 +86,6 @@ underscore@1.0.10
 url@1.3.2
 webapp@1.13.1
 webapp-hashing@1.1.0
-xolvio:cleaner@0.4.0
 zodern:caching-minifier@0.4.0
 zodern:minifier-js@4.1.0
 zodern:standard-minifier-js@4.1.1

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -1,7 +1,6 @@
 /* eslint-disable no-console */
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown';
 import { faCaretRight } from '@fortawesome/free-solid-svg-icons/faCaretRight';
 import { faMicrophoneSlash } from '@fortawesome/free-solid-svg-icons/faMicrophoneSlash';

--- a/imports/client/components/FirehosePage.tsx
+++ b/imports/client/components/FirehosePage.tsx
@@ -1,5 +1,4 @@
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import { faEraser } from '@fortawesome/free-solid-svg-icons/faEraser';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, {
@@ -12,6 +11,7 @@ import InputGroup from 'react-bootstrap/InputGroup';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { shortCalendarTimeFormat } from '../../lib/calendarTimeFormat';
+import { indexedById } from '../../lib/listUtils';
 import ChatMessages from '../../lib/models/ChatMessages';
 import { indexedDisplayNames } from '../../lib/models/MeteorUsers';
 import Puzzles from '../../lib/models/Puzzles';
@@ -90,8 +90,8 @@ const FirehosePage = () => {
   const displayNames = useTracker(() => (loading ? {} : indexedDisplayNames()), [loading]);
   const puzzles = useTracker(() => (
     loading ?
-      {} :
-      _.indexBy(Puzzles.findAllowingDeleted({ hunt: huntId }).fetch(), '_id')
+      new Map<string, PuzzleType>() :
+      indexedById(Puzzles.findAllowingDeleted({ hunt: huntId }).fetch())
   ), [loading, huntId]);
   const chatMessages = useTracker(() => (
     loading ?
@@ -242,7 +242,7 @@ const FirehosePage = () => {
               <Message
                 key={msg._id}
                 msg={msg}
-                puzzle={puzzles[msg.puzzle]}
+                puzzle={puzzles.get(msg.puzzle)}
                 displayName={msg.sender ? displayNames[msg.sender] : 'jolly-roger'}
               />
             );

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -3,7 +3,6 @@ import { Meteor } from 'meteor/meteor';
 import { OAuth } from 'meteor/oauth';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import { ServiceConfiguration } from 'meteor/service-configuration';
-import { _ } from 'meteor/underscore';
 import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
 import { faSkullCrossbones } from '@fortawesome/free-solid-svg-icons/faSkullCrossbones';
@@ -16,6 +15,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import Flags from '../../Flags';
 import { calendarTimeFormat } from '../../lib/calendarTimeFormat';
+import { indexedById } from '../../lib/listUtils';
 import Announcements from '../../lib/models/Announcements';
 import ChatNotifications from '../../lib/models/ChatNotifications';
 import Guesses from '../../lib/models/Guesses';
@@ -466,10 +466,10 @@ const NotificationCenter = () => {
   }, []);
 
   // Lookup tables to support guesses/pendingAnnouncements/chatNotifications
-  const hunts = useTracker(() => (loading ? {} : _.indexBy(Hunts.find().fetch(), '_id')), [loading]);
-  const puzzles = useTracker(() => (loading ? {} : _.indexBy(Puzzles.find().fetch(), '_id')), [loading]);
+  const hunts = useTracker(() => (loading ? new Map<string, HuntType>() : indexedById(Hunts.find().fetch())), [loading]);
+  const puzzles = useTracker(() => (loading ? new Map<string, PuzzleType>() : indexedById(Puzzles.find().fetch())), [loading]);
   const displayNames = useTracker(() => (loading ? {} : indexedDisplayNames()), [loading]);
-  const announcements = useTracker(() => (loading ? {} : _.indexBy(Announcements.find().fetch(), '_id')), [loading]);
+  const announcements = useTracker(() => (loading ? new Map<string, AnnouncementType>() : indexedById(Announcements.find().fetch())), [loading]);
 
   const guesses = useTracker(() => (
     loading || !fetchPendingGuesses ?
@@ -534,8 +534,8 @@ const NotificationCenter = () => {
     messages.push(<GuessMessage
       key={g._id}
       guess={g}
-      puzzle={puzzles[g.puzzle]!}
-      hunt={hunts[g.hunt]!}
+      puzzle={puzzles.get(g.puzzle)!}
+      hunt={hunts.get(g.hunt)!}
       guesser={displayNames[g.createdBy]!}
       onDismiss={dismissGuess}
     />);
@@ -546,7 +546,7 @@ const NotificationCenter = () => {
       <AnnouncementMessage
         key={pa._id}
         id={pa._id}
-        announcement={announcements[pa.announcement]!}
+        announcement={announcements.get(pa.announcement)!}
         createdByDisplayName={displayNames[pa.createdBy]!}
       />
     );
@@ -557,8 +557,8 @@ const NotificationCenter = () => {
       <ChatNotificationMessage
         key={cn._id}
         cn={cn}
-        hunt={hunts[cn.hunt]!}
-        puzzle={puzzles[cn.puzzle]!}
+        hunt={hunts.get(cn.hunt)!}
+        puzzle={puzzles.get(cn.puzzle)!}
         senderDisplayName={displayNames[cn.sender]!}
       />
     );

--- a/imports/client/components/OthersProfilePage.tsx
+++ b/imports/client/components/OthersProfilePage.tsx
@@ -1,11 +1,12 @@
 import { Meteor } from 'meteor/meteor';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import React from 'react';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/esm/Tooltip';
 import styled from 'styled-components';
+import { indexedById } from '../../lib/listUtils';
 import Hunts from '../../lib/models/Hunts';
+import { HuntType } from '../../lib/schemas/Hunt';
 import Avatar from './Avatar';
 
 const AvatarTooltip = styled(Tooltip)`
@@ -32,7 +33,10 @@ const OthersProfilePage = ({
 
   const huntsLoading = useSubscribe(showHuntList ? 'mongo.hunts' : undefined, {});
   const loading = huntsLoading();
-  const hunts = useTracker(() => (loading ? {} : _.indexBy(Hunts.find().fetch(), '_id')), [loading]);
+  const hunts = useTracker(() => (loading ?
+    new Map<string, HuntType>() :
+    indexedById(Hunts.find().fetch())
+  ), [loading]);
 
   return (
     <div>
@@ -97,7 +101,7 @@ const OthersProfilePage = ({
                   loading ?
                     'loading...' :
                     user.hunts?.map((huntId) => (
-                      hunts[huntId]?.name ?? `Unknown hunt ${huntId}`
+                      hunts.get(huntId)?.name ?? `Unknown hunt ${huntId}`
                     ))
                       .join(', ')
                 )}

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable max-len */
 import { Meteor } from 'meteor/meteor';
-import { _ } from 'meteor/underscore';
 import { faEdit } from '@fortawesome/free-solid-svg-icons/faEdit';
 import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
@@ -13,6 +12,7 @@ import ButtonGroup from 'react-bootstrap/esm/ButtonGroup';
 import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import Ansible from '../../Ansible';
+import { difference, indexedById } from '../../lib/listUtils';
 import { PuzzleType } from '../../lib/schemas/Puzzle';
 import { TagType } from '../../lib/schemas/Tag';
 import { computeSolvedness, Solvedness } from '../../lib/solvedness';
@@ -176,9 +176,11 @@ const Puzzle = React.memo(({
 
   // id, title, answer, tags
   const linkTarget = `/hunts/${puzzle.hunt}/puzzles/${puzzle._id}`;
-  const tagIndex = _.indexBy(allTags, '_id');
-  const shownTags = _.difference(puzzle.tags, suppressTags || []);
-  const ownTags = shownTags.map((tagId) => { return tagIndex[tagId]; }).filter(Boolean);
+  const tagIndex = indexedById(allTags);
+  const shownTags = difference(puzzle.tags, suppressTags || []);
+  const ownTags = shownTags
+    .map((tagId) => { return tagIndex.get(tagId); })
+    .filter<TagType>((t): t is TagType => t !== undefined);
 
   const solvedness = computeSolvedness(puzzle);
   const answers = puzzle.answers.map((answer, i) => {

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -1,6 +1,5 @@
 import { Meteor } from 'meteor/meteor';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import { faBullhorn } from '@fortawesome/free-solid-svg-icons/faBullhorn';
 import { faEraser } from '@fortawesome/free-solid-svg-icons/faEraser';
 import { faFaucet } from '@fortawesome/free-solid-svg-icons/faFaucet';
@@ -26,6 +25,7 @@ import ToggleButtonGroup from 'react-bootstrap/ToggleButtonGroup';
 import Tooltip from 'react-bootstrap/Tooltip';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import styled, { css } from 'styled-components';
+import { sortedBy } from '../../lib/listUtils';
 import Hunts from '../../lib/models/Hunts';
 import Puzzles from '../../lib/models/Puzzles';
 import Tags from '../../lib/models/Tags';
@@ -298,7 +298,7 @@ const PuzzleListView = ({
         break;
       }
       case 'unlock': {
-        const puzzlesByUnlock = _.sortBy(allPuzzles, (p) => { return p.createdAt; });
+        const puzzlesByUnlock = sortedBy(allPuzzles, (p) => { return p.createdAt; });
         const retainedPuzzlesByUnlock = puzzlesByUnlock.filter((p) => retainedIds.has(p._id));
         listComponent = (
           <PuzzleList

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -2,7 +2,6 @@
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import { faEdit } from '@fortawesome/free-solid-svg-icons/faEdit';
 import { faKey } from '@fortawesome/free-solid-svg-icons/faKey';
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons/faPaperPlane';
@@ -31,6 +30,7 @@ import TextareaAutosize from 'react-textarea-autosize';
 import styled, { css } from 'styled-components';
 import Ansible from '../../Ansible';
 import { calendarTimeFormat, shortCalendarTimeFormat } from '../../lib/calendarTimeFormat';
+import { indexedById, sortedBy } from '../../lib/listUtils';
 import ChatMessages from '../../lib/models/ChatMessages';
 import Documents from '../../lib/models/Documents';
 import Guesses from '../../lib/models/Guesses';
@@ -43,6 +43,7 @@ import { ChatMessageType } from '../../lib/schemas/ChatMessage';
 import { DocumentType } from '../../lib/schemas/Document';
 import { GuessType } from '../../lib/schemas/Guess';
 import { PuzzleType } from '../../lib/schemas/Puzzle';
+import { TagType } from '../../lib/schemas/Tag';
 import addPuzzleAnswer from '../../methods/addPuzzleAnswer';
 import addPuzzleTag from '../../methods/addPuzzleTag';
 import createGuess from '../../methods/createGuess';
@@ -700,8 +701,9 @@ const PuzzlePageMetadata = ({
     }
   }, []);
 
-  const tagsById = _.indexBy(allTags, '_id');
-  const tags = puzzle.tags.map((tagId) => { return tagsById[tagId]; }).filter(Boolean);
+  const tagsById = indexedById(allTags);
+  const maybeTags: (TagType | undefined)[] = puzzle.tags.map((tagId) => { return tagsById.get(tagId); });
+  const tags: TagType[] = maybeTags.filter<TagType>((t): t is TagType => t !== undefined);
   const correctGuesses = guesses.filter((guess) => guess.state === 'correct');
   const numGuesses = guesses.length;
 
@@ -1005,7 +1007,7 @@ const PuzzleGuessModal = React.forwardRef(({
             </tr>
           </thead>
           <tbody>
-            {_.sortBy(guesses, 'createdAt').reverse().map((guess) => {
+            {sortedBy(guesses, (g) => g.createdAt).reverse().map((guess) => {
               return (
                 <tr key={guess._id}>
                   <AnswerTableCell>{guess.guess}</AnswerTableCell>

--- a/imports/client/components/RelatedPuzzleList.tsx
+++ b/imports/client/components/RelatedPuzzleList.tsx
@@ -1,5 +1,5 @@
-import { _ } from 'meteor/underscore';
 import React from 'react';
+import { indexedById } from '../../lib/listUtils';
 import { puzzleInterestingness } from '../../lib/puzzle-sort-and-group';
 import { PuzzleType } from '../../lib/schemas/Puzzle';
 import { TagType } from '../../lib/schemas/Tag';
@@ -8,7 +8,7 @@ import PuzzleList from './PuzzleList';
 function sortPuzzlesByRelevanceWithinPuzzleGroup(
   puzzles: PuzzleType[],
   sharedTag: TagType | undefined,
-  indexedTags: Record<string, TagType>
+  indexedTags: Map<string, TagType>
 ) {
   let group: string;
   if (sharedTag && sharedTag.name.lastIndexOf('group:', 0) === 0) {
@@ -41,7 +41,7 @@ const RelatedPuzzleList = React.memo(({
   // Sort the puzzles within each tag group by interestingness.  For instance, metas
   // should probably be at the top of the group, then of the round puzzles, unsolved should
   // maybe sort above solved, and then perhaps by unlock order.
-  const tagIndex = _.indexBy(allTags, '_id');
+  const tagIndex = indexedById(allTags);
   const sortedPuzzles = sortPuzzlesByRelevanceWithinPuzzleGroup(
     relatedPuzzles,
     sharedTag,

--- a/imports/client/components/RelatedPuzzleTable.tsx
+++ b/imports/client/components/RelatedPuzzleTable.tsx
@@ -1,5 +1,5 @@
-import { _ } from 'meteor/underscore';
 import React from 'react';
+import { indexedById } from '../../lib/listUtils';
 import { PuzzleType } from '../../lib/schemas/Puzzle';
 import { TagType } from '../../lib/schemas/Tag';
 import PuzzleTable from './PuzzleTable';
@@ -16,7 +16,7 @@ const RelatedPuzzleTable = React.memo(({
   // Sort the puzzles within each tag group by interestingness.  For instance, metas
   // should probably be at the top of the group, then of the round puzzles, unsolved should
   // maybe sort above solved, and then perhaps by unlock order.
-  const tagIndex = _.indexBy(allTags, '_id');
+  const tagIndex = indexedById(allTags);
   const sortedPuzzles = sortPuzzlesByRelevanceWithinPuzzleGroup(
     relatedPuzzles,
     sharedTag,

--- a/imports/client/components/SplitPanePlus.tsx
+++ b/imports/client/components/SplitPanePlus.tsx
@@ -1,10 +1,10 @@
-import { _ } from 'meteor/underscore';
 import classnames from 'classnames';
 import elementResizeDetectorMaker from 'element-resize-detector';
 import React, {
   useCallback, useEffect, useRef, useState,
 } from 'react';
 import SplitPane, { SplitPaneProps } from 'react-split-pane';
+import throttle from '../../lib/throttle';
 
 /*
   Provides two panes with a user draggable divider featuring snap-to-collapse. Fully controlled.
@@ -243,7 +243,7 @@ const SplitPanePlus = ({
     const erd = getErd();
     const node = splitPaneNode();
     if (node) {
-      erd.listenTo(node, _.throttle(onResize, 50));
+      erd.listenTo(node, throttle(onResize, 50).attempt);
     }
 
     const resizerEl = resizerNode();

--- a/imports/client/components/Tag.tsx
+++ b/imports/client/components/Tag.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/destructuring-assignment */
-import { _ } from 'meteor/underscore';
 import { faAlignJustify } from '@fortawesome/free-solid-svg-icons/faAlignJustify';
 import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
@@ -12,6 +11,7 @@ import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Popover from 'react-bootstrap/Popover';
 import { Link } from 'react-router-dom';
 import styled, { css } from 'styled-components';
+import { indexedById } from '../../lib/listUtils';
 import { PuzzleType } from '../../lib/schemas/Puzzle';
 import { TagType } from '../../lib/schemas/Tag';
 import { removePunctuation } from './PuzzleAnswer';
@@ -244,7 +244,7 @@ const Tag = (props: TagProps) => {
     if (!props.popoverRelated) {
       return;
     }
-    const tagIndex = _.indexBy(allTagsIfPresent!, '_id');
+    const tagIndex = indexedById(allTagsIfPresent!);
     const sharedTagName = getRelatedPuzzlesSharedTagName(props.tag.name);
     const sharedTag = allTagsIfPresent!.find((t) => t.name === sharedTagName);
     const relatedPuzzles = sortPuzzlesByRelevanceWithinPuzzleGroup(

--- a/imports/client/hooks/useCallState.ts
+++ b/imports/client/hooks/useCallState.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-console */
 import { Meteor } from 'meteor/meteor';
 import { useFind, useTracker } from 'meteor/react-meteor-data';
-import { _ } from 'meteor/underscore';
 import { Device, types } from 'mediasoup-client';
 import React, {
   useEffect, useMemo, useReducer, useRef, useState, useCallback,
 } from 'react';
+import { groupedBy } from '../../lib/listUtils';
 import ConnectAcks from '../../lib/models/mediasoup/ConnectAcks';
 import Consumers from '../../lib/models/mediasoup/Consumers';
 import Peers from '../../lib/models/mediasoup/Peers';
@@ -738,7 +738,7 @@ const useCallState = ({ huntId, puzzleId, tabId }: {
     [puzzleId]
   );
   const groupedConsumers = useMemo(() => {
-    return _.groupBy(puzzleConsumers, (consumer) => consumer.producerPeer);
+    return groupedBy(puzzleConsumers, (consumer) => consumer.producerPeer);
   }, [puzzleConsumers]);
 
   // Map from consumer._id to our working state for that consumer.
@@ -763,7 +763,7 @@ const useCallState = ({ huntId, puzzleId, tabId }: {
     if (state.callState === CallJoinState.IN_CALL) {
       otherPeers.forEach((peer) => {
         activePeerIds.add(peer._id);
-        const consumers = groupedConsumers[peer._id] ?? [];
+        const consumers = groupedConsumers.get(peer._id) ?? [];
         consumers.forEach((consumer) => {
           const {
             _id: meteorConsumerId,

--- a/imports/lib/listUtils.ts
+++ b/imports/lib/listUtils.ts
@@ -1,0 +1,56 @@
+interface ObjectWithId {
+  _id: string;
+}
+
+export function indexedById<T extends ObjectWithId>(list: T[]): Map<string, T> {
+  const retval = new Map();
+  list.forEach((item) => {
+    if (retval.has(item._id)) {
+      throw new Error(`Duplicate id ${item._id} passed to indexedById`);
+    }
+    retval.set(item._id, item);
+  });
+  return retval;
+}
+
+export function difference<T>(universe: T[], removed: T[]): T[] {
+  const index = new Map<T, boolean>();
+  removed.forEach((item) => {
+    index.set(item, true);
+  });
+  return universe.filter((item) => !index.has(item));
+}
+
+export function sortedBy<T extends object, U>(list: T[], fn: (obj: T) => U): T[] {
+  // Returns a copy of the provided `list` sorted (ascending) by the result
+  // of applying `fn` to each element in the list.
+  const sortKeys = new WeakMap();
+  list.forEach((item) => {
+    sortKeys.set(item, fn(item));
+  });
+  const retval = [...list];
+  retval.sort((a, b) => {
+    const aKey = sortKeys.get(a);
+    const bKey = sortKeys.get(b);
+    if (aKey === bKey) {
+      return 0;
+    } else if (aKey < bKey) {
+      return -1;
+    } else {
+      return 1;
+    }
+  });
+  return retval;
+}
+
+export function groupedBy<T>(list: T[], fn: (obj: T) => string): Map<string, T[]> {
+  const groupIndex = new Map();
+  list.forEach((item) => {
+    const groupKey = fn(item);
+    if (!groupIndex.has(groupKey)) {
+      groupIndex.set(groupKey, []);
+    }
+    groupIndex.get(groupKey).push(item);
+  });
+  return groupIndex;
+}

--- a/imports/lib/throttle.ts
+++ b/imports/lib/throttle.ts
@@ -1,0 +1,64 @@
+type AnyVoidFunc<T> = (this: T, ...args: any[]) => void;
+type ThrottledFunctionHandle<T> = {
+  attempt: AnyVoidFunc<T>;
+  cancel: () => void;
+}
+
+export default function throttle<T>(
+  func: AnyVoidFunc<T>,
+  waitMsec: number,
+): ThrottledFunctionHandle<T> {
+  let timeoutHandle: number | undefined;
+  let lastCalled = 0; // The last time we actually called `func`
+  let savedThis: any; // the value of `this` as passed to func
+  let savedArgs: any;
+
+  const onTimeout = function () {
+    timeoutHandle = undefined;
+    lastCalled = Date.now();
+    func.apply(savedThis, savedArgs);
+    if (timeoutHandle !== undefined) {
+      savedThis = undefined;
+      savedArgs = undefined;
+    }
+  };
+
+  const throttled = function (this: T, ...args: any[]) {
+    const now = Date.now();
+    const remaining = waitMsec - (now - lastCalled);
+    if (remaining <= 0 || remaining > waitMsec) {
+      if (timeoutHandle !== undefined) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = undefined;
+      }
+      lastCalled = now;
+      func.apply(this, args);
+      if (timeoutHandle !== undefined) {
+        savedThis = undefined;
+        savedArgs = undefined;
+      }
+    } else if (timeoutHandle === undefined) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      savedThis = this;
+      savedArgs = args;
+      timeoutHandle = setTimeout(onTimeout, remaining) as any as number;
+    }
+  };
+
+  const cancel = function () {
+    if (timeoutHandle !== undefined) {
+      clearTimeout(timeoutHandle);
+    }
+    timeoutHandle = undefined;
+    lastCalled = 0;
+    savedThis = undefined;
+    savedArgs = undefined;
+  };
+
+  const handle = {
+    attempt: throttled,
+    cancel,
+  };
+
+  return handle;
+}

--- a/imports/server/methods/configureOrganizeGoogleDrive.ts
+++ b/imports/server/methods/configureOrganizeGoogleDrive.ts
@@ -1,7 +1,7 @@
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
-import { _ } from 'meteor/underscore';
 import Ansible from '../../Ansible';
+import { indexedById } from '../../lib/listUtils';
 import Documents from '../../lib/models/Documents';
 import Hunts from '../../lib/models/Hunts';
 import Puzzles from '../../lib/models/Puzzles';
@@ -40,10 +40,10 @@ configureOrganizeGoogleDrive.define({
     }, Promise.resolve());
 
     // Finally move all existing documents into the right folder
-    const puzzles = _.indexBy(Puzzles.find().fetch(), '_id');
+    const puzzles = indexedById(Puzzles.find().fetch());
     await Documents.find().fetch().reduce(async (promise, d) => {
       await promise;
-      const puzzle = puzzles[d.puzzle];
+      const puzzle = puzzles.get(d.puzzle);
       if (puzzle && !d.value.folder) await ensureDocument(puzzle);
     }, Promise.resolve());
   },

--- a/tests/unit/imports/lib/puzzle-sort-and-group.ts
+++ b/tests/unit/imports/lib/puzzle-sort-and-group.ts
@@ -5,8 +5,8 @@ import { TagType } from '../../../../imports/lib/schemas/Tag';
 
 const hunt = 'hunt_id';
 const allTags: TagType[] = [];
-const allTagsById: Record<string, TagType> = {}; // index by _id -- wanted by implementation
-const allTagsByName: Record<string, TagType> = {}; // index by name, wanted for test readability
+const allTagsById: Map<string, TagType> = new Map(); // index by _id -- wanted by implementation
+const allTagsByName: Map<string, TagType> = new Map(); // index by name, wanted for test readability
 const stubUserId = 'user';
 
 function makeTag(name: string): TagType {
@@ -23,8 +23,8 @@ function makeTag(name: string): TagType {
     updatedAt: undefined,
   };
   allTags.push(tag);
-  allTagsById[_id] = tag;
-  allTagsByName[name] = tag;
+  allTagsById.set(_id, tag);
+  allTagsByName.set(name, tag);
   return tag;
 }
 
@@ -41,8 +41,8 @@ function makePuzzle(title: string, tags: string[], opts: MakePuzzleOpts = {}): P
     expectedAnswerCount = 1,
   } = opts;
   const tagIds = tags.map((tagName) => {
-    if (tagName in allTagsByName) {
-      return allTagsByName[tagName];
+    if (allTagsByName.has(tagName)) {
+      return allTagsByName.get(tagName)!;
     } else {
       return makeTag(tagName);
     }
@@ -97,12 +97,12 @@ describe('puzzleGroupsByRelevance', function () {
       const groups = puzzleGroupsByRelevance([puzA, puzB], allTags);
       assert.deepEqual(groups, [
         {
-          sharedTag: allTagsByName['group:a'],
+          sharedTag: allTagsByName.get('group:a'),
           puzzles: [puzA, puzB],
           subgroups: [],
         },
         {
-          sharedTag: allTagsByName['group:b'],
+          sharedTag: allTagsByName.get('group:b'),
           puzzles: [puzA, puzB],
           subgroups: [],
         },
@@ -119,19 +119,19 @@ describe('puzzleGroupsByRelevance', function () {
       const groups = puzzleGroupsByRelevance(allPuz, allTags);
       assert.deepEqual(groups, [
         {
-          sharedTag: allTagsByName['group:all'],
+          sharedTag: allTagsByName.get('group:all'),
           puzzles: [puzA],
           subgroups: [
             {
-              sharedTag: allTagsByName['group:a'],
+              sharedTag: allTagsByName.get('group:a'),
               puzzles: [puzB],
               subgroups: [
                 {
-                  sharedTag: allTagsByName['group:b'],
+                  sharedTag: allTagsByName.get('group:b'),
                   puzzles: [puzC],
                   subgroups: [
                     {
-                      sharedTag: allTagsByName['group:c'],
+                      sharedTag: allTagsByName.get('group:c'),
                       puzzles: [puzD],
                       subgroups: [],
                     },
@@ -153,22 +153,22 @@ describe('puzzleGroupsByRelevance', function () {
       const groups = puzzleGroupsByRelevance([puzA, puzB, puzInner], allTags);
       assert.deepEqual(groups, [
         {
-          sharedTag: allTagsByName['group:a'],
+          sharedTag: allTagsByName.get('group:a'),
           puzzles: [puzA],
           subgroups: [
             {
-              sharedTag: allTagsByName['group:inner'],
+              sharedTag: allTagsByName.get('group:inner'),
               puzzles: [puzInner],
               subgroups: [],
             },
           ],
         },
         {
-          sharedTag: allTagsByName['group:b'],
+          sharedTag: allTagsByName.get('group:b'),
           puzzles: [puzB],
           subgroups: [
             {
-              sharedTag: allTagsByName['group:inner'],
+              sharedTag: allTagsByName.get('group:inner'),
               puzzles: [puzInner],
               subgroups: [],
             },
@@ -249,7 +249,7 @@ describe('puzzleGroupsByRelevance', function () {
         {
           // Administrivia
           // eslint-disable-next-line dot-notation
-          sharedTag: allTagsByName['administrivia'],
+          sharedTag: allTagsByName.get('administrivia'),
           puzzles: [admPuzzle],
           subgroups: [],
         },
@@ -257,19 +257,19 @@ describe('puzzleGroupsByRelevance', function () {
           // Group with an unsolved puzzle with matching meta-for: that group, even
           // though there's another puzzle with matching meta-for: that group that
           // is solved (-2)
-          sharedTag: allTagsByName['group:partly-solved'],
+          sharedTag: allTagsByName.get('group:partly-solved'),
           puzzles: [unsolvedRelatedMeta, solvedRelatedMeta, solvedRelatedPuzzle],
           subgroups: [],
         },
         {
           // Group with some other unsolved meta puzzle, but not the one that the group is for
-          sharedTag: allTagsByName['group:other-unsolved-meta'],
+          sharedTag: allTagsByName.get('group:other-unsolved-meta'),
           puzzles: [otherUnsolvedUnsolvedMeta, otherUnsolvedSolvedMeta],
           subgroups: [],
         },
         {
           // Group with no metas yet and at least one unsolved puzzle
-          sharedTag: allTagsByName['group:no-metas'],
+          sharedTag: allTagsByName.get('group:no-metas'),
           puzzles: [flatPuzzle1, flatPuzzle2],
           subgroups: [],
         },
@@ -281,13 +281,13 @@ describe('puzzleGroupsByRelevance', function () {
         },
         {
           // Group with solved meta for the group, but at least one unsolved puzzle (2)
-          sharedTag: allTagsByName['group:metas-solved'],
+          sharedTag: allTagsByName.get('group:metas-solved'),
           puzzles: [metasSolvedMeta1, metasSolvedMeta2, metasSolvedRoundUnsolvedPuzzle],
           subgroups: [],
         },
         {
           // group with only solved puzzles
-          sharedTag: allTagsByName['group:fully-solved'],
+          sharedTag: allTagsByName.get('group:fully-solved'),
           // Note: we preserve the given puzzle order from `allPuzzles` here.
           // Puzzle ordering within a group is deferred until rendering time, where
           // it will sort by puzzleInterestingness.  As a result, this round puzzle
@@ -297,7 +297,7 @@ describe('puzzleGroupsByRelevance', function () {
         },
         {
           // group with only solved puzzles, despite having no metapuzzle (also 3)
-          sharedTag: allTagsByName['group:flat-fully-solved'],
+          sharedTag: allTagsByName.get('group:flat-fully-solved'),
           puzzles: [flatFullySolved],
           subgroups: [],
         },
@@ -314,7 +314,7 @@ describe('filteredPuzzleGroups', function () {
     const filtered = filteredPuzzleGroups(groups, new Set([puzA._id]));
     assert.deepEqual(filtered, [
       {
-        sharedTag: allTagsByName['group:a'],
+        sharedTag: allTagsByName.get('group:a'),
         puzzles: [puzA],
         subgroups: [],
       },
@@ -328,11 +328,11 @@ describe('filteredPuzzleGroups', function () {
     const filtered = filteredPuzzleGroups(groups, new Set([puzB._id]));
     assert.deepEqual(filtered, [
       {
-        sharedTag: allTagsByName['group:outer'],
+        sharedTag: allTagsByName.get('group:outer'),
         puzzles: [],
         subgroups: [
           {
-            sharedTag: allTagsByName['group:inner'],
+            sharedTag: allTagsByName.get('group:inner'),
             puzzles: [puzB],
             subgroups: [],
           },

--- a/types/meteor/xolvio/cleaner/cleaner.d.ts
+++ b/types/meteor/xolvio/cleaner/cleaner.d.ts
@@ -1,6 +1,0 @@
-declare module 'meteor/xolvio:cleaner' {
-  export function resetDatabase(
-    options?: { excludedCollections: string[] },
-    callback?: () => void,
-  ): void;
-}


### PR DESCRIPTION
It seems that the Meteor ecosystem is moving away from underscore, at least on the client-side, which means that if we finish removing some of our remaining uses of it, we might be able to save a decent chunk of code size on the client.

This PR removes our remaining direct usages by reimplementing the relevant subset of functionality, and also removes one indirect usage via `xolvio:cleaner` by reimplementing the single serverside function we call directly.  (This also affords us the opportunity to move some of those DB interactions to use non-deprecated methods and async/await while we're there).

The one big remaining dependency that appears to be pulling in `underscore` on the client side is `meteorhacks:cluster`, which is probably a large enough rewrite that we should take it on as a separate PR.