### PR TITLE
Feature flag improvements

### DIFF
--- a/imports/Flags.ts
+++ b/imports/Flags.ts
@@ -1,11 +1,9 @@
-import { Match, check } from 'meteor/check';
-import { SHA256 } from 'meteor/sha';
+import { check } from 'meteor/check';
 import FeatureFlags from './lib/models/FeatureFlags';
 
 const Flags = {
-  active(name: unknown, shard?: unknown) {
+  active(name: unknown) {
     check(name, String);
-    check(shard, Match.Maybe(String));
 
     const flag = FeatureFlags.findOne({ name });
     if (!flag) {
@@ -15,13 +13,6 @@ const Flags = {
     switch (flag.type) {
       case 'on':
         return true;
-      case 'random_by': {
-        // eslint-disable-next-line new-cap
-        const hash = SHA256(`${name}.${shard}`);
-        // Use the first 48 bits (6 bytes) and convert to a float
-        const float = parseInt(hash.slice(0, 6), 16) / 0xffffff;
-        return float < (flag.random ?? 0);
-      }
       case 'off':
         return false;
       default:

--- a/imports/Flags.ts
+++ b/imports/Flags.ts
@@ -19,6 +19,33 @@ const Flags = {
         return false;
     }
   },
+
+  observeChanges(name: unknown, cb: (active: boolean) => void) {
+    check(name, String);
+    check(cb, Function);
+
+    let state: boolean | undefined;
+    const checkUpdate = () => {
+      const active = Flags.active(name);
+      if (state !== active) {
+        state = active;
+        cb(active);
+      }
+    };
+    const handle = FeatureFlags.find({ name }).observeChanges({
+      added: checkUpdate,
+      changed: checkUpdate,
+      removed: checkUpdate,
+    });
+
+    // If state is still undefined, then the record does not exist yet and we
+    // should explicitly initialize it to false.
+    if (state === undefined) {
+      checkUpdate();
+    }
+
+    return handle;
+  },
 };
 
 export default Flags;

--- a/imports/lib/schemas/FeatureFlag.ts
+++ b/imports/lib/schemas/FeatureFlag.ts
@@ -7,8 +7,7 @@ const FeatureFlagFields = t.type({
   // type represents the mode of a feature flag. If a feature flag
   // with a given name doesn't exist, it's assumed to be of type
   // "off"
-  type: t.union([t.literal('off'), t.literal('on'), t.literal('random_by')]),
-  random: t.union([t.number, t.undefined]),
+  type: t.union([t.literal('off'), t.literal('on')]),
 });
 
 const [FeatureFlagCodec, FeatureFlagOverrides] = inheritSchema(

--- a/imports/methods/setFeatureFlag.ts
+++ b/imports/methods/setFeatureFlag.ts
@@ -2,8 +2,7 @@ import TypedMethod from './TypedMethod';
 
 type SetFeatureFlagArgs = {
   name: string,
-  type: 'on' | 'off' | 'random_by',
-  random?: number,
+  type: 'on' | 'off',
 };
 
 export default new TypedMethod<SetFeatureFlagArgs, void>(

--- a/imports/server/discordClientRefresher.ts
+++ b/imports/server/discordClientRefresher.ts
@@ -2,7 +2,6 @@ import { Meteor } from 'meteor/meteor';
 import Discord from 'discord.js';
 import Flags from '../Flags';
 import DiscordCache from '../lib/models/DiscordCache';
-import FeatureFlags from '../lib/models/FeatureFlags';
 import MeteorUsers from '../lib/models/MeteorUsers';
 import Settings from '../lib/models/Settings';
 import { SettingType } from '../lib/schemas/Setting';
@@ -35,11 +34,7 @@ class DiscordClientRefresher {
       removed: () => this.clearBotConfig(),
     });
 
-    this.featureFlagObserveHandle = FeatureFlags.find({ name: 'disable.discord' }).observe({
-      added: () => this.refreshClient(),
-      changed: () => this.refreshClient(),
-      removed: () => this.refreshClient(),
-    });
+    this.featureFlagObserveHandle = Flags.observeChanges('disable.discord', () => this.refreshClient());
   }
 
   ready() {

--- a/imports/server/methods/setFeatureFlag.ts
+++ b/imports/server/methods/setFeatureFlag.ts
@@ -7,21 +7,16 @@ setFeatureFlag.define({
   validate(arg) {
     check(arg, {
       name: String,
-      type: Match.OneOf('off', 'on', 'random_by'),
-      random: Match.Optional(Number),
+      type: Match.OneOf('off', 'on'),
     });
-
-    // This check won't be reflected in the type signature, but reflects that
-    // "random" is only valid if type is "random_by"
-    check(arg.random, arg.type === 'random_by' ? Number : undefined);
 
     return arg;
   },
 
-  run({ name, type, random }) {
+  run({ name, type }) {
     // Feature flags may only be updated by admins
     checkAdmin(this.userId);
 
-    FeatureFlags.upsert({ name }, { $set: { type, random } });
+    FeatureFlags.upsert({ name }, { $set: { type } });
   },
 });


### PR DESCRIPTION
This eliminates the "random_by" feature flag mode, which as far as I'm aware we have never used, and uses the resulting simplification to introduce a `Flags.observeChanges` helper. I wanted the latter after feeling like I had written that logic too many times (including in #1226; if this lands first I'll update it)