### PR TITLE
Remove duplicate (incomplete) Meteor.User type decl

### DIFF
--- a/imports/lib/schemas/User.ts
+++ b/imports/lib/schemas/User.ts
@@ -5,7 +5,7 @@ import { Email, Id } from './regexes';
 import { Overrides, buildSchema } from './typedSchemas';
 
 declare module 'meteor/meteor' {
-  module Meteor {
+  namespace Meteor {
     interface User {
       lastLogin?: Date;
       hunts?: string[];

--- a/types/user.d.ts
+++ b/types/user.d.ts
@@ -1,9 +1,0 @@
-declare module 'meteor/meteor' {
-  module Meteor {
-    interface User {
-      lastLogin?: Date;
-      hunts?: string[];
-      roles?: Record<string, string[]>; // scope -> roles
-    }
-  }
-}


### PR DESCRIPTION
We have a more complete one in `imports/lib/schemas/User.ts`.

Also, follow the convention that `Meteor` is a `namespace`, not a `module`, since that appears to matter once we start using first-party type declarations.