### PR TITLE
Ignore whitespace when looking for duplicate answers

### DIFF
--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -878,7 +878,10 @@ const PuzzleGuessModal = React.forwardRef(({
   }, []);
 
   const onSubmitGuess = useCallback(() => {
-    const repeatGuess = guesses.find((g) => { return g.guess === guessInput; });
+    const strippedGuess = guessInput.replaceAll(/\s/, '');
+    const repeatGuess = guesses.find((g) => {
+      return g.guess.replaceAll(/\s/, '') === strippedGuess;
+    });
     const alreadySolved = puzzle.answers.length >= puzzle.expectedAnswerCount;
     if ((repeatGuess || alreadySolved) && !confirmingSubmit) {
       const repeatGuessStr = repeatGuess ? 'This answer has already been submitted. ' : '';


### PR DESCRIPTION
We give a client-side warning when a user attempts to submit an answer that has already been submitted. However, this warning only looks for exact equality, meaning that we won't warn if the only difference is whitespace.

Since this is only a warning and not a block, it seems acceptable if this results in some false-positives, but it should have prevented duplicate answers that were ultimately rejected in hunts past.