### PR TITLE
Guess Improvements: Round 1

### DIFF
--- a/imports/FixtureHunt.ts
+++ b/imports/FixtureHunt.ts
@@ -6,7 +6,7 @@ import { TagType } from './lib/schemas/Tag';
 type FixtureHuntType = Pick<HuntType, '_id' | 'name'> & {
   tags: Pick<TagType, '_id' | 'name'>[];
   puzzles: (Pick< PuzzleType, '_id' | 'title' | 'url' | 'expectedAnswerCount' | 'tags'> & {
-    guesses: Pick<GuessType, '_id' | 'guess' | 'state'>[];
+    guesses: (Pick<GuessType, '_id' | 'guess' | 'state'> & { additionalNotes?: string })[];
   })[];
 };
 
@@ -103,6 +103,12 @@ const FixtureHunt: FixtureHuntType = {
       expectedAnswerCount: 1,
       tags: ['o5JdfTizW4tGwhRnP', 'QeJLufdCqv7rMSSbS'],
       guesses: [
+        {
+          _id: 'yHtJYeqdmGkgCCcCL',
+          guess: 'TAPE YOUR HEEL TURN',
+          state: 'intermediate',
+          additionalNotes: 'Please upload your file to https://upload.head-hunters.org/.',
+        },
         { _id: 'wBik5mReoQMAhS6aX', guess: 'ERIC ANGLE', state: 'correct' },
       ],
     },
@@ -542,6 +548,12 @@ const FixtureHunt: FixtureHuntType = {
       expectedAnswerCount: 1,
       tags: ['nPbTi6DPvjAkot94n'],
       guesses: [
+        {
+          _id: 'kfeD2uWtGfCns5uoB',
+          guess: "NOW SOLVE TODAY'S LISTENER",
+          state: 'intermediate',
+          additionalNotes: 'The Listener can be found at http://www.listenercrossword.com/Solutions/S2018/Notes_4485.html',
+        },
         { _id: 'ukBCpRvEYNtmADDgX', guess: 'WHOOPEE', state: 'correct' },
       ],
     },
@@ -660,6 +672,12 @@ const FixtureHunt: FixtureHuntType = {
       expectedAnswerCount: 1,
       tags: ['nPbTi6DPvjAkot94n'],
       guesses: [
+        {
+          _id: 'v8fxXBfvn3HdXpNrZ',
+          guess: 'WE WANT A MOCKTAIL',
+          state: 'intermediate',
+          additionalNotes: 'Please bring your beverage to 66-100, and be prepared to tell them your team and the instruction that brought you here.',
+        },
         { _id: 'fN4zRHuk2xJkq6Wcr', guess: 'DIRTY MARTINI', state: 'correct' },
       ],
     },
