### PR TITLE
Fix multiple guess queue bugs and add countdown spinner

### DIFF
--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -39,7 +39,13 @@ import { guessURL } from '../../model-helpers';
 import { requestDiscordCredential } from '../discord';
 import { useOperatorActionsHidden } from '../hooks/persisted-state';
 import markdown from '../markdown';
+import SpinnerTimer from './SpinnerTimer';
 import Breakable from './styling/Breakable';
+
+// How long to keep showing guess notifications after actioning.
+// Note that this cannot usefully exceed the linger period implemented by the
+// subscription that fetches the data from imports/server/guesses.ts
+const LINGER_PERIOD = 4000;
 
 const StyledNotificationActionBar = styled.ul`
   display: flex;
@@ -124,6 +130,18 @@ const GuessMessage = React.memo(({
             <Breakable>{guesser}</Breakable>
           </a>
         </strong>
+        <small>
+          {calendarTimeFormat(guess.createdAt)}
+        </small>
+        {guess.state !== 'pending' && (
+          <SpinnerTimer
+            className="ms-3"
+            width={16}
+            height={16}
+            startTime={guess.updatedAt!.getTime()}
+            endTime={guess.updatedAt!.getTime() + LINGER_PERIOD}
+          />
+        )}
       </Toast.Header>
       <Toast.Body>
         <div>
@@ -389,11 +407,6 @@ const NotificationCenter = () => {
       discordConfiguredByUser: !!(user.discordAccount),
     };
   }, []);
-
-  // How long to keep showing guess notifications after actioning.
-  // Note that this cannot usefully exceed the linger period implemented by the
-  // subscription that fetches the data from imports/server/guesses.ts
-  const LINGER_PERIOD = 4000;
 
   // Lookup tables to support guesses/pendingAnnouncements/chatNotifications
   const hunts = useTracker(() => (loading ? new Map<string, HuntType>() : indexedById(Hunts.find().fetch())), [loading]);

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -456,7 +456,7 @@ const NotificationCenter = () => {
     // We want to schedule an update to recentGuessEpoch to run once the oldest
     // lingering guess would fall out of retention.
     const earliestLingerDisappearsAt = earliestLingerUpdatedAt + LINGER_PERIOD;
-    const timeUntilLingerDisappears = Date.now() - earliestLingerDisappearsAt;
+    const timeUntilLingerDisappears = earliestLingerDisappearsAt - Date.now();
 
     const timeout = Meteor.setTimeout(() => {
       setRecentGuessEpoch(Date.now() - LINGER_PERIOD);

--- a/imports/client/components/SpinnerTimer.tsx
+++ b/imports/client/components/SpinnerTimer.tsx
@@ -1,0 +1,94 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+
+// A component which animates a grey spinner between startTime and endTime like
+//     _____         __            __            __            __            __
+//    /  _  \       /  |  _       /  |          /  |          /  |          /  |           |
+//   /  / \  \     /  /  \ \     /  /          /  /          /  /           \_/
+//  |  |   | | -> |  |   | | -> |  |   --| -> |  |       -> |  |       ->            ->
+//   \  \_/  /     \  \_/  /     \  \_/  /     \  \_         \_/
+//    \_____/       \_____/       \_____/       \__|
+//
+//   startTime                              halfway between                             endTime
+const SpinnerTimer = ({
+  width,
+  height,
+  startTime,
+  endTime,
+  className,
+}: {
+  width: number;
+  height: number;
+  startTime: number;
+  endTime: number;
+  className?: string;
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const periodicHandle = useRef<number | undefined>(undefined);
+
+  const drawSpinner = useCallback(() => {
+    // request repaint on next animation frame
+    periodicHandle.current = window.requestAnimationFrame(drawSpinner);
+
+    // Compute fraction of spinner we should show (100% if <= startTime, 0% if >= endTime)
+    const now = Date.now();
+    let frac: number;
+    if (now < startTime) {
+      frac = 1;
+    } else if (now > endTime) {
+      frac = 0;
+    } else {
+      frac = (now - startTime) / (endTime - startTime);
+    }
+
+    // paint, if we have a canvas, the outline of an arc:
+    const centerX = width / 2;
+    const centerY = height / 2;
+
+    const outerRadius = Math.min(width, height) / 2;
+    const innerRadius = outerRadius / 3;
+
+    const startRadians = (frac * (Math.PI * 2)) + ((3 * Math.PI) / 2);
+    const endRadians = (3 * Math.PI) / 2;
+
+    const canvas = canvasRef.current;
+    if (canvas) {
+      const ctx = canvas.getContext('2d');
+      if (ctx) {
+        ctx.clearRect(0, 0, width, height);
+        ctx.fillStyle = 'rgb(100, 100, 100)'; // this could easily become a prop
+        ctx.beginPath();
+        // outer arc
+        ctx.arc(centerX, centerY, outerRadius, startRadians, endRadians);
+        // line to inner arc at endRadians, which is always just straight up
+        ctx.lineTo(centerX, centerY + innerRadius);
+        // inner arc
+        ctx.arc(centerX, centerY, innerRadius, endRadians, startRadians, true);
+        // fill to close
+        ctx.fill();
+      }
+    }
+  }, [startTime, endTime, width, height]);
+
+  useEffect(() => {
+    if (!periodicHandle.current) {
+      periodicHandle.current = window.requestAnimationFrame(drawSpinner);
+    }
+    return () => {
+      if (periodicHandle.current) {
+        window.cancelAnimationFrame(periodicHandle.current);
+        periodicHandle.current = undefined;
+      }
+    };
+  }, [drawSpinner]);
+
+  return (
+    <canvas
+      className={className}
+      ref={canvasRef}
+      width={width}
+      height={height}
+    />
+  );
+};
+
+export default SpinnerTimer;

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -45,11 +45,12 @@ class PendingGuessWatcher {
         });
       },
       changed: (_id, fields) => {
-        if (!fields.roles) {
+        if (!Object.prototype.hasOwnProperty.call(fields, 'roles')) {
+          // roles were unchanged
           return;
         }
 
-        const { roles } = fields;
+        const { roles = {} } = fields;
 
         Object.entries(roles).forEach(([huntId, huntRoles]) => {
           if (huntId === GLOBAL_SCOPE || !huntRoles.includes('operator')) return;

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -7,6 +7,8 @@ import Puzzles from '../lib/models/Puzzles';
 import { GuessType } from '../lib/schemas/Guess';
 import JoinPublisher, { PublishSpec } from './JoinPublisher';
 
+const LINGER_TIME = 5000;
+
 class PendingGuessWatcher {
   sub: Subscription;
 
@@ -41,7 +43,7 @@ class PendingGuessWatcher {
 
         Object.entries(roles).forEach(([huntId, huntRoles]) => {
           if (huntId === GLOBAL_SCOPE || !huntRoles.includes('operator')) return;
-          this.huntGuessWatchers[huntId] ||= new JoinPublisher(this.sub, huntGuessSpec, { state: 'pending', hunt: huntId }, { lingerTime: 5000 });
+          this.huntGuessWatchers[huntId] ||= new JoinPublisher(this.sub, huntGuessSpec, { state: 'pending', hunt: huntId }, { lingerTime: LINGER_TIME });
         });
       },
       changed: (_id, fields) => {
@@ -54,7 +56,7 @@ class PendingGuessWatcher {
 
         Object.entries(roles).forEach(([huntId, huntRoles]) => {
           if (huntId === GLOBAL_SCOPE || !huntRoles.includes('operator')) return;
-          this.huntGuessWatchers[huntId] ||= new JoinPublisher(this.sub, huntGuessSpec, { state: 'pending', hunt: huntId }, { lingerTime: 5000 });
+          this.huntGuessWatchers[huntId] ||= new JoinPublisher(this.sub, huntGuessSpec, { state: 'pending', hunt: huntId }, { lingerTime: LINGER_TIME });
         });
 
         Object.keys(this.huntGuessWatchers).forEach((huntId) => {

--- a/imports/server/guesses.ts
+++ b/imports/server/guesses.ts
@@ -35,6 +35,9 @@ class PendingGuessWatcher {
           projection: { displayName: 1 },
         },
       }],
+      // top-level Guess object and its referents should linger so we can
+      // display it in the guess queue briefly after processing for continuity
+      lingerTime: LINGER_TIME,
     };
 
     this.userWatch = MeteorUsers.find(sub.userId!, { fields: { roles: 1 } }).observeChanges({
@@ -43,7 +46,7 @@ class PendingGuessWatcher {
 
         Object.entries(roles).forEach(([huntId, huntRoles]) => {
           if (huntId === GLOBAL_SCOPE || !huntRoles.includes('operator')) return;
-          this.huntGuessWatchers[huntId] ||= new JoinPublisher(this.sub, huntGuessSpec, { state: 'pending', hunt: huntId }, { lingerTime: LINGER_TIME });
+          this.huntGuessWatchers[huntId] ||= new JoinPublisher(this.sub, huntGuessSpec, { state: 'pending', hunt: huntId });
         });
       },
       changed: (_id, fields) => {
@@ -56,7 +59,7 @@ class PendingGuessWatcher {
 
         Object.entries(roles).forEach(([huntId, huntRoles]) => {
           if (huntId === GLOBAL_SCOPE || !huntRoles.includes('operator')) return;
-          this.huntGuessWatchers[huntId] ||= new JoinPublisher(this.sub, huntGuessSpec, { state: 'pending', hunt: huntId }, { lingerTime: LINGER_TIME });
+          this.huntGuessWatchers[huntId] ||= new JoinPublisher(this.sub, huntGuessSpec, { state: 'pending', hunt: huntId });
         });
 
         Object.keys(this.huntGuessWatchers).forEach((huntId) => {


### PR DESCRIPTION
Fixes:

* a sign bug in the client-side refreshing that caused us to busy-loop timeouts updating values until completed guesses were marked (1c119d890f65ff97b081cf4d5867e69405ecbf19)
* incorrect `observeChanges` usages in `JoinedObjectObserver` (2cdb64ee1cdc713a6eb8edb767f0d9786d55b358) which, through spurious `decref`s, was causing us to lose client-side record of the user who submitted a guess on pages where we did not otherwise have that record locally due to another subscription
* incorrect `observeChanges` usages in `PendingGuessWatcher` (32b967d2c9baa148c2e03fd42335c4987930a769) which we probably would never hit since we don't remove the `roles` field but it's good to be correct

Adds:

* a spinner which indicates when a serviced guess will disappear from being shown

What it looks like now:

https://user-images.githubusercontent.com/307325/208751321-dc2101f7-782f-455f-93a4-9e72ac0954ab.mov