### PR TITLE
Revert #404

### DIFF
--- a/imports/client/components/ModalForm.tsx
+++ b/imports/client/components/ModalForm.tsx
@@ -60,20 +60,8 @@ const ModalForm = React.forwardRef((
   const submitLabel = props.submitLabel ?? 'Save';
   const submitStyle = props.submitStyle ?? 'primary';
 
-  // Note: the animation=false is working around a regression in
-  // react-bootstrap that otherwise breaks autofocus:
-  // https://github.com/react-bootstrap/react-bootstrap/issues/5102
-  // There's a way to avoid breaking things without losing animation,
-  // but then we'd need to hold a ref to the `autoFocus` child to explicitly
-  // focus it in the Modal's `onEntered` callback, and from within this
-  // class we don't know which of the children should receive focus. So
-  // we just disable animations for now.  Makes the UI feel snappier anyway.
   return (
-    <Modal
-      animation={false}
-      show={isShown}
-      onHide={hide}
-    >
+    <Modal show={isShown} onHide={hide}>
       <form className="form-horizontal" onSubmit={submit}>
         <Modal.Header closeButton>
           <Modal.Title>


### PR DESCRIPTION
We disabled animations for ModalForm due to poor interactions with autofocused inputs. That has since been fixed by upstream, so we can re-enable them.

I'll note that there's a comment saying that disabling the animations makes the UI feel snappier. I think the lack of animations feels a bit abrupt, but I don't have extraordinary strong opinions on the matter. I will accept either merging this PR or closing #406 as wontfix, but we should definitely do one or the other 🙂 

Fixes #406.

Before:

https://user-images.githubusercontent.com/28167/209875983-d1b40734-e5ad-4931-a9cb-6a70a1961dbd.mov

After:

https://user-images.githubusercontent.com/28167/209875993-40560e34-93fb-48c1-ae16-a835963fb86e.mov

