### PR TITLE
Track activity on Google Drive documents

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -71,6 +71,12 @@
     // We don't use imports with extensions
     "import/extensions": ["error", "never"],
 
+    // Allow optional imports
+    "import/no-extraneous-dependencies": ["error", {
+      "optionalDependencies": true,
+      "devDependencies": ["tests/**"]
+    }],
+
     // Imports should be grouped, and sorted within the group. Meteor imports
     // are their own group, after built-ins and before other external libraries
     "import/order": ["error", {

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,7 @@ RUN --mount=type=cache,target=/app/.meteor/local/ meteor build --allow-superuser
 
 # Install server dependencies
 WORKDIR /built_app/bundle/programs/server
-RUN --mount=type=cache,target=/root/.npm meteor npm install --production
+RUN --mount=type=cache,target=/root/.npm meteor npm install --production --omit=optional
 
 # Production image
 # (Be careful about creating as few layers as possible)

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -1745,6 +1745,23 @@ const CircuitBreakerSection = () => {
         </p>
       </CircuitBreakerControl>
       <CircuitBreakerControl
+        title="Drive activity watches"
+        flagName="disable.gdrive_watchers"
+      >
+        <p>
+          When Jolly Roger creates a spreadsheet or document, we set a watch on
+          the file and collect activity notifications from Google Drive. There is
+          some possibility that creating and maintaining these watches could
+          exhaust our rate limits with the Google Drive.
+        </p>
+        <p>
+          Disabling this feature means that Jolly Roger will continue to
+          create documents, but will not attempt to monitor them for updates. As
+          a result, we will not be able to display activity data about Google
+          Drive file edits.
+        </p>
+      </CircuitBreakerControl>
+      <CircuitBreakerControl
         title="WebRTC calls"
         flagName="disable.webrtc"
       >

--- a/imports/lib/models/DocumentActivities.ts
+++ b/imports/lib/models/DocumentActivities.ts
@@ -1,0 +1,7 @@
+import { Mongo } from 'meteor/mongo';
+import DocumentActivitiesSchema, { DocumentActivityType } from '../schemas/DocumentActivity';
+
+const DocumentActivities = new Mongo.Collection<DocumentActivityType>('jr_document_activities');
+DocumentActivities.attachSchema(DocumentActivitiesSchema);
+
+export default DocumentActivities;

--- a/imports/lib/models/facade.ts
+++ b/imports/lib/models/facade.ts
@@ -4,6 +4,7 @@ import BlobMappings from './BlobMappings';
 import ChatMessages from './ChatMessages';
 import ChatNotifications from './ChatNotifications';
 import DiscordCache from './DiscordCache';
+import DocumentActivities from './DocumentActivities';
 import Documents from './Documents';
 import FeatureFlags from './FeatureFlags';
 import FolderPermissions from './FolderPermissions';
@@ -35,6 +36,7 @@ const Models = {
   ChatMessages,
   ChatNotifications,
   DiscordCache,
+  DocumentActivities,
   Documents,
   FeatureFlags,
   FolderPermissions,

--- a/imports/lib/schemas/DocumentActivity.ts
+++ b/imports/lib/schemas/DocumentActivity.ts
@@ -1,0 +1,41 @@
+import * as t from 'io-ts';
+import { date } from 'io-ts-types';
+import { Id } from './regexes';
+import { Overrides, buildSchema } from './typedSchemas';
+
+/* DocumentActivityFields doesn't inherit from Base because it's created by the
+   server, not by users */
+export const DocumentActivityCodec = t.type({
+  _id: t.string,
+  ts: date, /* 5 minute granularity */
+  hunt: t.string,
+  puzzle: t.string,
+  document: t.string,
+});
+export type DocumentActivityType = t.TypeOf<typeof DocumentActivityCodec>;
+
+const DocumentActivityOverrides: Overrides<t.TypeOf<typeof DocumentActivityCodec>> = {
+  _id: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  ts: {
+    denyUpdate: true,
+  },
+  hunt: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  puzzle: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  document: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+};
+
+const DocumentActivity = buildSchema(DocumentActivityCodec, DocumentActivityOverrides);
+
+export default DocumentActivity;

--- a/imports/lib/schemas/facade.ts
+++ b/imports/lib/schemas/facade.ts
@@ -5,6 +5,7 @@ import ChatMessage from './ChatMessage';
 import ChatNotification from './ChatNotification';
 import DiscordCache from './DiscordCache';
 import DocumentSchema from './Document';
+import DocumentActivity from './DocumentActivity';
 import FeatureFlag from './FeatureFlag';
 import FolderPermission from './FolderPermission';
 import Guess from './Guess';
@@ -38,6 +39,7 @@ const Schemas = {
   DiscordCache,
   FolderPermission,
   Document: DocumentSchema,
+  DocumentActivity,
   FeatureFlag,
   Guess,
   Hunt,

--- a/imports/server/gdriveDocumentWatcher.ts
+++ b/imports/server/gdriveDocumentWatcher.ts
@@ -1,0 +1,284 @@
+import { Meteor } from 'meteor/meteor';
+import { Random } from 'meteor/random';
+import { WebApp } from 'meteor/webapp';
+import express from 'express';
+import Ansible from '../Ansible';
+import Flags from '../Flags';
+import DocumentActivities from '../lib/models/DocumentActivities';
+import Documents from '../lib/models/Documents';
+import FeatureFlags from '../lib/models/FeatureFlags';
+import DriveClient from './gdriveClientRefresher';
+import ignoringDuplicateKeyErrors from './ignoringDuplicateKeyErrors';
+import DocumentWatches from './models/DocumentWatches';
+import Locks from './models/Locks';
+import { DocumentWatchType } from './schemas/DocumentWatch';
+
+/* expire more quickly in development to minimize requests hitting after server shutdown */
+const EXPIRE_WINDOW = Meteor.isDevelopment ?
+  5 * 60 * 1000 :
+  24 * 60 * 60 * 1000;
+const RENEW_WINDOW = 60 * 1000; // milliseconds
+const ACTIVITY_GRANULARITY = 5 * 60 * 1000; // milliseconds
+const WEBHOOK_PREFIX = '/_gdrive/watch';
+
+// Handle incoming webhooks from Google Drive
+const webhook = express();
+// Express's API is entirely callback-driven, so it doesn't matter if our
+// function is async (it just means that exceptions won't be caught).
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
+webhook.post('/', async (req, res) => {
+  if (req.get('X-Goog-Resource-State') === 'sync') {
+    res.sendStatus(200);
+    return;
+  }
+
+  const documentId = req.get('X-Goog-Channel-Token');
+  if (!documentId) {
+    res.sendStatus(400);
+    return;
+  }
+
+  const document = Documents.findOne(documentId);
+  if (!document) {
+    res.sendStatus(404);
+    return;
+  }
+
+  // Round the current time to the nearest 5 seconds
+  const roundedTime = new Date(
+    Math.round(new Date().getTime() / ACTIVITY_GRANULARITY) * ACTIVITY_GRANULARITY
+  );
+  await ignoringDuplicateKeyErrors(async () => {
+    await DocumentActivities.insertAsync({
+      ts: roundedTime,
+      hunt: document.hunt,
+      puzzle: document.puzzle,
+      document: document._id,
+    });
+  });
+  res.sendStatus(200);
+});
+WebApp.connectHandlers.use(WEBHOOK_PREFIX, Meteor.bindEnvironment(webhook));
+
+// Setup and maintain watches on all Google Drive documents
+class GDriveDocumentWatcher {
+  rootUrl: string;
+
+  watchUrl: string;
+
+  documentWatchTimeouts: Map<string, number>;
+
+  documentObserver: Meteor.LiveQueryHandle;
+
+  documentWatchObserver: Meteor.LiveQueryHandle;
+
+  constructor(rootUrl: string) {
+    this.rootUrl = rootUrl;
+    this.watchUrl = Meteor.absoluteUrl(WEBHOOK_PREFIX, { rootUrl });
+    this.documentWatchTimeouts = new Map();
+
+    this.documentObserver = Documents.find({ provider: 'google' }).observeChanges({
+      added: (id) => {
+        void this.refreshWatch(id);
+      },
+    });
+
+    this.documentWatchObserver = DocumentWatches.find().observe({
+      added: (watch) => {
+        void this.scheduleWatchRefresh(watch._id, watch.watchExpiration, watch.document);
+      },
+      changed: (watch) => {
+        void this.scheduleWatchRefresh(watch._id, watch.watchExpiration, watch.document);
+      },
+      removed: (watch) => {
+        void this.clearWatchRefresh(watch._id);
+      },
+    });
+  }
+
+  stop() {
+    this.documentObserver.stop();
+  }
+
+  scheduleWatchRefresh(id: string, expiration: Date, document: string) {
+    this.clearWatchRefresh(id);
+
+    const now = new Date();
+    // Schedule renewal at least 1/2 of the renewal window before expiration
+    const renewalBuffer = (Math.random() / 2 + 0.5) * RENEW_WINDOW;
+    const timeout = Math.max(
+      0,
+      expiration.getTime() - now.getTime() - renewalBuffer,
+    );
+    this.documentWatchTimeouts.set(id, Meteor.setTimeout(() => {
+      void this.refreshWatch(document);
+    }, timeout));
+  }
+
+  clearWatchRefresh(id: string) {
+    const oldTimeout = this.documentWatchTimeouts.get(id);
+    if (oldTimeout) {
+      Meteor.clearTimeout(oldTimeout);
+      this.documentWatchTimeouts.delete(id);
+    }
+  }
+
+  watchExpired(watch: DocumentWatchType | undefined) {
+    if (!watch) {
+      return true;
+    }
+
+    const now = new Date();
+    return now.getTime() > watch.watchExpiration.getTime() - RENEW_WINDOW;
+  }
+
+  async refreshWatch(id: string) {
+    const preLockWatch = await DocumentWatches.findOneAsync({ document: id });
+    if (!this.watchExpired(preLockWatch)) {
+      return;
+    }
+
+    await Locks.withLock(`document-watch:${id}`, async () => {
+      if (!DriveClient.gdrive) {
+        return;
+      }
+
+      const watch = await DocumentWatches.findOneAsync({ document: id });
+      if (!this.watchExpired(watch)) {
+        return;
+      }
+
+      const document = await Documents.findOneAsync({ _id: id });
+      if (!document) {
+        return;
+      }
+
+      const watchId = Random.id();
+      const watchExpiration = new Date(Date.now() + EXPIRE_WINDOW);
+
+      Ansible.log('Refreshing watch', { document: document.value.id, watchId, watchExpiration });
+      const resp = await DriveClient.gdrive.files.watch({
+        fileId: document.value.id,
+        requestBody: {
+          id: watchId,
+          token: document._id,
+          type: 'webhook',
+          address: this.watchUrl,
+          expiration: watchExpiration.getTime() as any,
+        },
+      });
+
+      const update = {
+        watchId,
+        watchExpiration,
+        watchResourceId: resp.data.resourceId!,
+      };
+      if (watch) {
+        await DocumentWatches.updateAsync(watch._id, {
+          $set: update,
+        });
+      } else {
+        await DocumentWatches.insertAsync({
+          document: id,
+          ...update,
+        });
+      }
+
+      // Clean up the old watch if there was one
+      if (watch) {
+        await DriveClient.gdrive.channels.stop({
+          requestBody: {
+            id: watch.watchId,
+            resourceId: watch.watchResourceId,
+          },
+        });
+      }
+    });
+  }
+}
+
+const NGROK_API_URL = 'http://127.0.0.1:4040';
+
+let warnedAboutWebhooks = false;
+async function discoverWebhookRoot() {
+  const url = Meteor.absoluteUrl();
+  if (!Meteor.isDevelopment) {
+    return url;
+  }
+
+  const parsed = new URL(url);
+  if (parsed.hostname !== 'localhost') {
+    return url;
+  }
+
+  const ngrok = await import('ngrok');
+  const api = new ngrok.NgrokClient(NGROK_API_URL);
+
+  let tunnels;
+  try {
+    tunnels = await api.listTunnels();
+  } catch (e) {
+    if (!warnedAboutWebhooks) {
+      /* eslint-disable no-console */
+      console.warn(e);
+      console.warn();
+      console.warn(
+        'Unable to discover a URL for receiving webhooks. If you want to test incoming Google\n' +
+        'Drive webhooks, then jolly-roger needs to be accessible from the internet. The easiest\n' +
+        'choice is to start ngrok by running "meteor npx ngrok start --none" (we will\n' +
+        'automatically configure the rest).\n' +
+        '\n' +
+        'But if you would prefer to set things up manually, set the ROOT_URL environment\n' +
+        'variable to a publicly accessible URL that routes to this jolly-roger server.'
+      );
+      /* eslint-enable no-console */
+      warnedAboutWebhooks = true;
+    }
+    return undefined;
+  }
+
+  const tunnel = tunnels.tunnels.find((t) => {
+    const parsedTunnel = new URL(t.config.addr);
+    return t.proto === 'https' && parsedTunnel.port === parsed.port;
+  });
+
+  if (tunnel) {
+    return tunnel.public_url;
+  }
+
+  // No tunnel, so we need to try and create one
+  const newTunnel = await api.startTunnel({ name: 'jolly-roger', proto: 'http', addr: url });
+  return newTunnel.public_url;
+}
+
+Meteor.startup(() => {
+  if (Meteor.isTest || Meteor.isAppTest) {
+    return;
+  }
+
+  let watcher: GDriveDocumentWatcher | undefined;
+  let enabledByFeatureFlag = true;
+  const updateWatcher = async () => {
+    const newEnabledByFeatureFlag = !Flags.active('disable.gdrive_watchers');
+    const newRootUrl = await discoverWebhookRoot();
+    const shouldRestart =
+      newRootUrl !== watcher?.rootUrl ||
+      newEnabledByFeatureFlag !== enabledByFeatureFlag;
+    enabledByFeatureFlag = newEnabledByFeatureFlag;
+
+    if (shouldRestart) {
+      watcher?.stop();
+    }
+
+    if (shouldRestart && newRootUrl && enabledByFeatureFlag) {
+      Ansible.log('Starting Google Drive webhooks with public URL', { url: newRootUrl });
+      watcher = new GDriveDocumentWatcher(newRootUrl);
+    }
+  };
+  Meteor.setInterval(updateWatcher, 5 * 1000);
+  FeatureFlags.find({ name: 'disable.gdrive_watchers' }).observe({
+    added: () => { void updateWatcher(); },
+    changed: () => { void updateWatcher(); },
+    removed: () => { void updateWatcher(); },
+  });
+});

--- a/imports/server/migrations/41-document-activities.ts
+++ b/imports/server/migrations/41-document-activities.ts
@@ -1,0 +1,14 @@
+import DocumentActivities from '../../lib/models/DocumentActivities';
+import DocumentWatches from '../models/DocumentWatches';
+import Migrations from './Migrations';
+
+Migrations.add({
+  version: 41,
+  name: 'Add document activities collections and indexes',
+  async up() {
+    await DocumentActivities.createIndexAsync({ hunt: 1 });
+    await DocumentActivities.createIndexAsync({ document: 1, ts: 1 }, { unique: true });
+    await DocumentWatches.createIndexAsync({ document: 1 }, { unique: true });
+    await DocumentWatches.createIndexAsync({ watchId: 1 });
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -39,3 +39,4 @@ import './37-role-reorganization';
 import './38-consolidate-profiles';
 import './39-promote-profiles-to-toplevel';
 import './40-cleanup-celebrations';
+import './41-document-activities';

--- a/imports/server/models/DocumentWatches.ts
+++ b/imports/server/models/DocumentWatches.ts
@@ -1,0 +1,7 @@
+import { Mongo } from 'meteor/mongo';
+import DocumentWatch, { DocumentWatchType } from '../schemas/DocumentWatch';
+
+const DocumentWatches = new Mongo.Collection<DocumentWatchType>('jr_document_watches');
+DocumentWatches.attachSchema(DocumentWatch);
+
+export default DocumentWatches;

--- a/imports/server/schemas/DocumentWatch.ts
+++ b/imports/server/schemas/DocumentWatch.ts
@@ -1,0 +1,32 @@
+import * as t from 'io-ts';
+import { date } from 'io-ts-types';
+import { Id } from '../../lib/schemas/regexes';
+import { Overrides, buildSchema } from '../../lib/schemas/typedSchemas';
+
+export const DocumentWatchCodec = t.type({
+  _id: t.string,
+  document: t.string,
+  watchId: t.string,
+  watchResourceId: t.string,
+  watchExpiration: date,
+});
+
+export type DocumentWatchType = t.TypeOf<typeof DocumentWatchCodec>;
+
+const DocumentWatchOverrides: Overrides<DocumentWatchType> = {
+  _id: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  document: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  watchId: {
+    regEx: Id,
+  },
+};
+
+const DocumentWatch = buildSchema(DocumentWatchCodec, DocumentWatchOverrides);
+
+export default DocumentWatch;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1999,6 +1999,21 @@
         "warning": "^4.0.3"
       }
     },
+    "@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "optional": true
+    },
+    "@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "optional": true,
+      "requires": {
+        "defer-to-connect": "^2.0.0"
+      }
+    },
     "@testing-library/dom": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.19.0.tgz",
@@ -2081,6 +2096,18 @@
         "@types/node": "*"
       }
     },
+    "@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "optional": true,
+      "requires": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
     "@types/chai": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
@@ -2158,6 +2185,12 @@
         "hoist-non-react-statics": "^3.3.0"
       }
     },
