### PR TITLE
Respect `disable.discord` circuit breaker

### DIFF
--- a/imports/server/addUsersToDiscordRole.ts
+++ b/imports/server/addUsersToDiscordRole.ts
@@ -8,6 +8,7 @@ import { DiscordBot } from './discord';
 export default async (userIds: string[], huntId: string) => {
   if (Flags.active('disable.discord')) {
     Ansible.log('Can not add users to Discord role because Discord is disabled by feature flag', { userIds, huntId });
+    return;
   }
 
   const discordGuildDoc = await Settings.findOneAsync({ name: 'discord.guild' });


### PR DESCRIPTION
We logged about it, but didn't early-exit, which is really the most important part.