### PR TITLE
New helper for optional TypedMethod args

### DIFF
--- a/imports/methods/TypedMethod.ts
+++ b/imports/methods/TypedMethod.ts
@@ -1,4 +1,4 @@
-import { check } from 'meteor/check';
+import { check, Match } from 'meteor/check';
 import { EJSONable, EJSONableProperty } from 'meteor/ejson';
 import { Meteor } from 'meteor/meteor';
 import ValidateShape from '../lib/ValidateShape';
@@ -27,6 +27,10 @@ type TypedMethodCallPromiseArgs<T, Arg extends TypedMethodArgs> =
   Arg extends void ?
     [] :
     [ValidateShape<T, Arg>];
+
+export const optional = <T extends Match.Pattern>(pattern: T) => {
+  return Match.OneOf(Match.Optional(pattern), undefined);
+};
 
 const voidValidator = () => { /* noop */ };
 

--- a/imports/server/methods/configureDiscordBotGuild.ts
+++ b/imports/server/methods/configureDiscordBotGuild.ts
@@ -1,15 +1,16 @@
-import { check, Match } from 'meteor/check';
+import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import Ansible from '../../Ansible';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Settings from '../../lib/models/Settings';
 import { userMayConfigureDiscordBot } from '../../lib/permission_stubs';