+    "@types/http-cache-semantics": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+      "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
+      "optional": true
+    },
     "@types/http-proxy": {
       "version": "1.17.9",
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.9.tgz",
@@ -2193,6 +2226,15 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
+    },
+    "@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/logfmt": {
       "version": "1.2.2",
@@ -2260,8 +2302,7 @@
     "@types/node": {
       "version": "14.18.34",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.34.tgz",
-      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA==",
-      "dev": true
+      "integrity": "sha512-hcU9AIQVHmPnmjRK+XUUYlILlr9pQrsqSrwov/JK1pnf3GTQowVBhx54FbvM0AU/VXGH4i3+vgXS5EguR7fysA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2364,6 +2405,15 @@
         "@types/react": "*"
       }
     },
+    "@types/responselike": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+      "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
@@ -2457,7 +2507,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==",
-      "dev": true,
       "optional": true,
       "requires": {
         "@types/node": "*"
@@ -3673,8 +3722,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -3685,6 +3733,27 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
+    },
+    "cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "optional": true
+    },
+    "cacheable-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.2.tgz",
+      "integrity": "sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==",
+      "optional": true,
+      "requires": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      }
     },
     "call-bind": {
       "version": "1.0.2",
@@ -3818,6 +3887,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
       "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+    },
+    "clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "optional": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
     },
     "color-convert": {
       "version": "2.0.1",
@@ -4032,6 +4110,23 @@
         }
       }
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "optional": true,
+      "requires": {
+        "mimic-response": "^3.1.0"
+      },
+      "dependencies": {
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+          "optional": true
+        }
+      }
+    },
     "deep-eql": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.2.tgz",
