### PR TITLE
Fix feature flag for disabling Google Drive changes

### DIFF
--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -1745,20 +1745,18 @@ const CircuitBreakerSection = () => {
         </p>
       </CircuitBreakerControl>
       <CircuitBreakerControl
-        title="Drive activity watches"
-        flagName="disable.gdrive_watchers"
+        title="Drive fetching Google Drive activity"
+        flagName="disable.gdrive_document_activity"
       >
         <p>
-          When Jolly Roger creates a spreadsheet or document, we set a watch on
-          the file and collect activity notifications from Google Drive. There is
-          some possibility that creating and maintaining these watches could
-          exhaust our rate limits with the Google Drive.
+          Jolly Roger periodically attempts to fetch recent changes to Google Drive
+          documents for display in activity data. There is some possibility that
+          these fetches could exhaust our rate limits with the Google Drive.
         </p>
         <p>
           Disabling this feature means that Jolly Roger will continue to
           create documents, but will not attempt to monitor them for updates. As
-          a result, we will not be able to display activity data about Google
-          Drive file edits.
+          a result, we will hide activity data about Google Drive file edits.
         </p>
       </CircuitBreakerControl>
       <CircuitBreakerControl


### PR DESCRIPTION
When we reimplemented fetching of document changes, we didn't adjust the feature flag name (or description) on the setup page.