### PR TITLE
Increase Drive watch renewal window in production

### DIFF
--- a/imports/server/gdriveDocumentWatcher.ts
+++ b/imports/server/gdriveDocumentWatcher.ts
@@ -18,7 +18,7 @@ import { DocumentWatchType } from './schemas/DocumentWatch';
 const EXPIRE_WINDOW = Meteor.isDevelopment ?
   5 * 60 * 1000 :
   24 * 60 * 60 * 1000;
-const RENEW_WINDOW = 60 * 1000; // milliseconds
+const RENEW_WINDOW = EXPIRE_WINDOW * 0.2;
 const ACTIVITY_GRANULARITY = 5 * 60 * 1000; // milliseconds
 const WEBHOOK_PREFIX = '/_gdrive/watch';
 


### PR DESCRIPTION
We're struggling a bit to avoid Google's rate limiting on watch creation. I think in the long term I may have to take another look at `changes.watch` to see if I can set fewer watches and get more data, but in the interim, I'm hoping that this will help jitter things out a little better.