### PR TITLE
Rework NotificationCenter with bootstrap Toast and make guess notifications linger briefly after state change

### DIFF
--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -5,10 +5,12 @@ import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import { ServiceConfiguration } from 'meteor/service-configuration';
 import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
-import { faSkullCrossbones } from '@fortawesome/free-solid-svg-icons/faSkullCrossbones';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { useCallback, useState } from 'react';
+import Button from 'react-bootstrap/Button';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Toast from 'react-bootstrap/Toast';
+import ToastContainer from 'react-bootstrap/ToastContainer';
 import Tooltip from 'react-bootstrap/Tooltip';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import { Link } from 'react-router-dom';
@@ -39,48 +41,6 @@ import { useOperatorActionsHidden } from '../hooks/persisted-state';
 import markdown from '../markdown';
 import Breakable from './styling/Breakable';
 
-const StyledDismissButton = styled.button`
-  background: none;
-  border: none;
-  width: 32px;
-  height: 32px;
-  font-size: 20px;
-  font-weight: bold;
-  right: 0;
-  top: 0;
-  color: #888;
-
-  &:hover {
-    color: #f0f0f0;
-  }
-`;
-
-const StyledNotificationMessage = styled.li`
-  width: 100%;
-  position: relative;
-  background-color: #404040;
-  color: #f0f0f0;
-  display: flex;
-  flex-direction: row;
-  align-items: stretch;
-  justify-content: flex-start;
-  overflow: hidden;
-
-  &:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-  }
-
-  &:not(:last-child) {
-    border-bottom: 1px solid #595959;
-  }
-
-  &:last-child {
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-  }
-`;
-
 const StyledNotificationActionBar = styled.ul`
   display: flex;
   list-style-type: none;
@@ -92,60 +52,7 @@ const StyledNotificationActionBar = styled.ul`
 const StyledNotificationActionItem = styled.li`
   margin: 8px 8px 4px 0;
   display: inline-block;
-
-  a,
-  button {
-    display: inline-block;
-    border: none;
-    padding: 4px 10px;
-    border-radius: 4px;
-    background-color: #2e2e2e;
-    color: #aaa;
-
-    &:hover {
-      color: #f0f0f0;
-      cursor: pointer;
-      text-decoration: none;
-    }
-  }
 `;