@@ -4119,6 +4214,12 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
+    },
+    "defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "optional": true
     },
     "define-lazy-prop": {
       "version": "2.0.0",
@@ -4271,7 +4372,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -5761,7 +5861,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
       "requires": {
         "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
@@ -5850,7 +5949,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
       "requires": {
         "pend": "~1.2.0"
       }
@@ -6079,7 +6177,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -6320,6 +6417,25 @@
         }
       }
     },
+    "got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "optional": true,
+      "requires": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -6442,11 +6558,23 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
+    "hpagent": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-0.1.2.tgz",
+      "integrity": "sha512-ePqFXHtSQWAFXYmj+JtOTHr84iNrII4/QRlAAPPE+zqnKy4xJo7Ie1Y4kC7AdB+LxLxSTTzBMASsEcy0q8YyvQ==",
+      "optional": true
+    },
     "html-tags": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
       "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
       "dev": true
+    },
+    "http-cache-semantics": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+      "optional": true
     },
     "http-errors": {
       "version": "2.0.0",
@@ -6468,6 +6596,24 @@
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
+      }
+    },
+    "http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "optional": true,
+      "requires": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "dependencies": {
+        "quick-lru": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+          "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+          "optional": true
+        }
       }
     },
     "https-proxy-agent": {
@@ -6898,6 +7044,12 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "optional": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -7115,6 +7267,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "keyv": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+      "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+      "optional": true,
+      "requires": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -7244,6 +7405,12 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "optional": true
+    },
     "lodash.isfinite": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
