### PR TITLE
Use queries to narrow down the return type

### DIFF
--- a/imports/client/components/HuntEditPage.tsx
+++ b/imports/client/components/HuntEditPage.tsx
@@ -21,7 +21,6 @@ import Hunts from '../../lib/models/Hunts';
 import Settings from '../../lib/models/Settings';
 import { BaseType } from '../../lib/schemas/Base';
 import { HuntType, SavedDiscordObjectType } from '../../lib/schemas/Hunt';
-import { SettingType } from '../../lib/schemas/Setting';
 import createHunt from '../../methods/createHunt';
 import updateHunt from '../../methods/updateHunt';
 import { useBreadcrumb } from '../hooks/breadcrumb';
@@ -183,7 +182,7 @@ const HuntEditPage = () => {
 
   useSubscribe('mongo.settings', { name: 'discord.guild' });
   const guildId = useTracker(() => {
-    const setting = Settings.findOne({ name: 'discord.guild' }) as SettingType & { name: 'discord.guild' } | undefined;
+    const setting = Settings.findOne({ name: 'discord.guild' });
     return setting?.value.guild.id;
   }, []);
 

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -481,10 +481,10 @@ const GoogleIntegrationSection = () => {
   const {
     gdriveCredential, root, docTemplate, spreadsheetTemplate,
   } = useTracker(() => {
-    const rootSetting = Settings.findOne({ name: 'gdrive.root' }) as SettingType & { name: 'gdrive.root' } | undefined;
-    const docTemplateSetting = Settings.findOne({ name: 'gdrive.template.document' }) as SettingType & { name: 'gdrive.template.document' } | undefined;
-    const spreadsheetTemplateSetting = Settings.findOne({ name: 'gdrive.template.spreadsheet' }) as SettingType & { name: 'gdrive.template.spreadsheet' } | undefined;
-    const gdriveSetting = Settings.findOne({ name: 'gdrive.credential' }) as SettingType & { name: 'gdrive.credential' } | undefined;
+    const rootSetting = Settings.findOne({ name: 'gdrive.root' });
+    const docTemplateSetting = Settings.findOne({ name: 'gdrive.template.document' });
+    const spreadsheetTemplateSetting = Settings.findOne({ name: 'gdrive.template.spreadsheet' });
+    const gdriveSetting = Settings.findOne({ name: 'gdrive.credential' });
     return {
       gdriveCredential: gdriveSetting,
       root: rootSetting?.value.id,
@@ -965,7 +965,7 @@ const EmailConfigForm = ({ initialConfig }: {
 
 const EmailConfigSection = () => {
   const config = useTracker(() => {
-    return Settings.findOne({ name: 'email.branding' }) as SettingType & { name: 'email.branding' } | undefined;
+    return Settings.findOne({ name: 'email.branding' });
   }, []);
   const configured = !!config?.value.from;
   const badgeVariant = configured ? 'success' : 'warning';
@@ -1256,8 +1256,8 @@ const DiscordIntegrationSection = () => {
   const enabled = useTracker(() => !Flags.active('disable.discord'), []);
   const oauthSettings = useTracker(() => ServiceConfiguration.configurations.findOne({ service: 'discord' }), []);
   const { botToken, guild } = useTracker(() => {
-    const botSetting = Settings.findOne({ name: 'discord.bot' }) as SettingType & { name: 'discord.bot' } | undefined;
-    const guildSetting = Settings.findOne({ name: 'discord.guild' }) as SettingType & { name: 'discord.guild' } | undefined;
+    const botSetting = Settings.findOne({ name: 'discord.bot' });
+    const guildSetting = Settings.findOne({ name: 'discord.guild' });
     return {
       botToken: botSetting?.value.token,
       guild: guildSetting?.value.guild,
@@ -1392,7 +1392,7 @@ const DiscordIntegrationSection = () => {
 
 const BrandingTeamName = () => {
   const initialTeamName = useTracker(() => {
-    const teamNameSetting = Settings.findOne({ name: 'teamname' }) as SettingType & { name: 'teamname' } | undefined;
+    const teamNameSetting = Settings.findOne({ name: 'teamname' });
     return teamNameSetting?.value.teamName;
   }, []);
 

--- a/imports/server/accounts.ts
+++ b/imports/server/accounts.ts
@@ -138,11 +138,7 @@ function makeView(user: Meteor.User, url: string) {
   };
 }
 
-function updateEmailTemplatesHooks(doc: SettingType) {
-  if (doc.name !== 'email.branding') {
-    return; // this should be impossible
-  }
-
+function updateEmailTemplatesHooks(doc: SettingType & { name: 'email.branding' }) {
   Accounts.emailTemplates.from = doc.value.from ? doc.value.from : 'no-reply@example.com';
   Accounts.emailTemplates.enrollAccount.subject = (user: Meteor.User) => {
     const view = {

--- a/imports/server/addUsersToDiscordRole.ts
+++ b/imports/server/addUsersToDiscordRole.ts
@@ -11,10 +11,10 @@ export default async (userIds: string[], huntId: string) => {
   }
 
   const discordGuildDoc = await Settings.findOneAsync({ name: 'discord.guild' });
-  const guild = discordGuildDoc && discordGuildDoc.name === 'discord.guild' && discordGuildDoc.value.guild;
+  const guild = discordGuildDoc?.value.guild;
 
   const discordBotTokenDoc = await Settings.findOneAsync({ name: 'discord.bot' });
-  const botToken = discordBotTokenDoc && discordBotTokenDoc.name === 'discord.bot' && discordBotTokenDoc.value.token;
+  const botToken = discordBotTokenDoc?.value.token;
 
   if (!guild || !botToken) {
     Ansible.log('Can not add users to Discord role because Discord is not configured', { userIds, huntId });

--- a/imports/server/getTeamName.ts
+++ b/imports/server/getTeamName.ts
@@ -2,7 +2,7 @@ import Settings from '../lib/models/Settings';
 
 async function getTeamName(): Promise<string> {
   const teamNameObj = await Settings.findOneAsync({ name: 'teamname' });
-  if (teamNameObj && teamNameObj.name === 'teamname') {
+  if (teamNameObj) {
     return teamNameObj.value.teamName;
   }
 

--- a/imports/server/methods/configureOrganizeGoogleDrive.ts
+++ b/imports/server/methods/configureOrganizeGoogleDrive.ts
@@ -8,7 +8,6 @@ import MeteorUsers from '../../lib/models/MeteorUsers';
 import Puzzles from '../../lib/models/Puzzles';
 import Settings from '../../lib/models/Settings';
 import { userMayConfigureGdrive } from '../../lib/permission_stubs';
-import { SettingType } from '../../lib/schemas/Setting';
 import configureOrganizeGoogleDrive from '../../methods/configureOrganizeGoogleDrive';
 import { moveDocument, ensureHuntFolder, ensureDocument } from '../gdrive';
 import HuntFolders from '../models/HuntFolders';
@@ -26,7 +25,7 @@ configureOrganizeGoogleDrive.define({
     Ansible.log('Reorganizing Google Drive files');
 
     // First make sure any existing folders are under the root
-    const root = (await Settings.findOneAsync({ name: 'gdrive.root' })) as SettingType & { name: 'gdrive.root' } | undefined;
+    const root = await Settings.findOneAsync({ name: 'gdrive.root' });
     if (root) {
       await (await HuntFolders.find().fetchAsync()).reduce(async (promise, hf) => {
         await promise;

--- a/imports/server/methods/linkUserDiscordAccount.ts
+++ b/imports/server/methods/linkUserDiscordAccount.ts
@@ -43,10 +43,10 @@ linkUserDiscordAccount.define({
 
     // Invite the user to the guild, if one is configured.
     const discordGuildDoc = await Settings.findOneAsync({ name: 'discord.guild' });
-    const guild = discordGuildDoc && discordGuildDoc.name === 'discord.guild' && discordGuildDoc.value.guild;
+    const guild = discordGuildDoc?.value.guild;
 
     const discordBotTokenDoc = await Settings.findOneAsync({ name: 'discord.bot' });
-    const botToken = discordBotTokenDoc && discordBotTokenDoc.name === 'discord.bot' && discordBotTokenDoc.value.token;
+    const botToken = discordBotTokenDoc?.value.token;
 
     if (guild && botToken) {
       // Invitations to the guild must be performed by the bot user.

--- a/imports/server/setup.ts
+++ b/imports/server/setup.ts
@@ -47,15 +47,11 @@ Meteor.publish('teamName', function () {
   let tracked = false;
   const handle: Meteor.LiveQueryHandle = cursor.observe({
     added: (doc) => {
-      if (doc.name === 'teamname' && doc.value && doc.value.teamName) {
-        tracked = true;
-        this.added('teamName', 'teamName', { name: doc.value.teamName });
-      }
+      tracked = true;
+      this.added('teamName', 'teamName', { name: doc.value.teamName });
     },
     changed: (newDoc) => {
-      if (newDoc.name === 'teamname' && newDoc.value.teamName) {
-        this.changed('teamName', 'teamName', { name: newDoc.value.teamName });
-      }
+      this.changed('teamName', 'teamName', { name: newDoc.value.teamName });
     },
     removed: () => {
       if (tracked) {


### PR DESCRIPTION
If we make a query with a literal value, we can use that to infer something about the types of records that will be returned. This is especially useful for the Settings collection, where we often query on the tag of a tagged union.

I think the biggest argument against this change is that the runtime checks ensure that we aren't, e.g., getting back bogus data from the database. But I'd argue that we're in for a bad time if that's happening regardless of whether or not we have runtime checks in place to prevent it.