-
-const MessengerDismissButton = React.memo(({ onDismiss }: {
-  onDismiss: (event: React.MouseEvent<HTMLButtonElement>) => void;
-}) => {
-  return <StyledDismissButton type="button" onClick={onDismiss}>×</StyledDismissButton>;
-});
-
-const MessengerContent = styled.div`
-  overflow-x: hidden; // overflow-wrap on children just overflows the box without this
-  padding: 10px;
-`;
-
-const StyledSpinnerBox = styled.div`
-  background-color: #292929;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  width: 55px;
-  flex: 0 0 55px;
-`;
-
-const StyledSpinner = styled.div`
-  display: block;
-  width: 16px;
-  height: 16px;
-  border-radius: 8px;
-  background-color: #61c4b8;
-`;
-
-const MessengerSpinner = React.memo(() => {
-  return (
-    <StyledSpinnerBox>
-      <StyledSpinner />
-    </StyledSpinnerBox>
-  );
-});
 
 const GuessMessage = React.memo(({
   guess, puzzle, hunt, guesser, onDismiss,
@@ -173,27 +80,22 @@ const GuessMessage = React.memo(({
   }, [onDismiss, guess._id]);
 
   const directionTooltip = (
-    <Tooltip id="direction-tooltip">
+    <Tooltip id={`guess-${guess._id}-direction-tooltip`}>
       Direction this puzzle was solved, ranging from completely backsolved (-10) to completely forward solved (10)
     </Tooltip>
   );
   const confidenceTooltip = (
-    <Tooltip id="confidence-tooltip">
+    <Tooltip id={`guess-${guess._id}-confidence-tooltip`}>
       Submitter-estimated likelihood that this answer is correct
     </Tooltip>
   );
   const copyTooltip = (
-    <Tooltip id="copy-tooltip">
+    <Tooltip id={`guess-${guess._id}-copy-tooltip`}>
       Copy to clipboard
     </Tooltip>
   );
-  const jrLinkTooltip = (
-    <Tooltip id="jr-link-tooltip">
-      Open Jolly Roger page
-    </Tooltip>
-  );
   const extLinkTooltip = (
-    <Tooltip id="ext-link-tooltip">
+    <Tooltip id={`guess-${guess._id}-ext-link-tooltip`}>
       Open puzzle
     </Tooltip>
   );
@@ -201,23 +103,28 @@ const GuessMessage = React.memo(({
   const linkTarget = `/hunts/${puzzle.hunt}/puzzles/${puzzle._id}`;
 
   return (
-    <StyledNotificationMessage>
-      <MessengerSpinner />
-      <MessengerContent>
-        <div>
+    <Toast onClose={dismissGuess}>
+      <Toast.Header>
+        <strong className="me-auto">
           Guess for
           {' '}
-          {puzzle.title}
+          <a href={linkTarget} target="_blank" rel="noopener noreferrer">
+            {puzzle.title}
+          </a>
           {' '}
           from
           {' '}
-          <Breakable>{guesser}</Breakable>
-          :
-          {' '}
+          <a href={`/users/${guess.createdBy}`} target="_blank" rel="noopener noreferrer">
+            <Breakable>{guesser}</Breakable>
+          </a>
+        </strong>
+      </Toast.Header>
+      <Toast.Body>
+        <div>
           <Breakable>{guess.guess}</Breakable>
         </div>
         <div>
-          <OverlayTrigger placement="bottom" overlay={directionTooltip}>
+          <OverlayTrigger placement="top" overlay={directionTooltip}>
             <span>
               Solve direction:
               {' '}
@@ -226,7 +133,7 @@ const GuessMessage = React.memo(({
           </OverlayTrigger>
         </div>
         <div>
-          <OverlayTrigger placement="bottom" overlay={confidenceTooltip}>
+          <OverlayTrigger placement="top" overlay={confidenceTooltip}>
             <span>
               Confidence:
               {' '}
@@ -240,34 +147,32 @@ const GuessMessage = React.memo(({
             <OverlayTrigger placement="top" overlay={copyTooltip}>
               {({ ref, ...triggerHandler }) => (
                 <CopyToClipboard text={guess.guess} {...triggerHandler}>
-                  <button ref={ref} type="button" aria-label="Copy"><FontAwesomeIcon icon={faCopy} /></button>
+                  <Button variant="outline-secondary" size="sm" ref={ref} aria-label="Copy"><FontAwesomeIcon icon={faCopy} /></Button>
                 </CopyToClipboard>
               )}
             </OverlayTrigger>
           </StyledNotificationActionItem>
           <StyledNotificationActionItem>
-            <OverlayTrigger placement="top" overlay={jrLinkTooltip}>
-              <a href={linkTarget} target="_blank" rel="noopener noreferrer">
-                <FontAwesomeIcon icon={faSkullCrossbones} />
-              </a>
-            </OverlayTrigger>
-          </StyledNotificationActionItem>
-          <StyledNotificationActionItem>
             <OverlayTrigger placement="top" overlay={extLinkTooltip}>
-              <a href={guessURL(hunt, puzzle)} target="_blank" rel="noopener noreferrer">
+              <Button variant="outline-secondary" size="sm" as="a" href={guessURL(hunt, puzzle)} target="_blank" rel="noopener noreferrer">
                 <FontAwesomeIcon icon={faPuzzlePiece} />
-              </a>
+              </Button>
             </OverlayTrigger>
           </StyledNotificationActionItem>
         </StyledNotificationActionBar>
         <StyledNotificationActionBar>
-          <StyledNotificationActionItem><button type="button" onClick={markCorrect}>Correct</button></StyledNotificationActionItem>
-          <StyledNotificationActionItem><button type="button" onClick={markIncorrect}>Incorrect</button></StyledNotificationActionItem>
-          <StyledNotificationActionItem><button type="button" onClick={markRejected}>Reject</button></StyledNotificationActionItem>
+          <StyledNotificationActionItem>
+            <Button variant="outline-secondary" size="sm" onClick={markCorrect}>Correct</Button>
+          </StyledNotificationActionItem>
+          <StyledNotificationActionItem>
+            <Button variant="outline-secondary" size="sm" onClick={markIncorrect}>Incorrect</Button>
+          </StyledNotificationActionItem>
+          <StyledNotificationActionItem>
+            <Button variant="outline-secondary" size="sm" onClick={markRejected}>Reject</Button>
+          </StyledNotificationActionItem>
         </StyledNotificationActionBar>
-      </MessengerContent>
-      <MessengerDismissButton onDismiss={dismissGuess} />
-    </StyledNotificationMessage>
+      </Toast.Body>
+    </Toast>
   );
 });
 
@@ -312,28 +217,31 @@ const DiscordMessage = React.memo(({ onDismiss }: {
   const msg = 'It looks like you\'re not in our Discord server, which Jolly Roger manages access to.  Get added:';
   const actions = [
     <StyledNotificationActionItem key="invite">
-      <button
-        type="button"
+      <Button
+        variant="outline-secondary"
         disabled={!(state.status === DiscordMessageStatus.IDLE || state.status === DiscordMessageStatus.ERROR)}
         onClick={initiateOauthFlow}
       >
         Add me
-      </button>
+      </Button>
     </StyledNotificationActionItem>,
   ];
 
   return (
-    <StyledNotificationMessage>
-      <MessengerSpinner />
-      <MessengerContent>
+    <Toast onClose={onDismiss}>
+      <Toast.Header>
+        <strong className="me-auto">
+          Discord account not linked
+        </strong>
+      </Toast.Header>
+      <Toast.Body>
         {msg}
         <StyledNotificationActionBar>
           {actions}
         </StyledNotificationActionBar>
         {state.status === DiscordMessageStatus.ERROR ? state.error! : null}
-      </MessengerContent>
-      <MessengerDismissButton onDismiss={onDismiss} />
-    </StyledNotificationMessage>
+      </Toast.Body>
+    </Toast>
   );
 });
 
@@ -355,22 +263,26 @@ const AnnouncementMessage = React.memo(({
   }
 
   return (
-    <StyledNotificationMessage>
-      <MessengerSpinner />
-      <MessengerContent>
+    <Toast onClose={onDismiss}>
+      <Toast.Header>
+        <strong className="me-auto">
+          Announcement
+        </strong>
+        <small>
+          {calendarTimeFormat(announcement.createdAt)}
+        </small>
+      </Toast.Header>
+      <Toast.Body>
         <div
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: markdown(announcement.message) }}
         />
-        <footer>
+        <div>
           {'- '}
           {createdByDisplayName}
-          {', '}
-          {calendarTimeFormat(announcement.createdAt)}
-        </footer>
-      </MessengerContent>
-      <MessengerDismissButton onDismiss={onDismiss} />
-    </StyledNotificationMessage>
+        </div>
+      </Toast.Body>
+    </Toast>
   );
 });
 
@@ -378,9 +290,13 @@ const ProfileMissingMessage = ({ onDismiss }: {
   onDismiss: () => void;
 }) => {
   return (
-    <StyledNotificationMessage>
-      <MessengerSpinner />
-      <MessengerContent>
+    <Toast onClose={onDismiss}>
+      <Toast.Header>
+        <strong className="me-auto">
+          Profile missing
+        </strong>
+      </Toast.Header>
+      <Toast.Body>
         Somehow you don&apos;t seem to have a profile.  (This can happen if you wind
         up having to do a password reset before you successfully log in for the
         first time.)  Please set a display name for yourself via
@@ -389,9 +305,8 @@ const ProfileMissingMessage = ({ onDismiss }: {
           the profile page
         </Link>
         .
-      </MessengerContent>
-      <MessengerDismissButton onDismiss={onDismiss} />
-    </StyledNotificationMessage>
+      </Toast.Body>
+    </Toast>
   );
 };
 
@@ -405,13 +320,22 @@ const ChatNotificationMessage = ({
 }) => {
   const id = cn._id;
   const dismiss = useCallback(() => dismissChatNotification.call({ chatNotificationId: id }), [id]);
+
   return (
-    <StyledNotificationMessage>
-      <MessengerSpinner />
-      <MessengerContent>
-        <Link to={`/hunts/${hunt._id}/puzzles/${puzzle._id}`}>
-          {puzzle.title}
-        </Link>
+    <Toast onClose={dismiss}>
+      <Toast.Header>
+        <strong className="me-auto">
+          Mention on
+          {' '}
+          <Link to={`/hunts/${hunt._id}/puzzles/${puzzle._id}`}>
+            {puzzle.title}
+          </Link>
+        </strong>
+        <small>
+          {calendarTimeFormat(cn.createdAt)}
+        </small>
+      </Toast.Header>
+      <Toast.Body>
         <div>
           {senderDisplayName}
           {': '}
@@ -419,23 +343,18 @@ const ChatNotificationMessage = ({
             {cn.text}
           </div>
         </div>
-        <footer>
-          {calendarTimeFormat(cn.createdAt)}
-        </footer>
-      </MessengerContent>
-      <MessengerDismissButton onDismiss={dismiss} />
-    </StyledNotificationMessage>
+      </Toast.Body>
+    </Toast>
   );
 };
 
-const StyledNotificationCenter = styled.ul`
-  position: fixed;
-  width: 350px;
-  top: 20px;
-  right: 20px;
-  margin: 0;
-  padding: 0;
+const StyledToastContainer = styled(ToastContainer)`
   z-index: 1050;
+
+  >*:not(:last-child) {
+    // I like these toasts packed a little more efficiently
+    margin-bottom: 0.5rem;
+  }
 `;
 
 const NotificationCenter = () => {
@@ -566,9 +485,9 @@ const NotificationCenter = () => {
   });
 
   return (
-    <StyledNotificationCenter>
+    <StyledToastContainer position="bottom-end" className="p-3 position-fixed">
       {messages}
-    </StyledNotificationCenter>
+    </StyledToastContainer>
   );
 };
 

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -41,7 +41,7 @@ class PendingGuessWatcher {
 
         Object.entries(roles).forEach(([huntId, huntRoles]) => {
           if (huntId === GLOBAL_SCOPE || !huntRoles.includes('operator')) return;
-          this.huntGuessWatchers[huntId] ||= new JoinPublisher(this.sub, huntGuessSpec, { state: 'pending', hunt: huntId });
+          this.huntGuessWatchers[huntId] ||= new JoinPublisher(this.sub, huntGuessSpec, { state: 'pending', hunt: huntId }, { lingerTime: 5000 });
         });
       },
       changed: (_id, fields) => {
@@ -53,7 +53,7 @@ class PendingGuessWatcher {
 
         Object.entries(roles).forEach(([huntId, huntRoles]) => {
           if (huntId === GLOBAL_SCOPE || !huntRoles.includes('operator')) return;
-          this.huntGuessWatchers[huntId] ||= new JoinPublisher(this.sub, huntGuessSpec, { state: 'pending', hunt: huntId });
+          this.huntGuessWatchers[huntId] ||= new JoinPublisher(this.sub, huntGuessSpec, { state: 'pending', hunt: huntId }, { lingerTime: 5000 });
         });
 
         Object.keys(this.huntGuessWatchers).forEach((huntId) => {


### PR DESCRIPTION
These are conceptually separate changes, but they wind up touching the same lines in the same file, so for expedience they're in this PR together.  If desired, I can pull them apart.

The first change drops our custom-rolled notifications and switches to using [Toasts](https://react-bootstrap.netlify.app/components/toasts/).  While I was poking at it, I realized that it might make more sense to put the inbound notifications at the bottom right instead of the top-right, since that way it would mostly cover spreadsheet or puzzle list (both of which are generally scrollable) rather than the "Add puzzle" or nav UI.  This should help with the primary complaint in #230 (though I think that bug has some other interesting ideas, so I won't close it yet).

The second change adds support for a pretty old feature request: showing what became of a pending guess briefly before disappearing after the operator processed it.

Some screenshots:

What you might see after logging in for the first time:

<img width="1045" alt="Screenshot 2022-12-18 at 1 53 21 AM" src="https://user-images.githubusercontent.com/307325/208291821-6fe98bf7-9810-4c3f-8d18-7d4245a76ead.png">

Guess queue, announcements, and dingword notification:

<img width="967" alt="Screenshot 2022-12-18 at 1 56 10 AM" src="https://user-images.githubusercontent.com/307325/208291915-d5cec8d0-9585-495d-ba68-83e5ce8c63b5.png">

And a video showing the lingering effect:

https://user-images.githubusercontent.com/307325/208292205-f8e90e37-ae33-4c67-8e3a-d3b9729ac22c.mov


Fixes #186.