### PR TITLE
Mute when joining a large call

### DIFF
--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -10,6 +10,8 @@ import React, {
   useCallback, useEffect, useRef, useState,
 } from 'react';
 import Alert from 'react-bootstrap/Alert';
+import Button from 'react-bootstrap/Button';
+import Overlay from 'react-bootstrap/Overlay';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
 import styled from 'styled-components';
@@ -325,6 +327,11 @@ const CallSection = ({
   const onLeaveCall = useCallback(() => {
     callDispatch({ type: 'leave-call' });
   }, [callDispatch]);
+  const onDismissPeerStateNotification = useCallback(() => {
+    callDispatch({ type: 'dismiss-peer-state-notification' });
+  }, [callDispatch]);
+
+  const muteRef = useRef(null);
 
   if (!callState.device) {
     return <JoiningCall details="Missing device" />;
@@ -342,6 +349,7 @@ const CallSection = ({
     <>
       <AVActions>
         <AVButton
+          ref={muteRef}
           variant={muted ? 'secondary' : 'light'}
           size="sm"
           onClick={onToggleMute}
@@ -357,6 +365,15 @@ const CallSection = ({
         </AVButton>
         <AVButton variant="danger" size="sm" onClick={onLeaveCall}>Leave call</AVButton>
       </AVActions>
+      <Overlay target={muteRef.current} show={callState.allowInitialPeerStateNotification && muted} placement="bottom">
+        <Tooltip id="muted-on-join-notification">
+          <div>
+            We&apos;ve left your mic muted for now given the number of people on the
+            call.  You can unmute yourself at any time.
+          </div>
+          <Button onClick={onDismissPeerStateNotification}>Got it</Button>
+        </Tooltip>
+      </Overlay>
       <Callers
         muted={muted}
         deafened={deafened}

--- a/imports/client/hooks/useCallState.ts
+++ b/imports/client/hooks/useCallState.ts
@@ -314,6 +314,7 @@ function cleanupProducerMapEntry(map: Map<string, ProducerState>, trackId: strin
 
 type ProducerCallback = ({ id }: { id: string }) => void;
 type ProducerState = {
+  transport: string;
   producer: types.Producer | undefined;
   subHandle: Meteor.SubscriptionHandle | undefined;
   producerServerCallback: ProducerCallback | undefined;
@@ -629,9 +630,10 @@ const useCallState = ({ huntId, puzzleId, tabId }: {
 
       if (sendTransport) {
         let producerState = producerMapRef.current.get(track.id);
-        if (!producerState) {
+        if (!producerState || producerState.transport !== sendTransport.appData._id) {
           // Create empty entry, before we attempt to produce for the track
           producerState = {
+            transport: (sendTransport.appData as any)._id,
             producer: undefined,
             subHandle: undefined,
             producerServerCallback: undefined,
@@ -645,6 +647,7 @@ const useCallState = ({ huntId, puzzleId, tabId }: {
             const newProducer = await sendTransport.produce({
               track,
               zeroRtpOnPause: true,
+              stopTracks: false,
               appData: { trackId: track.id },
             });
             log('got producer', newProducer);

--- a/imports/lib/schemas/mediasoup/Peer.ts
+++ b/imports/lib/schemas/mediasoup/Peer.ts
@@ -10,6 +10,7 @@ const PeerFields = t.type({
   hunt: t.string,
   call: t.string,
   tab: t.string,
+  initialPeerState: t.union([t.literal('active'), t.literal('muted'), t.literal('deafened')]),
   muted: t.boolean,
   deafened: t.boolean,
 });
@@ -29,6 +30,9 @@ const PeerFieldsOverrides: Overrides<t.TypeOf<typeof PeerFields>> = {
   },
   tab: {
     regEx: Id,
+    denyUpdate: true,
+  },
+  initialPeerState: {
     denyUpdate: true,
   },
 };


### PR DESCRIPTION
This improves the experience of using audiocalls that have a whole bunch of people listening in at once.

We achieve this by adding a field on `Peer` that indicates the server's desired stream states, and then having the client respect that, showing a popover message if the server has requested they be muted.

To avoid producing strange effects on server disconnection, we also track more explicitly if we're creating a Peer where the same hunt/call/tab had already joined that call (indicating reconnection on server failure/disconnection, rather than initial join), and if so, propagate the last-known state from the previous Peer record (since we'd like for reconnections not to perturb client state).

<img width="302" alt="Screenshot 2022-12-03 at 5 47 56 PM" src="https://user-images.githubusercontent.com/307325/205470023-f805484c-605a-4651-854c-ff82e6214d54.png">

Fixes #501.