### PR TITLE
Next Drive changes page token is allowed to be undefined

### DIFF
--- a/imports/server/schemas/DriveChangesPageToken.ts
+++ b/imports/server/schemas/DriveChangesPageToken.ts
@@ -3,7 +3,7 @@ import { Overrides, buildSchema } from '../../lib/schemas/typedSchemas';
 
 const DriveChangesPageTokenCodec = t.type({
   _id: t.string,
-  token: t.string,
+  token: t.union([t.undefined, t.string]),
 });
 
 export type DriveChangesPageTokenType = t.TypeOf<typeof DriveChangesPageTokenCodec>;


### PR DESCRIPTION
This can happen when we hit the end of an iteration loop or when something goes wrong with an iteration.