### PR TITLE
Update responsive breakpoints for BS v5

### DIFF
--- a/client/stylesheets/_theme.scss
+++ b/client/stylesheets/_theme.scss
@@ -8,3 +8,9 @@ $link-hover-decoration: underline;
 @import "../../node_modules/bootstrap/scss/functions";
 @import "../../node_modules/bootstrap/scss/variables";
 @import "../../node_modules/bootstrap/scss/mixins";
+
+:root {
+  @each $name, $value in $grid-breakpoints {
+    --bs-breakpoint-#{$name}: #{$value};
+  }
+}

--- a/imports/client/components/styling/responsive.tsx
+++ b/imports/client/components/styling/responsive.tsx
@@ -13,7 +13,7 @@ function getBreakpoint(b: Breakpoint) {
   // Bootstrap breakpoints are stored as variables on the root element, but you
   // can't use a variable directly in a media query, so we have to pull it out
   // with code.
-  return window.getComputedStyle(document.body).getPropertyValue(`--breakpoint-${b}`);
+  return window.getComputedStyle(document.body).getPropertyValue(`--bs-breakpoint-${b}`);
 }
 
 export function mediaBreakpointDown(


### PR DESCRIPTION
Bootstrap stopped including the widths for the grid breakpoints in v5. They're scheduled to be readded in v5.3 (with new names); in the interim, we can duplicate the logic.