@@ -7344,6 +7511,12 @@
       "requires": {
         "get-func-name": "^2.0.0"
       }
+    },
+    "lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "optional": true
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -8369,6 +8542,12 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "optional": true
+    },
     "min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -8655,6 +8834,35 @@
       "resolved": "https://registry.npmjs.org/newtype-ts/-/newtype-ts-0.3.5.tgz",
       "integrity": "sha512-v83UEQMlVR75yf1OUdoSFssjitxzjZlqBAjiGQ4WJaML8Jdc68LJ+BaSAXUmKY4bNzp7hygkKLYTsDi14PxI2g=="
     },
+    "ngrok": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/ngrok/-/ngrok-4.3.3.tgz",
+      "integrity": "sha512-a2KApnkiG5urRxBPdDf76nNBQTnNNWXU0nXw0SsqsPI+Kmt2lGf9TdVYpYrHMnC+T9KhcNSWjCpWqBgC6QcFvw==",
+      "optional": true,
+      "requires": {
+        "@types/node": "^8.10.50",
+        "extract-zip": "^2.0.1",
+        "got": "^11.8.5",
+        "hpagent": "^0.1.2",
+        "lodash.clonedeep": "^4.5.0",
+        "uuid": "^7.0.0 || ^8.0.0",
+        "yaml": "^1.10.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "8.10.66",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+          "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
+          "optional": true
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "optional": true
+        }
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -8712,6 +8920,12 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
+    },
+    "normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "optional": true
     },
     "npm-run-all": {
       "version": "4.1.5",
@@ -9362,6 +9576,12 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "optional": true
+    },
     "p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -9451,8 +9671,7 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "picocolors": {
       "version": "1.0.0",
