### PR TITLE
Ensure `meta-for:` tag when creating `group:` tag

### DIFF
--- a/imports/server/getOrCreateTagByName.ts
+++ b/imports/server/getOrCreateTagByName.ts
@@ -13,6 +13,14 @@ export default function getOrCreateTagByName(huntId: string, name: string): {
 
   Ansible.log('Creating a new tag', { hunt: huntId, name });
   const newTagId = Tags.insert({ hunt: huntId, name });
+
+  // When creating a `group:*` tag, also ensure a matching `meta-for:` tag exists.
+  if (name.startsWith('group:')) {
+    const groupName = name.slice('group:'.length);
+    const metaTagName = `meta-for:${groupName}`;
+    getOrCreateTagByName(huntId, metaTagName);
+  }
+
   return {
     _id: newTagId,
     hunt: huntId,


### PR DESCRIPTION
This should increase convenience but also help with discoverability of `meta-for:` functionality.  `meta-for:` carries a lot of helpful behavior (grouping, sort ordering, chat dispatch) but is also rather undiscoverable without knowing a priori the magic tag structure.