@@ -879,6 +897,18 @@ const FixtureHunt: FixtureHuntType = {
       tags: ['PWZZge8id26rPH8t9', '9RDaMHxkZSJFezo6r'],
       guesses: [
         {
+          _id: 'zQf7his5HcxmesfC6',
+          guess: "DON'T BRUSH US OFF",
+          state: 'intermediate',
+          additionalNotes: 'Please come to 66-110 to pick up your item. Make sure to knock, and don’t come in until we let you in. Be prepared to say what team you’re with and the request that you submitted.',
+        },
+        {
+          _id: 'eaWNnnySz8kqDwcXu',
+          guess: 'MAKE A TIFO AND HOIST FOR HQ',
+          state: 'intermediate',
+          additionalNotes: 'Please upload your file to https://upload.head-hunters.org/.',
+        },
+        {
           _id: 'jtTXcz8QXJfJYvzNx',
           guess: 'CONFINED AQUIFER',
           state: 'correct',
@@ -892,6 +922,12 @@ const FixtureHunt: FixtureHuntType = {
       expectedAnswerCount: 1,
       tags: ['PWZZge8id26rPH8t9', '9RDaMHxkZSJFezo6r'],
       guesses: [
+        {
+          _id: 'tcTAgnRefAKGtWBGC',
+          guess: 'SQUARE POINTS',
+          state: 'intermediate',
+          additionalNotes: 'Please come to 66-110 to pick up your item. Make sure to knock, and don’t come in until we let you in. Be prepared to say what team you’re with and the request that you submitted.',
+        },
         { _id: '9KtYfxo7dG2fNkEdy', guess: 'THREE POUNDER', state: 'correct' },
       ],
     },

--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -7,6 +7,7 @@ import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
 import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
 import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
 import { faEraser } from '@fortawesome/free-solid-svg-icons/faEraser';
+import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclamationCircle';
 import { faForward } from '@fortawesome/free-solid-svg-icons/faForward';
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
 import { faSkullCrossbones } from '@fortawesome/free-solid-svg-icons/faSkullCrossbones';
@@ -36,6 +37,7 @@ import setGuessState from '../../methods/setGuessState';
 import { guessURL } from '../../model-helpers';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 import useSubscribeDisplayNames from '../hooks/useSubscribeDisplayNames';
+import markdown from '../markdown';
 import PuzzleAnswer from './PuzzleAnswer';
 import Breakable from './styling/Breakable';
 import { NavBarHeight } from './styling/constants';
@@ -83,6 +85,8 @@ const StyledRow = styled.div<{ $state: GuessType['state'] }>`
     switch (props.$state) {
       case 'correct':
         return '#f0fff0';
+      case 'intermediate':
+        return '#fffff0';
       case 'incorrect':
         return '#fff0f0';
       case 'rejected':
@@ -101,6 +105,8 @@ const StyledRow = styled.div<{ $state: GuessType['state'] }>`
     switch (props.$state) {
       case 'correct':
         return '#d0ffd0';
+      case 'intermediate':
+        return '#ffffd0';
       case 'incorrect':
         return '#ffd0d0';
       case 'rejected':
@@ -210,6 +216,11 @@ const StyledTooltipCompact = styled.span`
   `)}
 `;
 
+const StyledAdditionalNotes = styled(StyledCell)`
+  grid-column: 1 / -1;
+  overflow: hidden;
+`;
+
 const GuessBlock = React.memo(({
   canEdit, hunt, guess, createdByDisplayName, puzzle,
 }: {
@@ -265,6 +276,15 @@ const GuessBlock = React.memo(({
           <FontAwesomeIcon icon={faCheckCircle} color="#00ff00" fixedWidth />
           {' '}
           Correct
+        </>
+      );
+      break;
+    case 'intermediate':
+      displayState = (
+        <>
+          <FontAwesomeIcon icon={faExclamationCircle} color="#dddd00" fixedWidth />
+          {' '}
+          Intermediate answer
         </>
       );
       break;
@@ -383,6 +403,11 @@ const GuessBlock = React.memo(({
           <Button variant="outline-secondary" size="sm" onClick={markPending}>Return to queue</Button>
         )}
       </StyledCell>
+      {guess.additionalNotes && (
+        <StyledAdditionalNotes
+          dangerouslySetInnerHTML={{ __html: markdown(guess.additionalNotes) }}
+        />
+      )}
     </StyledRow>
   );
 });

--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -1,15 +1,28 @@
 /* eslint-disable max-len */
 import { Meteor } from 'meteor/meteor';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
+import { faBackward } from '@fortawesome/free-solid-svg-icons/faBackward';
+import { faBan } from '@fortawesome/free-solid-svg-icons/faBan';
+import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
+import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
+import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
 import { faEraser } from '@fortawesome/free-solid-svg-icons/faEraser';
+import { faForward } from '@fortawesome/free-solid-svg-icons/faForward';
+import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
+import { faSkullCrossbones } from '@fortawesome/free-solid-svg-icons/faSkullCrossbones';
+import { faTimesCircle } from '@fortawesome/free-solid-svg-icons/faTimesCircle';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { useCallback, useEffect, useRef } from 'react';
 import Button from 'react-bootstrap/Button';
 import FormControl, { FormControlProps } from 'react-bootstrap/FormControl';
 import FormGroup from 'react-bootstrap/FormGroup';
 import InputGroup from 'react-bootstrap/InputGroup';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+import CopyToClipboard from 'react-copy-to-clipboard';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import styled, { css } from 'styled-components';
+import { calendarTimeFormat } from '../../lib/calendarTimeFormat';
 import { indexedById } from '../../lib/listUtils';
 import Guesses from '../../lib/models/Guesses';
 import Hunts from '../../lib/models/Hunts';
@@ -23,35 +36,50 @@ import setGuessState from '../../methods/setGuessState';
 import { guessURL } from '../../model-helpers';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 import useSubscribeDisplayNames from '../hooks/useSubscribeDisplayNames';
+import PuzzleAnswer from './PuzzleAnswer';
 import Breakable from './styling/Breakable';
+import { NavBarHeight } from './styling/constants';
+import { Breakpoint, mediaBreakpointDown } from './styling/responsive';
 
-const AutoSelectInput = ({ value }: { value: string }) => {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const onFocus = useCallback(() => {
-    // Use the selection API to select the contents of this, for easier clipboarding.
-    if (inputRef.current) {
-      inputRef.current.select();
-    }
-  }, []);
+const compactViewBreakpoint: Breakpoint = 'lg';
 
-  return (
-    <input
-      ref={inputRef}
-      readOnly
-      value={value}
-      onFocus={onFocus}
-    />
-  );
-};
+const StyledTable = styled.div`
+  display: grid;
+  grid-template-columns:
+    [timestamp] auto
+    [submitter] auto
+    [puzzle] auto
+    [answer] auto
+    [direction] minmax(200px, auto)
+    [confidence] minmax(200px, auto)
+    [status] auto
+    [actions] auto;
+  ${mediaBreakpointDown(compactViewBreakpoint, css`
+    grid-template-columns: auto;
+  `)}
+`;
 
-const daysOfWeek = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+const StyledHeaderRow = styled.div`
+  display: contents;
+`;
 
-const StyledGuessBlock = styled.div<{ $state: GuessType['state'] }>`
+const StyledHeader = styled.div`
+  position: sticky;
+  top: ${NavBarHeight};
+  background-color: white;
+  font-weight: bold;
+  ${mediaBreakpointDown(compactViewBreakpoint, css`
+    display: none;
+  `)}
+`;
+
+const StyledRow = styled.div<{ $state: GuessType['state'] }>`
+  display: contents;
   margin-bottom: 8px;
-  display: flex;
-  flex-direction: row;
-  background-color:
-    ${(props) => {
+
+  * {
+    background-color:
+      ${(props) => {
     switch (props.$state) {
       case 'correct':
         return '#f0fff0';
@@ -65,63 +93,122 @@ const StyledGuessBlock = styled.div<{ $state: GuessType['state'] }>`
         return '#fff';
     }
   }};
