### PR TITLE
Collect consolidated activity tracking data

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -60,6 +60,8 @@
       "allow": ["__meteor_runtime_config__"]
     }],
 
+    "no-constant-condition": ["error", { "checkLoops": false }],
+
     // We have files with multiple React components.  Maybe we should split them out
     // later, but right now I don't want to deal with this
     "react/no-multi-comp": ["off"],

--- a/imports/lib/config/activityTracking.ts
+++ b/imports/lib/config/activityTracking.ts
@@ -1,0 +1,9 @@
+import { Meteor } from 'meteor/meteor';
+
+// eslint-disable-next-line import/prefer-default-export
+export const ACTIVITY_GRANULARITY = Meteor.isDevelopment ?
+  // Set granularity to be quite low in development. Note that this will not
+  // meaningfully improve granularity of Google Drive tracking, since we're
+  // constrained by what we get from the API, but works for chat and voice.
+  5 * 1000 :
+  5 * 60 * 1000; // milliseconds

--- a/imports/lib/roundedTime.ts
+++ b/imports/lib/roundedTime.ts
@@ -1,0 +1,3 @@
+export default function roundedTime(granularityMilliseconds: number, now = new Date()) {
+  return new Date(Math.round(now.getTime() / granularityMilliseconds) * granularityMilliseconds);
+}

--- a/imports/server/GlobalHooks.ts
+++ b/imports/server/GlobalHooks.ts
@@ -1,3 +1,4 @@
+import ActivityHooks from './hooks/ActivityHooks';
 import ChatHooks from './hooks/ChatHooks';
 import DingwordHooks from './hooks/DingwordHooks';
 import DiscordHooks from './hooks/DiscordHooks';
@@ -7,6 +8,7 @@ import TagCleanupHooks from './hooks/TagCleanupHooks';
 // Instantiate the application-global hookset list.
 const GlobalHooks = new HooksRegistry();
 // Add all hooksets.
+GlobalHooks.addHookSet(ActivityHooks);
 GlobalHooks.addHookSet(DiscordHooks);
 GlobalHooks.addHookSet(DingwordHooks);
 GlobalHooks.addHookSet(TagCleanupHooks);

--- a/imports/server/activityTracking.ts
+++ b/imports/server/activityTracking.ts
@@ -1,0 +1,123 @@
+import { Meteor } from 'meteor/meteor';
+import { MongoInternals } from 'meteor/mongo';
+import { Random } from 'meteor/random';
+import Ansible from '../Ansible';
+import { ACTIVITY_GRANULARITY } from '../lib/config/activityTracking';
+import ConsolidatedActivities from './models/ConsolidatedActivities';
+import RecentActivities from './models/RecentActivities';
+import { RecentActivityType } from './schemas/RecentActivity';
+
+interface ActivityKey {
+  ts: Date;
+  hunt: string;
+  puzzle: string;
+}
+
+function serializeActivityKey({ ts, hunt, puzzle }: ActivityKey) {
+  return `${ts.getTime()}-${hunt}-${puzzle}`;
+}
+
+function deserializeActivityKey(key: string) {
+  const [ts, hunt, puzzle] = key.split('-');
+  if (!ts || !hunt || !puzzle) {
+    throw new Error(`Invalid activity key: ${key}`);
+  }
+  return { ts: new Date(parseInt(ts, 10)), hunt, puzzle };
+}
+
+async function fetchAndDeleteRecentActivity(
+  cutoff: Date,
+  session: InstanceType<typeof MongoInternals.NpmModules.mongodb.module.ClientSession>,
+) {
+  if (!session) {
+    throw new Error('Must be called with a session');
+  }
+
+  const usersByKeyAndType = new Map<string, Map<RecentActivityType['type'], Set<string>>>();
+  while (true) {
+    /* eslint-disable no-await-in-loop */
+    const recent = await RecentActivities.rawCollection().findOneAndDelete(
+      { ts: { $lt: cutoff } } as any,
+      { session }
+    );
+    if (!recent.value) {
+      break;
+    }
+
+    const key = serializeActivityKey(recent.value);
+    const usersByType = usersByKeyAndType.get(key) ?? new Map();
+    const users = usersByType.get(recent.value.type) ?? new Set();
+    users.add(recent.value.user);
+    usersByType.set(recent.value.type, users);
+    usersByKeyAndType.set(key, usersByType);
+    /* eslint-enable no-await-in-loop */
+  }
+
+  return usersByKeyAndType;
+}
+
+async function consolidateRecentActivity() {
+  const ageForConsolidation = ACTIVITY_GRANULARITY * 2;
+  const cutoff = new Date(Date.now() - ageForConsolidation);
+
+  // By using a transaction, we avoid races with other servers, since we only
+  // count records that we delete (and if we fail to update the consolidated
+  // counters, the deletions will be rolled back).
+  //
+  // However: note that using the raw collection bypasses our schema
+  // enforcement, so we need to make sure of compliance
+  const { client } = MongoInternals.defaultRemoteCollectionDriver().mongo;
+  const session = client.startSession();
+  await session.withTransaction(async () => {
+    const usersByKeyAndType = await fetchAndDeleteRecentActivity(
+      cutoff,
+      session,
+    );
+
+    await [...usersByKeyAndType.entries()].reduce(async (p, [key, usersByType]) => {
+      await p;
+
+      const matcher = deserializeActivityKey(key);
+      const increments = new Map<'total' | `components.${RecentActivityType['type']}`, number>();
+      const allUsers = new Set<string>();
+      [...usersByType.entries()].forEach(([type, users]) => {
+        const incrementKey = `components.${type}` as const;
+        increments.set(incrementKey, (increments.get(incrementKey) ?? 0) + users.size);
+        users.forEach((user) => allUsers.add(user));
+      });
+      increments.set('total', allUsers.size);
+
+      await ConsolidatedActivities.rawCollection().updateOne(
+        { ...matcher },
+        {
+          $setOnInsert: {
+            _id: Random.id(),
+          },
+          $inc: Object.fromEntries(increments),
+        },
+        { upsert: true, session },
+      );
+    }, Promise.resolve());
+  });
+}
+
+function scheduleConsolidate() {
+  // Consolidate recent activity every ACTIVITY_GRANULARITY / 2 milliseconds
+  // plus or minus some jitter
+  const jitter = Math.random() * ACTIVITY_GRANULARITY;
+  setTimeout(() => {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    void periodicConsolidate();
+  }, ACTIVITY_GRANULARITY / 2 + jitter);
+}
+
+async function periodicConsolidate() {
+  try {
+    await consolidateRecentActivity();
+  } catch (e) {
+    Ansible.error('Error consolidating recent activity', { e });
+  }
+  scheduleConsolidate();
+}
+
+Meteor.startup(() => scheduleConsolidate());

