### PR TITLE
Upgrade Docker build to Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # We use separate stages for running lint and test vs. building the production
 # bundle so that they can run in parallel
 
-FROM ubuntu:18.04 AS buildenv
+FROM ubuntu:22.04 AS buildenv
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -18,22 +18,22 @@ apt-get update
 # We need:
 # * git: for fetching moira and capturing git rev in Meteor artifact
 # * curl: for the Meteor installer and fetching new apt keys
-# * gnupg: for installing new apt keys
 # * python3 et al: for building mediasoup
 # * comerr-dev et al: for building moira
 apt-get install --no-install-recommends -y \
 	build-essential \
 	git \
 	curl \
-	gnupg \
 	python3 python3-pip python3-dev python3-setuptools python3-wheel \
-	comerr-dev libkrb5-dev libreadline-dev libhesiod-dev libncurses5-dev autotools-dev
+	comerr-dev libkrb5-dev libreadline-dev libhesiod-dev libncurses5-dev autoconf
 
-# Install chromium-browser's dependencies, which should match puppeteer's
-# dependencies. Note: this will need to be updated when we upgrade to 20.04,
-# as chromium-browser on 20.04 is a wrapper around a snap package (although
-# apt-get satisfy will make it easier)
-apt-get install --no-install-recommends -y $(apt-cache depends chromium-browser | sed -ne 's/^ *Depends://p')
+# The easiest way to install puppeteer's dependencies is to pull the
+# dependencies for Chrome. We don't actually need to install Chrome, but this
+# prevents us from needing to manually maintain the list of dependencies here.
+curl https://dl-ssl.google.com/linux/linux_signing_key.pub > /etc/apt/trusted.gpg.d/google.asc
+echo "deb https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+apt-get update
+apt-get satisfy --no-install-recommends -y "$(apt-cache show google-chrome-stable | sed -ne 's/^Depends: //p')"
 EOF
 
 FROM buildenv as moiraenv
@@ -50,7 +50,7 @@ set -eux
 set -o pipefail
 # Update config.guess and config.sub to support aarch64 (note that in newer
 # Ubuntu releases, this has moved to /usr/share/autoconf/build-aux)
-cp /usr/share/misc/config.{guess,sub} .
+cp /usr/share/autoconf/build-aux/config.{guess,sub} .
 ./configure --with-krb5 --with-com_err --with-afs --with-hesiod --with-readline --without-zephyr --without-java --prefix=/usr
 make -j
 make install DESTDIR=/moira/build
@@ -107,7 +107,7 @@ RUN --mount=type=cache,target=/root/.npm meteor npm install --production
 # Production image
 # (Be careful about creating as few layers as possible)
 
-FROM ubuntu:18.04 AS production
+FROM ubuntu:22.04 AS production
 
 # Install runtime deps
 RUN <<'EOF'
@@ -116,15 +116,15 @@ set -eux
 set -o pipefail
 . /etc/os-release
 
-# Install apt https support for node.  Install gnupg so that apt-key add works.
+# Install apt https support for node.
 apt-get update
-apt-get install --no-install-recommends -y apt-transport-https ca-certificates gnupg curl
+apt-get install --no-install-recommends -y apt-transport-https ca-certificates curl
 
 # Install moira dependencies (use the dev packages to avoid pinning to specific sonames)
 apt-get install --no-install-recommends -y comerr-dev libkrb5-dev libreadline-dev libhesiod-dev libncurses5-dev
 
 # Add node apt repo
-curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
+curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key > /etc/apt/trusted.gpg.d/nodesource.asc
 echo "deb https://deb.nodesource.com/node_14.x $VERSION_CODENAME main" > /etc/apt/sources.list.d/node.list
 apt-get update
 


### PR DESCRIPTION
Now that we are no longer blocked on Debathena giving us a build of moira for modern releases, we can upgrade to jammy without a ton of work. A few specific changes:

* The `apt-key` command has been deprecated, in favor of just dropping files into `/etc/apt/trusted.gpg.d/`. However, this lets us drop our dependency on the `gnupg` package, as we were never using it directly.
* Ubuntu's `chromium-browser` package is now just a wrapper around a snap package, so we can't use that to ensure we have the dependencies for puppeteer. Instead, add the Google Chrome apt repository so we can get metadata on what Chrome-like dependencies look like (but don't actually install Chrome).