+  }
+
+  :hover * {
+    background-color:
+      ${(props) => {
+    switch (props.$state) {
+      case 'correct':
+        return '#d0ffd0';
+      case 'incorrect':
+        return '#ffd0d0';
+      case 'rejected':
+        return '#d0d0d0';
+      case 'pending':
+        return '#d0d0ff';
+      default:
+        return '#fff';
+    }
+  }};
+  }
 `;
 
-const StyledGuessInfo = styled.div`
-  flex: 1 0 50%;
-  overflow-x: hidden;
+const StyledCell = styled.div`
+  padding: 4px;
 `;
 
-const StyledGuessButtonGroup = styled.div`
-  flex: 0 1 330px;
-  display: flex;
-  flex-flow: row wrap;
-  align-items: stretch;
-  justify-content: space-between;
+const StyledLinkButton = styled(Button)`
   padding: 0;
+  vertical-align: baseline;
 `;
 
-const StyledGuessButton = styled.button`
-  flex: 1 1 72px;
-  border-radius: 5px;
-  margin: 4px;
-  border: 0;
-  background-color: transparent;
+const StyledPuzzleTimestampAndSubmitter = styled.div`
+  display: contents;
+  ${mediaBreakpointDown(compactViewBreakpoint, css`
+    padding: 4px;
+    display: flex;
+    & > * {
+      padding: 0;
+    }
+  `)}
 `;
 