--- a/imports/server/gdriveChangeFetcher.ts
+++ b/imports/server/gdriveChangeFetcher.ts
@@ -105,7 +105,6 @@ async function featureFlagChanged() {
 }
 
 async function fetchDriveLoop() {
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     /* eslint-disable no-await-in-loop */
     // Only try to grab the lock if feature flags would allow it

--- a/imports/server/hooks/ActivityHooks.ts
+++ b/imports/server/hooks/ActivityHooks.ts
@@ -1,0 +1,28 @@
+import { ACTIVITY_GRANULARITY } from '../../lib/config/activityTracking';
+import ChatMessages from '../../lib/models/ChatMessages';
+import roundedTime from '../../lib/roundedTime';
+import ignoringDuplicateKeyErrors from '../ignoringDuplicateKeyErrors';
+import RecentActivities from '../models/RecentActivities';
+import Hookset from './Hookset';
+
+const ActivityHooks: Hookset = {
+  async onChatMessageCreated(chatMessageId: string) {
+    const message = ChatMessages.findOne(chatMessageId);
+    if (!message) return;
+
+    const { sender } = message;
+    if (!sender) return; // Ignore system messages
+
+    await ignoringDuplicateKeyErrors(async () => {
+      await RecentActivities.insertAsync({
+        hunt: message.hunt,
+        puzzle: message.puzzle,
+        user: sender,
+        ts: roundedTime(ACTIVITY_GRANULARITY, message.createdAt),
+        type: 'chat',
+      });
+    });
+  },
+};
+
+export default ActivityHooks;

--- a/imports/server/migrations/43-puzzle-activity.ts
+++ b/imports/server/migrations/43-puzzle-activity.ts
@@ -1,0 +1,20 @@
+import ConsolidatedActivities from '../models/ConsolidatedActivities';
+import RecentActivities from '../models/RecentActivities';
+import Migrations from './Migrations';
+
+Migrations.add({
+  version: 43,
+  name: 'Indexes for puzzle activity tracking',
+  async up() {
+    await RecentActivities.createIndexAsync({
+      ts: 1,
+      type: 1,
+      puzzle: 1,
+      user: 1,
+    }, { unique: true });
+    await ConsolidatedActivities.createIndexAsync({
+      ts: 1,
+      puzzle: 1,
+    }, { unique: true });
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -41,3 +41,4 @@ import './39-promote-profiles-to-toplevel';
 import './40-cleanup-celebrations';
 import './41-document-activities';
 import './42-document-by-external-id';
+import './43-puzzle-activity';

--- a/imports/server/models/ConsolidatedActivities.ts
+++ b/imports/server/models/ConsolidatedActivities.ts
@@ -1,0 +1,7 @@
+import { Mongo } from 'meteor/mongo';
+import ConsolidatedActivitySchema, { ConsolidatedActivityType } from '../schemas/ConsolidatedActivity';
+
+const ConsolidatedActivities = new Mongo.Collection<ConsolidatedActivityType>('jr_consolidated_activities');
+ConsolidatedActivities.attachSchema(ConsolidatedActivitySchema);
+
+export default ConsolidatedActivities;

--- a/imports/server/models/Locks.ts
+++ b/imports/server/models/Locks.ts
@@ -36,7 +36,6 @@ const Locks = new class extends Mongo.Collection<LockType> {
   }
 
   async withLock<T>(name: string, critSection: (id: string) => Promise<T>) {
-    // eslint-disable-next-line no-constant-condition
     while (true) {
       let handle: Meteor.LiveQueryHandle | undefined;
       let lock: string | undefined;

--- a/imports/server/models/RecentActivities.ts
+++ b/imports/server/models/RecentActivities.ts
@@ -1,0 +1,7 @@
+import { Mongo } from 'meteor/mongo';
+import RecentActivitySchema, { RecentActivityType } from '../schemas/RecentActivity';
+
+const RecentActivities = new Mongo.Collection<RecentActivityType>('jr_recent_activities');
+RecentActivities.attachSchema(RecentActivitySchema);
+
+export default RecentActivities;

--- a/imports/server/schemas/ConsolidatedActivity.ts
+++ b/imports/server/schemas/ConsolidatedActivity.ts
@@ -1,0 +1,35 @@
+import * as t from 'io-ts';
+import { date } from 'io-ts-types';
+import { Id } from '../../lib/schemas/regexes';
+import { buildSchema, Overrides } from '../../lib/schemas/typedSchemas';
+
+const ConsolidatedActivityCodec = t.type({
+  _id: t.string,
+  ts: date,
+  hunt: t.string,
+  puzzle: t.string,
+  total: t.Int,
+  components: t.type({
+    chat: t.Int,
+    call: t.Int,
+  }),
+});
+
+export type ConsolidatedActivityType = t.OutputOf<typeof ConsolidatedActivityCodec>;
+
+const ConsolidatedActivityOverrides: Overrides<t.TypeOf<typeof ConsolidatedActivityCodec>> = {
+  _id: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  hunt: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  puzzle: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+};
+
+export default buildSchema(ConsolidatedActivityCodec, ConsolidatedActivityOverrides);

--- a/imports/server/schemas/RecentActivity.ts
+++ b/imports/server/schemas/RecentActivity.ts
@@ -1,0 +1,37 @@
+import * as t from 'io-ts';
+import { date } from 'io-ts-types';
+import { Id } from '../../lib/schemas/regexes';
+import { buildSchema, Overrides } from '../../lib/schemas/typedSchemas';
+
+// Not descended from Base as this is managed by the server
+const RecentActivityCodec = t.type({
+  _id: t.string,
+  ts: date,
+  type: t.union([t.literal('chat'), t.literal('call')]),
+  hunt: t.string,
+  puzzle: t.string,
+  user: t.string,
+});
+
+export type RecentActivityType = t.TypeOf<typeof RecentActivityCodec>;
+
+const RecentActivityOverrides: Overrides<RecentActivityType> = {
+  _id: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  hunt: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  puzzle: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  user: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+};
+
+export default buildSchema(RecentActivityCodec, RecentActivityOverrides);

--- a/server/main.ts
+++ b/server/main.ts
@@ -13,6 +13,7 @@ import '../imports/server/methods/index';
 
 // Other stuff in the server folder
 import '../imports/server/accounts';
+import '../imports/server/activityTracking';
 import '../imports/server/announcements';
 import '../imports/server/api-init';
 import '../imports/server/sendChatMessageInternal';


### PR DESCRIPTION
As part of addressing #172, we need better time-series data on how many users are working on any given puzzle. This collects that data for calls and chats. Together with the data we already get from documents, this should be enough for us to aggregate and display that data.

The first two commits are mostly cleanup and refactor to support the third commit, which is effectively the crux of this PR. The commit message is (IMO) important enough that I'll just paste it here for reference:

> In order to display chat and call activity data to clients without processing or shipping an overwhelming amount of data, we need to compress it in two ways. First, we need to aggregate multiple operations from a single user within the same time window. Second, we need to aggregate a count of unique users per time window.
> 
> This introduces a two-stage process for performing that aggregation for both chat and call data. First, as activity occurs, we create "recent" activity records. These dedup multiple events from a single user within our activity window but are otherwise unaggregated and represent a convenient queue of records for further consolidation. After our activity window has passed, we aggregate these recent records into summary records, which only contain unique user counts.
>
> Since Google Drive data does not require aggregation for either reason (we don't currently get per-user data and we only see records roughly every 3-5 minutes anyway), this preserves Google Drive document activity as a separate collection.
>
> As an implementation note, the consolidation processes takes advantage of MongoDB's transaction support to ensure that we delete recent records and increment consolidated records atomically. Transactions are supported by MongoDB at the version we run, and the resulting oplog entries are understood by Meteor. However, it's not possible to create a transaction using Meteor's MongoDB APIs, so we have to use the underlying driver directly.
>
> Note that this doesn't yet publish the resulting activity data to the client.
