### PR TITLE
Fix document watches to try and avoid spamming everyone

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9535,6 +9535,11 @@
         "p-limit": "^3.0.2"
       }
     },
+    "p-throttle": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-5.0.0.tgz",
+      "integrity": "sha512-iXBFjW4kP/5Ivw7uC9EDnj+/xo3pNn4Rws3zgMGPwXnWTv1M3P0LVdZxLrqRUI5JK0Fp3Du0bt6lCaVrI3WF7g=="
+    },
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "monocle-ts": "^2.3.13",
     "mustache": "^4.2.0",
     "newtype-ts": "^0.3.5",
+    "p-throttle": "^5.0.0",
     "portscanner": "^2.2.0",
     "react": "^18.2.0",
     "react-bootstrap": "^2.6.0",


### PR DESCRIPTION
First, when we re-create the document watcher, make sure we clean up the old timeouts we set. Second, use the p-throttle library to limit the number of requests we have open at a time.