@@ -9624,7 +9843,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -10116,10 +10334,25 @@
         "path-parse": "^1.0.6"
       }
     },
+    "resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "optional": true
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "optional": true,
+      "requires": {
+        "lowercase-keys": "^2.0.0"
+      }
     },
     "reusify": {
       "version": "1.0.4",
@@ -11616,7 +11849,6 @@
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
     "styled-components": "^5.3.6",
     "use-persisted-state": "^0.3.3"
   },
+  "optionalDependencies": {
+    "ngrok": "^4.3.3"
+  },
   "devDependencies": {
     "@testing-library/react": "^13.4.0",
     "@types/chai": "^4.3.4",

--- a/server/main.ts
+++ b/server/main.ts
@@ -19,6 +19,7 @@ import '../imports/server/sendChatMessageInternal';
 import '../imports/server/chat-notifications';
 import '../imports/server/discord';
 import '../imports/server/discordClientRefresher';
+import '../imports/server/gdriveDocumentWatcher';
 import '../imports/server/guesses';
 import '../imports/server/assets';
 import '../imports/server/browserconfig';

--- a/types/ngrok.d.ts
+++ b/types/ngrok.d.ts
@@ -1,0 +1,10 @@
+declare module 'ngrok' {
+  namespace Ngrok {
+    interface Tunnel {
+      config: {
+        addr: string;
+        inspect: boolean;
+      }
+    }
+  }
+}


### PR DESCRIPTION
This uses the Google Drive API's `files.watch` API method to receive webhooks when changes are made to a document. We setup a watch on every document in the database and handle renewing it as necessary.

When we're notified by Google that a document has been changed, we store a record in the database - effectively a tuple of `(timestamp, document)`. Absence of a record indicates lack of activity.

Google's notifications aren't especially timely - in practice they seem to send notifications at about 3 minute granularity - so we use 5 minute granularity for our own tracking. It's a nice round number, and pretty well approximates the granularity of the notifications.

Activity records are currently never garbage collected. This should be safe because generally puzzles don't see constant activity over the course of a hunt - e.g. in 2022, puzzles were open for an average of 5 hours. Assuming perfect density, that's a total of roughly 12,000 records - not nothing, but not completely unmanageable. We can always revisit in the future and add a expiration index if needed.

Since we're now asking an external service to reach out to us, we need some way of addressing the server from the internet. In production, this is easy. In development, if Meteor otherwise only knows itself to be accessible over localhost, we attempt to integrate with ngrok to setup a tunnel.

This commit only wires up collection of activity data; serving that to clients and displaying it in a useful way is left as an exercise for the reader (or more likely, me).

As it's written, I think this fixes #107, although arguably that's a bit of a cop-out given lack of any display of the data.