-const StyledGuessButtonCorrect = styled(StyledGuessButton)`
-  ${(props) => !props.disabled && css`
-    border: 1px solid #00ff00;
-    background-color: #f0fff0;
-  `}
+const StyledPuzzleTimestamp = styled(StyledCell)`
+  ${mediaBreakpointDown(compactViewBreakpoint, css`
+    ::after {
+      content: " submitted by ";
+      white-space: pre;
+    }
+  `)}
 `;
 
-const StyledGuessButtonIncorrect = styled(StyledGuessButton)`
-  ${(props) => !props.disabled && css`
-    border: 1px solid #ff0000;
-    background-color: #fff0f0;
-  `}
+const StyledPuzzleCell = styled(StyledCell)`
+  display: flex;
+  align-items: start;
+  ${mediaBreakpointDown(compactViewBreakpoint, css`
+    &::before {
+      content: "Puzzle: ";
+      white-space: pre;
+    }
+  `)}
 `;
 
-const StyledGuessButtonRejected = styled(StyledGuessButton)`
-  ${(props) => !props.disabled && css`
-    border: 1px solid #000000;
-    background-color: #f0f0f0;
-  `}
+const StyledGuessCell = styled(StyledCell)`
+  display: flex;
+  align-items: start;
+  ${mediaBreakpointDown(compactViewBreakpoint, css`
+    &::before {
+      content: "Guess: ";
+      white-space: pre;
+    }
+  `)}
 `;
 
-const StyledGuessButtonPending = styled(StyledGuessButton)`
-  ${(props) => !props.disabled && css`
-    border: 1px solid #0000ff;
-    background-color: #f0f0ff;
-  `}
+const StyledGuessSliders = styled.div`
+  display: contents;
+  ${mediaBreakpointDown(compactViewBreakpoint, css`
+    display: flex;
+  `)}
 `;
 