+import { optional } from '../../methods/TypedMethod';
 import configureDiscordBotGuild from '../../methods/configureDiscordBotGuild';
 
 configureDiscordBotGuild.define({
   validate(arg) {
     check(arg, {
-      guild: Match.Optional({
+      guild: optional({
         id: String,
         name: String,
       }),

--- a/imports/server/methods/configureEmailBranding.ts
+++ b/imports/server/methods/configureEmailBranding.ts
@@ -1,18 +1,19 @@
-import { check, Match } from 'meteor/check';
+import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Settings from '../../lib/models/Settings';
 import { userMayConfigureEmailBranding } from '../../lib/permission_stubs';
+import { optional } from '../../methods/TypedMethod';
 import configureEmailBranding from '../../methods/configureEmailBranding';
 
 configureEmailBranding.define({
   validate(arg) {
     check(arg, {
-      from: Match.Optional(String),
-      enrollSubject: Match.Optional(String),
-      enrollMessage: Match.Optional(String),
-      joinSubject: Match.Optional(String),
-      joinMessage: Match.Optional(String),
+      from: optional(String),
+      enrollSubject: optional(String),
+      enrollMessage: optional(String),
+      joinSubject: optional(String),
+      joinMessage: optional(String),
     });
     return arg;
   },

--- a/imports/server/methods/configureGdriveRoot.ts
+++ b/imports/server/methods/configureGdriveRoot.ts
@@ -1,14 +1,15 @@
-import { check, Match } from 'meteor/check';
+import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Settings from '../../lib/models/Settings';
 import { userMayConfigureGdrive } from '../../lib/permission_stubs';
+import { optional } from '../../methods/TypedMethod';
 import configureGdriveRoot from '../../methods/configureGdriveRoot';
 
 configureGdriveRoot.define({
   validate(arg) {
     check(arg, {
-      root: Match.Optional(String),
+      root: optional(String),
     });
     return arg;
   },

--- a/imports/server/methods/configureGdriveTemplates.ts
+++ b/imports/server/methods/configureGdriveTemplates.ts
@@ -1,15 +1,16 @@
-import { check, Match } from 'meteor/check';
+import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Settings from '../../lib/models/Settings';
 import { userMayConfigureGdrive } from '../../lib/permission_stubs';
+import { optional } from '../../methods/TypedMethod';
 import configureGdriveTemplates from '../../methods/configureGdriveTemplates';
 
 configureGdriveTemplates.define({
   validate(arg) {
     check(arg, {
-      spreadsheetTemplate: Match.Optional(String),
-      documentTemplate: Match.Optional(String),
+      spreadsheetTemplate: optional(String),
+      documentTemplate: optional(String),
     });
     return arg;
   },

--- a/imports/server/methods/configureTeamName.ts
+++ b/imports/server/methods/configureTeamName.ts
@@ -1,14 +1,15 @@
-import { check, Match } from 'meteor/check';
+import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Settings from '../../lib/models/Settings';
 import { userMayConfigureTeamName } from '../../lib/permission_stubs';
+import { optional } from '../../methods/TypedMethod';
 import configureTeamName from '../../methods/configureTeamName';
 
 configureTeamName.define({
   validate(arg) {
     check(arg, {
-      teamName: Match.Optional(String),
+      teamName: optional(String),
     });
     return arg;
   },

--- a/imports/server/methods/createPuzzle.ts
+++ b/imports/server/methods/createPuzzle.ts
@@ -7,6 +7,7 @@ import GdriveMimeTypes, { GdriveMimeTypesType } from '../../lib/GdriveMimeTypes'
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Puzzles from '../../lib/models/Puzzles';
 import { userMayWritePuzzlesForHunt } from '../../lib/permission_stubs';
+import { optional } from '../../methods/TypedMethod';
 import createPuzzle from '../../methods/createPuzzle';
 import GlobalHooks from '../GlobalHooks';
 import { ensureDocument } from '../gdrive';
@@ -18,7 +19,7 @@ createPuzzle.define({
     check(arg, {
       huntId: String,
       title: String,
-      url: Match.Optional(String),
+      url: optional(String),
       tags: [String],
       expectedAnswerCount: Number,
       docType: Match.OneOf(...Object.keys(GdriveMimeTypes) as GdriveMimeTypesType[]),

--- a/imports/server/methods/destroyPuzzle.ts
+++ b/imports/server/methods/destroyPuzzle.ts
@@ -1,10 +1,11 @@
-import { check, Match } from 'meteor/check';
+import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import Flags from '../../Flags';
 import Documents from '../../lib/models/Documents';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Puzzles from '../../lib/models/Puzzles';
 import { userMayWritePuzzlesForHunt } from '../../lib/permission_stubs';
+import { optional } from '../../methods/TypedMethod';
 import destroyPuzzle from '../../methods/destroyPuzzle';
 import { makeReadOnly } from '../gdrive';
 
@@ -12,7 +13,7 @@ destroyPuzzle.define({
   validate(arg) {
     check(arg, {
       puzzleId: String,
-      replacedBy: Match.Optional(String),
+      replacedBy: optional(String),
     });
     return arg;
   },

--- a/imports/server/methods/fetchAPIKey.ts
+++ b/imports/server/methods/fetchAPIKey.ts
@@ -1,6 +1,7 @@
-import { check, Match } from 'meteor/check';
+import { check } from 'meteor/check';
 import { Random } from 'meteor/random';
 import Ansible from '../../Ansible';
+import { optional } from '../../methods/TypedMethod';
 import fetchAPIKey from '../../methods/fetchAPIKey';
 import APIKeys from '../models/APIKeys';
 import Locks from '../models/Locks';
@@ -8,7 +9,7 @@ import userForKeyOperation from '../userForKeyOperation';
 
 fetchAPIKey.define({
   validate(arg) {
-    check(arg, { forUser: Match.Optional(String) });
+    check(arg, { forUser: optional(String) });
 
     return arg;
   },

--- a/imports/server/methods/logAnsibleMessage.ts
+++ b/imports/server/methods/logAnsibleMessage.ts
@@ -1,6 +1,7 @@
 import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import logfmt from 'logfmt';
+import { optional } from '../../methods/TypedMethod';
 import logAnsibleMessage, { logLevels } from '../../methods/logAnsibleMessage';
 
 logAnsibleMessage.define({
@@ -8,7 +9,7 @@ logAnsibleMessage.define({
     check(arg, {
       level: Match.OneOf(...logLevels),
       line: String,
-      obj: Match.Optional(Object),
+      obj: optional(Object),
     });
     return arg;
   },

--- a/imports/server/methods/rollAPIKey.ts
+++ b/imports/server/methods/rollAPIKey.ts
@@ -1,5 +1,6 @@
-import { check, Match } from 'meteor/check';
+import { check } from 'meteor/check';
 import Ansible from '../../Ansible';
+import { optional } from '../../methods/TypedMethod';
 import fetchAPIKey from '../../methods/fetchAPIKey';
 import rollAPIKey from '../../methods/rollAPIKey';
 import APIKeys from '../models/APIKeys';
@@ -7,7 +8,7 @@ import userForKeyOperation from '../userForKeyOperation';
 
 rollAPIKey.define({
   validate(arg) {
-    check(arg, { forUser: Match.Optional(String) });
+    check(arg, { forUser: optional(String) });
 
     return arg;
   },

--- a/imports/server/methods/setGuessState.ts
+++ b/imports/server/methods/setGuessState.ts
@@ -5,6 +5,7 @@ import Guesses from '../../lib/models/Guesses';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import { userMayUpdateGuessesForHunt } from '../../lib/permission_stubs';
 import { GuessCodec } from '../../lib/schemas/Guess';
+import { optional } from '../../methods/TypedMethod';
 import setGuessState from '../../methods/setGuessState';
 import transitionGuess from '../transitionGuess';
 
@@ -13,7 +14,7 @@ setGuessState.define({
     check(arg, {
       guessId: String,
       state: Match.OneOf(...GuessCodec.props.state.types.map((t) => t.value)),
-      additionalNotes: Match.Optional(String),
+      additionalNotes: optional(String),
     });
     return arg;
   },

--- a/imports/server/methods/updatePuzzle.ts
+++ b/imports/server/methods/updatePuzzle.ts
@@ -1,4 +1,4 @@
-import { check, Match } from 'meteor/check';
+import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import Ansible from '../../Ansible';
@@ -6,6 +6,7 @@ import MeteorUsers from '../../lib/models/MeteorUsers';
 import Puzzles from '../../lib/models/Puzzles';
 import { userMayWritePuzzlesForHunt } from '../../lib/permission_stubs';
 import { PuzzleType } from '../../lib/schemas/Puzzle';
+import { optional } from '../../methods/TypedMethod';
 import updatePuzzle from '../../methods/updatePuzzle';
 import { ensureDocument, renameDocument } from '../gdrive';
 import getOrCreateTagByName from '../getOrCreateTagByName';
@@ -16,7 +17,7 @@ updatePuzzle.define({
     check(arg, {
       puzzleId: String,
       title: String,
-      url: Match.Optional(String),
+      url: optional(String),
       tags: [String],
       expectedAnswerCount: Number,
     });


### PR DESCRIPTION
Match.Optional and Match.Maybe have slightly weird behavior when used in a pattern for an object. In an object, they match if the key is absent, but _not_ if the key is explicitly set to undefined.

This is mostly not a problem for our TypedMethods, because null and undefined values are stripped out by EJSON encoding. But that doesn't happen when we invoke a method from server-side code (such as when we use Ansible.log), which can cause spurious match failures.

This introduces a custom matcher which allows for explicit undefine and switches all TypedMethod's check methods to use it. This isn't strictly necessary (since it only matters for methods we want to invoke from the server with explicit undefined values), but is good for consistency and to encourage good copy-pasting.

I specifically ran into this with the "Reorganize Google Drive" button, since the implementation of that method logs something without passing an object as a second argument.