### PR TITLE
Make RemoteMuteConfirmModal visible on first render

### DIFF
--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -188,7 +188,7 @@ const RemoteMuteConfirmModal = React.forwardRef((
   { peerId, name } : { peerId: string, name: string },
   forwardedRef: React.Ref<RemoteMuteConfirmModalHandle>,
 ) => {
-  const [visible, setVisible] = useState(false);
+  const [visible, setVisible] = useState(true);
   const show = useCallback(() => setVisible(true), []);
   const hide = useCallback(() => setVisible(false), []);
   useImperativeHandle(forwardedRef, () => ({ show }), [show]);


### PR DESCRIPTION
In order to avoid the overhead of the remote mute modal until we actually need it, we don't render it to the DOM until we're ready to display it. If it defaults to being hidden when it is first rendered, then you have to click on someone twice in order to mute them.