-const formatDate = (date: Date) => {
-  // We only care about days in so far as which day of hunt this guess was submitted on
-  const day = daysOfWeek[date.getDay()];
-  return `${date.toLocaleTimeString()} on ${day}`;
-};
+const StyledGuessSliderCell = styled(StyledCell)`
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+`;
+
+const StyledGuessSliderWithLabel = styled(StyledCell)`
+  display: contents;
+  ${mediaBreakpointDown(compactViewBreakpoint, css`
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    flex-grow: 1;
+  `)}
+`;
+
+const StyledGuessSliderLabel = styled.span`
+  display: none;
+  ${mediaBreakpointDown(compactViewBreakpoint, css`
+    display: inline;
+  `)}
+`;
+
+const StyledSlider = styled.input`
+  ${mediaBreakpointDown(compactViewBreakpoint, css`
+    width: 1px;
+    flex-grow: 1;
+  `)}
+`;
+
+const StyledTooltipCompact = styled.span`
+  display: none;
+  white-space: pre;
+  ${mediaBreakpointDown(compactViewBreakpoint, css`
+    display: inline;
+  `)}
+`;
 
 const GuessBlock = React.memo(({
   canEdit, hunt, guess, createdByDisplayName, puzzle,
@@ -136,55 +223,167 @@ const GuessBlock = React.memo(({
     setGuessState.call({ guessId: guess._id, state: 'pending' });
   }, [guess._id]);
 
-  const markCorrect = useCallback(() => {
-    setGuessState.call({ guessId: guess._id, state: 'correct' });
-  }, [guess._id]);
-
-  const markIncorrect = useCallback(() => {
-    setGuessState.call({ guessId: guess._id, state: 'incorrect' });
-  }, [guess._id]);
-
-  const markRejected = useCallback(() => {
-    setGuessState.call({ guessId: guess._id, state: 'rejected' });
-  }, [guess._id]);
-
-  const timestamp = formatDate(guess.createdAt);
-  const guessButtons = (
-    <StyledGuessButtonGroup>
-      <StyledGuessButtonCorrect onClick={markCorrect} disabled={guess.state === 'correct'}>Correct</StyledGuessButtonCorrect>
-      <StyledGuessButtonIncorrect onClick={markIncorrect} disabled={guess.state === 'incorrect'}>Incorrect</StyledGuessButtonIncorrect>
-      <StyledGuessButtonRejected onClick={markRejected} disabled={guess.state === 'rejected'}>Rejected</StyledGuessButtonRejected>
-      <StyledGuessButtonPending onClick={markPending} disabled={guess.state === 'pending'}>Pending</StyledGuessButtonPending>
-    </StyledGuessButtonGroup>
+  const puzzleTooltip = (
+    <Tooltip id={`guess-${guess._id}-puzzle-tooltip`}>
+      Open puzzle
+    </Tooltip>
+  );
+  const discussionTooltip = (
+    <Tooltip id={`guess-${guess._id}-discussion-tooltip`}>
+      Open Jolly Roger discussion
+    </Tooltip>
+  );
+  const copyTooltip = (
+    <Tooltip id={`guess-${guess._id}-copy-tooltip`}>
+      Copy to clipboard
+    </Tooltip>
+  );
+  const directionTooltip = (
+    <Tooltip id={`guess-${guess._id}-direction-tooltip`}>
+      <StyledTooltipCompact>
+        Solve direction:
+        {' '}
+      </StyledTooltipCompact>
+      {guess.direction}
+    </Tooltip>
+  );
+  const confidenceTooltip = (
+    <Tooltip id={`guess-${guess._id}-confidence-tooltip`}>
+      <StyledTooltipCompact>
+        Confidence:
+        {' '}
+      </StyledTooltipCompact>
+      {guess.confidence}
+    </Tooltip>
   );
 
+  let displayState;
+  switch (guess.state) {
+    case 'correct':
+      displayState = (
+        <>
+          <FontAwesomeIcon icon={faCheckCircle} color="#00ff00" fixedWidth />
+          {' '}
+          Correct
+        </>
+      );
+      break;
+    case 'incorrect':
+      displayState = (
+        <>
+          <FontAwesomeIcon icon={faTimesCircle} color="#ff0000" fixedWidth />
+          {' '}
+          Incorrect
+        </>
+      );
+      break;
+    case 'rejected':
+      displayState = (
+        <>
+          <FontAwesomeIcon icon={faBan} color="#000000" fixedWidth />
+          {' '}
+          Rejected
+        </>
+      );
+      break;
+    case 'pending':
+      displayState = (
+        <>
+          <FontAwesomeIcon icon={faClock} color="#0000ff" fixedWidth />
+          {' '}
+          Pending
+        </>
+      );
+      break;
+    default:
+      displayState = 'unknown';
+  }
+
   return (
-    <StyledGuessBlock $state={guess.state}>
-      <StyledGuessInfo>
-        <div>
-          {timestamp}
-          {' from '}
-          <Breakable>{createdByDisplayName || '<no name given>'}</Breakable>
-        </div>
-        <div>
-          {'Puzzle: '}
-          <a href={guessURL(hunt, puzzle)} target="_blank" rel="noopener noreferrer">{puzzle.title}</a>
-          {' ('}
-          <Link to={`/hunts/${puzzle.hunt}/puzzles/${puzzle._id}`}>discussion</Link>
-          )
-        </div>
-        <div>
-          {'Solve direction: '}
-          {guess.direction}
-        </div>
-        <div>
-          {'Confidence: '}
-          {guess.confidence}
-        </div>
-        <div><AutoSelectInput value={guess.guess} /></div>
-      </StyledGuessInfo>
-      {canEdit ? guessButtons : <StyledGuessButtonGroup>{guess.state}</StyledGuessButtonGroup>}
-    </StyledGuessBlock>
+    <StyledRow $state={guess.state}>
+      <StyledPuzzleTimestampAndSubmitter>
+        <StyledPuzzleTimestamp>{calendarTimeFormat(guess.createdAt)}</StyledPuzzleTimestamp>
+        <StyledCell><Breakable>{createdByDisplayName}</Breakable></StyledCell>
+      </StyledPuzzleTimestampAndSubmitter>
+      <StyledPuzzleCell>
+        <OverlayTrigger placement="top" overlay={puzzleTooltip}>
+          <a href={guessURL(hunt, puzzle)} target="_blank" rel="noopener noreferrer">
+            <FontAwesomeIcon icon={faPuzzlePiece} fixedWidth />
+          </a>
+        </OverlayTrigger>
+        {' '}
+        <OverlayTrigger placement="top" overlay={discussionTooltip}>
+          <Link to={`/hunts/${puzzle.hunt}/puzzles/${puzzle._id}`}>
+            <FontAwesomeIcon icon={faSkullCrossbones} fixedWidth />
+          </Link>
+        </OverlayTrigger>
+        {' '}
+        {puzzle.title}
+      </StyledPuzzleCell>
+      <StyledGuessCell>
+        <OverlayTrigger placement="top" overlay={copyTooltip}>
+          {({ ref, ...triggerHandler }) => (
+            <CopyToClipboard text={guess.guess} {...triggerHandler}>
+              <StyledLinkButton ref={ref} variant="link" aria-label="Copy">
+                <FontAwesomeIcon icon={faCopy} fixedWidth />
+              </StyledLinkButton>
+            </CopyToClipboard>
+          )}
+        </OverlayTrigger>
+        {' '}
+        <PuzzleAnswer answer={guess.guess} />
+      </StyledGuessCell>
+      <StyledGuessSliders>
+        <StyledGuessSliderWithLabel>
+          <StyledGuessSliderLabel>
+            Solve direction
+          </StyledGuessSliderLabel>
+          <OverlayTrigger placement="top" overlay={directionTooltip}>
+            <StyledGuessSliderCell>
+              <FontAwesomeIcon icon={faBackward} fixedWidth />
+              {' '}
+              <StyledSlider type="range" min="-10" max="10" value={guess.direction} disabled list={`guess-${guess._id}-direction-data`} />
+              <datalist id={`guess-${guess._id}-direction-data`}>
+                <option value="-10">-10</option>
+                <option value="0">0</option>
+                <option value="10">10</option>
+              </datalist>
+              {' '}
+              <FontAwesomeIcon icon={faForward} fixedWidth />
+            </StyledGuessSliderCell>
+          </OverlayTrigger>
+        </StyledGuessSliderWithLabel>
+        <StyledGuessSliderWithLabel>
+          <StyledGuessSliderLabel>
+            Confidence
+          </StyledGuessSliderLabel>
+          <OverlayTrigger placement="top" overlay={confidenceTooltip}>
+            <StyledGuessSliderCell>
+              0%
+              {' '}
+              <StyledSlider type="range" min="0" max="100" value={guess.confidence} disabled list={`guess-${guess._id}-confidence-data`} />
+              <datalist id={`guess-${guess._id}-confidence-data`}>
+                <option value="0">0%</option>
+                <option value="25">25%</option>
+                <option value="50">50%</option>
+                <option value="75">75%</option>
+                <option value="100">100%</option>
+              </datalist>
+              {' '}
+              100%
+            </StyledGuessSliderCell>
+          </OverlayTrigger>
+        </StyledGuessSliderWithLabel>
+      </StyledGuessSliders>
+      <StyledCell>
+        {displayState}
+      </StyledCell>
+      <StyledCell>
+        {canEdit && guess.state !== 'pending' && (
+          <Button variant="outline-secondary" size="sm" onClick={markPending}>Return to queue</Button>
+        )}
+      </StyledCell>
+    </StyledRow>
   );
 });
 
@@ -286,6 +485,17 @@ const GuessQueuePage = () => {
     return <div>loading...</div>;
   }
 
+  const directionTooltip = (
+    <Tooltip id="direction-tooltip">
+      Direction this puzzle was solved, ranging from completely backsolved (-10) to completely forward solved (10)
+    </Tooltip>
+  );
+  const confidenceTooltip = (
+    <Tooltip id="confidence-tooltip">
+      Submitter-estimated likelihood that this answer is correct
+    </Tooltip>
+  );
+
   return (
     <div>
       <h1>Guess queue</h1>
@@ -305,18 +515,38 @@ const GuessQueuePage = () => {
           </Button>
         </InputGroup>
       </FormGroup>
-      {filteredGuesses(guesses).map((guess) => {
-        return (
-          <GuessBlock
-            key={guess._id}
-            hunt={hunt}
-            guess={guess}
-            createdByDisplayName={displayNames[guess.createdBy] ?? '???'}
-            puzzle={puzzles.get(guess.puzzle)!}
-            canEdit={canEdit}
-          />
-        );
-      })}
+      <StyledTable>
+        <StyledHeaderRow>
+          <StyledHeader>Time</StyledHeader>
+          <StyledHeader>Submitter</StyledHeader>
+          <StyledHeader>Puzzle</StyledHeader>
+          <StyledHeader>Answer</StyledHeader>
+          <OverlayTrigger placement="top" overlay={directionTooltip}>
+            <StyledHeader>
+              Direction
+            </StyledHeader>
+          </OverlayTrigger>
+          <OverlayTrigger placement="top" overlay={confidenceTooltip}>
+            <StyledHeader>
+              Confidence
+            </StyledHeader>
+          </OverlayTrigger>
+          <StyledHeader>Status</StyledHeader>
+          <StyledHeader>&nbsp;</StyledHeader>
+        </StyledHeaderRow>
+        {filteredGuesses(guesses).map((guess) => {
+          return (
+            <GuessBlock
+              key={guess._id}
+              hunt={hunt}
+              guess={guess}
+              createdByDisplayName={displayNames[guess.createdBy] ?? '???'}
+              puzzle={puzzles.get(guess.puzzle)!}
+              canEdit={canEdit}
+            />
+          );
+        })}
+      </StyledTable>
     </div>
   );
 };

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -489,7 +489,7 @@ const NotificationCenter = () => {
 
   const [hideDiscordSetupMessage, setHideDiscordSetupMessage] = useState<boolean>(false);
   const [hideProfileSetupMessage, setHideProfileSetupMessage] = useState<boolean>(false);
-  const [dismissedGuesses, setDismissedGuesses] = useState<Record<string, boolean>>({});
+  const [dismissedGuesses, setDismissedGuesses] = useState<Record<string, Date>>({});
 
   const onHideDiscordSetupMessage = useCallback(() => {
     setHideDiscordSetupMessage(true);
@@ -501,8 +501,8 @@ const NotificationCenter = () => {
 
   const dismissGuess = useCallback((guessId: string) => {
     setDismissedGuesses((prevDismissedGuesses) => {
-      const newState: Record<string, boolean> = {};
-      newState[guessId] = true;
+      const newState: Record<string, Date> = {};
+      newState[guessId] = new Date();
       Object.assign(newState, prevDismissedGuesses);
       return newState;
     });
@@ -529,7 +529,8 @@ const NotificationCenter = () => {
   }
 
   guesses.forEach((g) => {
-    if (dismissedGuesses[g._id]) return;
+    const dismissedAt = dismissedGuesses[g._id];
+    if (dismissedAt && dismissedAt > (g.updatedAt ?? g.createdAt)) return;
     if (operatorActionsHidden[g.hunt]) return;
     messages.push(<GuessMessage
       key={g._id}

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -1026,12 +1026,23 @@ const PuzzleGuessModal = React.forwardRef(({
           <tbody>
             {sortedBy(guesses, (g) => g.createdAt).reverse().map((guess) => {
               return (
-                <tr key={guess._id}>
-                  <AnswerTableCell>{guess.guess}</AnswerTableCell>
-                  <td>{calendarTimeFormat(guess.createdAt)}</td>
-                  <td>{displayNames[guess.createdBy]}</td>
-                  <td style={{ textTransform: 'capitalize' }}>{guess.state}</td>
-                </tr>
+                <>
+                  <tr key={guess._id}>
+                    <AnswerTableCell>{guess.guess}</AnswerTableCell>
+                    <td>{calendarTimeFormat(guess.createdAt)}</td>
+                    <td>{displayNames[guess.createdBy]}</td>
+                    <td style={{ textTransform: 'capitalize' }}>{guess.state}</td>
+                  </tr>
+                  {guess.additionalNotes && (
+                    <tr key={`${guess._id}-notes`}>
+                      <td
+                        colSpan={4}
+                        // eslint-disable-next-line react/no-danger
+                        dangerouslySetInnerHTML={{ __html: markdown(guess.additionalNotes) }}
+                      />
+                    </tr>
+                  )}
+                </>
               );
             })}
           </tbody>

--- a/imports/lib/schemas/Guess.ts
+++ b/imports/lib/schemas/Guess.ts
@@ -19,11 +19,23 @@ const GuessFields = t.type({
   confidence: t.union([t.Int, t.undefined]),
   // The state of this guess, as handled by the operators:
   // * 'pending' means "shows up in the operator queue"
-  // * 'correct', "incorrect", and "rejected" all mean "no longer in the operator queue"
-  // * 'incorrect' answers should be listed or at least discoverable on the puzzle page
+  // * "intermediate", "correct", "incorrect", and "rejected" all mean "no longer in the operator
+  //   queue"
+  // * 'incorrect' and 'intermediate' answers should be listed or at least discoverable on the
+  //   puzzle page
   // * 'correct' answers should be accompanied by an update to the corresponding puzzle's answer
   //   field.
-  state: t.union([t.literal('pending'), t.literal('correct'), t.literal('incorrect'), t.literal('rejected')]),
+  state: t.union([
+    t.literal('pending'),
+    t.literal('intermediate'),
+    t.literal('correct'),
+    t.literal('incorrect'),
+    t.literal('rejected'),
+  ]),
+  // Additional notes can be used by the operator either for sharing (e.g.)
+  // additional information received from the puzzle (e.g. for an intermediate
+  // instruction) or why a guess was rejected.
+  additionalNotes: t.union([t.string, t.undefined]),
 });
 
 const GuessFieldsOverrides: Overrides<t.TypeOf<typeof GuessFields>> = {

--- a/imports/server/methods/createFixtureHunt.ts
+++ b/imports/server/methods/createFixtureHunt.ts
@@ -66,6 +66,7 @@ createFixtureHunt.define({
             state: g.state,
             direction: 10,
             confidence: 100,
+            additionalNotes: g.additionalNotes,
           },
         });
       });


### PR DESCRIPTION
First round of improvements to the guess state machine.

The eventual goals are:

- Allowing guesses to have an "intermediate" state (short for "correct intermediate answer"). This state can be used when we receive a cluephrase or instruction that has been validated by HQ; we know it's correct, but it's not a solution to the puzzle. (Re: #231)
- Allowing guesses to capture additional notes from the operator beyond state. This is useful for intermediate answers to capture any additional instructions we receive from HQ ("send your video here" - we'll add some examples to the fixture data) and for rejections to capture why the operator rejected the answer.
- Allowing operators to modify the spacing of a guess, in order to reflect the canonical representation of the answer that we get back from HQ. (Re: #600)

This PR doesn't address any of those issues, but knocks out some prerequisite work to support them.

First of all, it introduces `"intermediate"` as a valid state for guesses and adds an `"additionalNotes"` field which can be used to capture either rejection details or additional instructions received from HQ. There is no support for creating new guess records with either of these. However, I did incorporate some intermediate instructions into our fixture data.

Secondly, this PR significantly reworks the guess queue page. Previously, the guess queue could be used to change guess state (in addition to changing state from the popup notifications). However, I didn't want to implement the new UI flows for intermediate answers and rejections in two different places. Instead, the guess queue UI now allows non-pending guesses to be returned to pending (the only function that was possible from the guess queue but not from notifications), but is otherwise read-only.

Once those UI elements had been removed, the resulting page was quite sparse, so I used this as an opportunity to densify the display (especially on desktop-sized UIs) and make it significantly more visual.

Here's what the new guess queue page looks like on desktop:

<img width="1835" alt="Screenshot 2022-12-17 at 4 47 41 PM" src="https://user-images.githubusercontent.com/28167/208272024-af852ccb-fe29-4578-93a3-7b0b8bbf2410.png">

and on mobile:

<img width="390" src="https://user-images.githubusercontent.com/28167/208272029-6006c58c-feb6-4166-b4be-5569bc765e73.png">

