### PR TITLE
Add a log line when a peer leaves a call

### DIFF
--- a/imports/server/mediasoup-api.ts
+++ b/imports/server/mediasoup-api.ts
@@ -187,6 +187,11 @@ Meteor.publish('mediasoup:join', function (hunt, call, tab) {
   }));
 
   this.onStop(() => {
+    Ansible.log('Peer left call', {
+      peer: peerId,
+      call,
+    });
+
     MeteorPromise.await(Locks.withLock(`mediasoup:room:${call}`, async () => {
       await Peers.removeAsync(peerId);
 


### PR DESCRIPTION
Adding this as a stop-gap until we get around to #601. This was the biggest piece of information we were missing.