### PR TITLE
Avoid browser-driven form submission when submitting Rejected reason

### DIFF
--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -186,7 +186,7 @@ const GuessMessage = React.memo(({
           />
           <StyledNotificationActionBar>
             <StyledNotificationActionItem>
-              <Button type="submit" variant="outline-secondary" size="sm" disabled={disableForms} onClick={submitStageTwo}>Save (or press Enter)</Button>
+              <Button variant="outline-secondary" size="sm" disabled={disableForms} onClick={submitStageTwo}>Save (or press Enter)</Button>
             </StyledNotificationActionItem>
           </StyledNotificationActionBar>
         </Form>


### PR DESCRIPTION
The default event handler for Clicking a button with `type="submit"` causes a form submission which causes a navigation.

We could also have kept the `type="submit"` and overridden an event handler to call `preventDefault()` if we wanted to be more semantically-correct, but this seemed simpler.