### PR TITLE
Avoid changing overlay text during dismiss animation

### DIFF
--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -449,9 +449,6 @@ const CallSection = ({
   const onDismissPeerStateNotification = useCallback(() => {
     callDispatch({ type: 'dismiss-peer-state-notification' });
   }, [callDispatch]);
-  const onDismissRemoteMuted = useCallback(() => {
-    callDispatch({ type: 'dismiss-remote-muted' });
-  }, [callDispatch]);
 
   const muteRef = useRef(null);
 
@@ -460,6 +457,23 @@ const CallSection = ({
       Meteor.users.findOne(callState.remoteMutedBy)?.displayName :
       undefined;
   }, [callState.remoteMutedBy]);
+
+  const [showMutedBy, setShowMutedBy] = useState<'hidden' | 'show' | 'dismissing'>('hidden');
+
+  useEffect(() => {
+    if (mutedBy !== undefined && showMutedBy === 'hidden') {
+      setShowMutedBy('show');
+    }
+  }, [mutedBy, showMutedBy]);
+
+  const onDismissRemoteMuted = useCallback(() => {
+    setShowMutedBy('dismissing');
+  }, []);
+
+  const onShowMutedByDismissed = useCallback(() => {
+    callDispatch({ type: 'dismiss-remote-muted' });
+    setShowMutedBy('hidden');
+  }, [callDispatch]);
 
   if (!callState.device) {
     return <JoiningCall details="Missing device" />;
@@ -502,7 +516,12 @@ const CallSection = ({
           <Button onClick={onDismissPeerStateNotification}>Got it</Button>
         </Tooltip>
       </Overlay>
-      <Overlay target={muteRef.current} show={!!callState.remoteMutedBy} placement="bottom">
+      <Overlay
+        target={muteRef.current}
+        show={showMutedBy === 'show'}
+        placement="bottom"
+        onExited={onShowMutedByDismissed}
+      >
         <Tooltip id="remote-muted-notification">
           <div>
             You were muted by


### PR DESCRIPTION
Before this patchset, if another call participant muted you, then when you dismissed the remote mute popup, as the popup animated out, the contents would change from naming the user you were muted by to saying "someone", as the value of `mutedBy` had changed to undefined.

This patch defers clearing the `remoteMutedBy` value in `callState` until after the animation is completed.

Before:

https://user-images.githubusercontent.com/307325/209432530-3aec3042-0d73-4f30-9350-c3804273f1b3.mov

After:

https://user-images.githubusercontent.com/307325/209432537-2c2d5eab-9519-4002-950c-926cd7b5be9a.mov

Special thanks to @aldeka, who pointed out this issue!