### PR TITLE
Bundle size reductions

### DIFF
--- a/imports/client/components/Tag.tsx
+++ b/imports/client/components/Tag.tsx
@@ -3,8 +3,8 @@ import { faAlignJustify } from '@fortawesome/free-solid-svg-icons/faAlignJustify
 import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { detectOverflow } from '@popperjs/core';
 import type { ModifierArguments, Modifier, Padding } from '@popperjs/core';
+import detectOverflow from '@popperjs/core/lib/utils/detectOverflow';
 import React, { useCallback, useEffect, useState } from 'react';
 import Button from 'react-bootstrap/Button';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';

--- a/imports/client/hooks/useCallState.ts
+++ b/imports/client/hooks/useCallState.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { Meteor } from 'meteor/meteor';
 import { useFind, useTracker } from 'meteor/react-meteor-data';
-import { Device, types } from 'mediasoup-client';
+import type { types } from 'mediasoup-client';
 import React, {
   useEffect, useMemo, useReducer, useRef, useState, useCallback,
 } from 'react';
@@ -418,6 +418,8 @@ const useCallState = ({ huntId, puzzleId, tabId }: {
   useEffect(() => {
     if (router?._id) {
       void (async () => {
+        console.log('Fetching mediasoup-client code');
+        const { Device } = await import('mediasoup-client');
         console.log('Creating new Mediasoup device');
         const newDevice = new Device();
         await newDevice.load({


### PR DESCRIPTION
One tiny win (3k removed) from popperjs/core and one bigger one (200k deferred) from loading `mediasoup-client` only once the user is actually trying to join a call and needs to create a mediasoup `Device`.

Bundle size before: 1.75MB
Bundle size after: 1.52MB