### PR TITLE
Eliminate database queries from permission_stubs

### DIFF
--- a/imports/client/components/AnnouncementsPage.tsx
+++ b/imports/client/components/AnnouncementsPage.tsx
@@ -8,6 +8,7 @@ import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { calendarTimeFormat } from '../../lib/calendarTimeFormat';
 import Announcements from '../../lib/models/Announcements';
+import Hunts from '../../lib/models/Hunts';
 import { indexedDisplayNames } from '../../lib/models/MeteorUsers';
 import { userMayAddAnnouncementToHunt } from '../../lib/permission_stubs';
 import { AnnouncementType } from '../../lib/schemas/Announcement';
@@ -140,7 +141,7 @@ const AnnouncementsPage = () => {
     loading ? [] : Announcements.find({ hunt: huntId }, { sort: { createdAt: 1 } }).fetch()
   ), [loading, huntId]);
   const displayNames = useTracker(() => (loading ? {} : indexedDisplayNames()), [loading]);
-  const canCreateAnnouncements = useTracker(() => userMayAddAnnouncementToHunt(Meteor.user(), huntId), [huntId]);
+  const canCreateAnnouncements = useTracker(() => userMayAddAnnouncementToHunt(Meteor.user(), Hunts.findOne(huntId)), [huntId]);
 
   if (loading) {
     return <div>loading...</div>;

--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -433,7 +433,7 @@ const GuessQueuePage = () => {
   const guesses = useTracker(() => (loading ? [] : Guesses.find({ hunt: huntId }, { sort: { createdAt: -1 } }).fetch()), [huntId, loading]);
   const puzzles = useTracker(() => (loading ? new Map<string, PuzzleType>() : indexedById(Puzzles.find({ hunt: huntId }).fetch())), [huntId, loading]);
   const displayNames = useTracker(() => (loading ? {} : indexedDisplayNames()), [loading]);
-  const canEdit = useTracker(() => userMayUpdateGuessesForHunt(Meteor.user(), huntId), [huntId]);
+  const canEdit = useTracker(() => userMayUpdateGuessesForHunt(Meteor.user(), hunt), [hunt]);
 
   const searchBarRef = useRef<HTMLInputElement>(null);
 

--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -122,10 +122,10 @@ const HuntApp = React.memo(() => {
   } = useTracker(() => {
     return {
       member: Meteor.user()?.hunts?.includes(huntId) ?? false,
-      canUndestroy: userMayUpdateHunt(Meteor.user(), huntId),
-      canJoin: userMayAddUsersToHunt(Meteor.user(), huntId),
+      canUndestroy: userMayUpdateHunt(Meteor.user(), hunt),
+      canJoin: userMayAddUsersToHunt(Meteor.user(), hunt),
     };
-  }, [huntId]);
+  }, [huntId, hunt]);
 
   useBreadcrumb({
     title: loading || !hunt ? 'loading...' : hunt.name,

--- a/imports/client/components/HuntListPage.tsx
+++ b/imports/client/components/HuntListPage.tsx
@@ -26,13 +26,13 @@ const Hunt = React.memo(({ hunt }: { hunt: HuntType }) => {
 
   const { canUpdate, canDestroy } = useTracker(() => {
     return {
-      canUpdate: userMayUpdateHunt(Meteor.user(), huntId),
+      canUpdate: userMayUpdateHunt(Meteor.user(), hunt),
 
       // Because we delete by setting the deleted flag, you only need
       // update to "remove" something
-      canDestroy: userMayUpdateHunt(Meteor.user(), huntId),
+      canDestroy: userMayUpdateHunt(Meteor.user(), hunt),
     };
-  }, [huntId]);
+  }, [hunt]);
 
   const deleteModalRef = useRef<ModalFormHandle>(null);
 

--- a/imports/client/components/HuntProfileListPage.tsx
+++ b/imports/client/components/HuntProfileListPage.tsx
@@ -2,6 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import React from 'react';
 import { useParams } from 'react-router-dom';
+import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import {
   listAllRolesForHunt, userMayAddUsersToHunt, userMayMakeOperatorForHunt, userMayUseDiscordBotAPIs,
@@ -26,19 +27,20 @@ const HuntProfileListPage = () => {
       ).fetch()
   ), [huntId, loading]);
 
+  const hunt = useTracker(() => Hunts.findOne(huntId), [huntId]);
   const { canInvite, canSyncDiscord, canMakeOperator } = useTracker(() => {
     return {
-      canInvite: userMayAddUsersToHunt(Meteor.user(), huntId),
+      canInvite: userMayAddUsersToHunt(Meteor.user(), hunt),
       canSyncDiscord: userMayUseDiscordBotAPIs(Meteor.user()),
-      canMakeOperator: userMayMakeOperatorForHunt(Meteor.user(), huntId),
+      canMakeOperator: userMayMakeOperatorForHunt(Meteor.user(), hunt),
     };
-  }, [huntId]);
+  }, [hunt]);
   const roles = useTracker(() => (
     loading || !canMakeOperator ?
       {} :
       Object.fromEntries(MeteorUsers.find({ hunts: huntId })
-        .map((u) => [u._id, listAllRolesForHunt(u, huntId)]))
-  ), [huntId, loading, canMakeOperator]);
+        .map((u) => [u._id, listAllRolesForHunt(u, hunt)]))
+  ), [huntId, hunt, loading, canMakeOperator]);
 
   if (loading) {
     return <div>loading...</div>;
@@ -48,7 +50,7 @@ const HuntProfileListPage = () => {
     <ProfileList
       users={users}
       roles={roles}
-      huntId={huntId}
+      hunt={hunt}
       canInvite={canInvite}
       canSyncDiscord={canSyncDiscord}
       canMakeOperator={canMakeOperator}

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -496,10 +496,10 @@ const PuzzleListPage = () => {
   const hunt = useTracker(() => Hunts.findOne(huntId)!, [huntId]);
   const { canAdd, canUpdate } = useTracker(() => {
     return {
-      canAdd: userMayWritePuzzlesForHunt(Meteor.user(), huntId),
-      canUpdate: userMayWritePuzzlesForHunt(Meteor.user(), huntId),
+      canAdd: userMayWritePuzzlesForHunt(Meteor.user(), hunt),
+      canUpdate: userMayWritePuzzlesForHunt(Meteor.user(), hunt),
     };
-  }, [huntId]);
+  }, [hunt]);
 
   const huntLink = hunt.homepageUrl && (
     <StyledPuzzleListExternalLink>

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -637,8 +637,9 @@ const PuzzlePageMetadata = ({
   const huntId = puzzle.hunt;
   const puzzleId = puzzle._id;
 
-  const hasGuessQueue = useTracker(() => Hunts.findOne(huntId)?.hasGuessQueue ?? false, [huntId]);
-  const canUpdate = useTracker(() => userMayWritePuzzlesForHunt(Meteor.user(), huntId), [huntId]);
+  const hunt = useTracker(() => Hunts.findOne(huntId), [huntId]);
+  const hasGuessQueue = hunt?.hasGuessQueue ?? false;
+  const canUpdate = useTracker(() => userMayWritePuzzlesForHunt(Meteor.user(), hunt), [hunt]);
 
   const allPuzzles = useTracker(() => Puzzles.find({ hunt: huntId }).fetch(), [huntId]);
   const allTags = useTracker(() => Tags.find({ hunt: huntId }).fetch(), [huntId]);
@@ -1181,7 +1182,7 @@ const PuzzlePageMultiplayerDocument = React.memo(({ document }: {
 const PuzzleDeletedModal = ({
   puzzleId, huntId, replacedBy,
 }: { puzzleId: string, huntId: string, replacedBy?: string }) => {
-  const canUpdate = useTracker(() => userMayWritePuzzlesForHunt(Meteor.user(), huntId), [huntId]);
+  const canUpdate = useTracker(() => userMayWritePuzzlesForHunt(Meteor.user(), Hunts.findOne(huntId)), [huntId]);
 
   const replacementLoading = useSubscribe('mongo.puzzles.allowingDeleted', { _id: replacedBy });
   const loading = replacementLoading();

--- a/imports/client/components/UserInvitePage.tsx
+++ b/imports/client/components/UserInvitePage.tsx
@@ -10,6 +10,7 @@ import FormLabel from 'react-bootstrap/FormLabel';
 import Row from 'react-bootstrap/Row';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import Hunts from '../../lib/models/Hunts';
 import { userMayBulkAddToHunt } from '../../lib/permission_stubs';
 import addHuntUser from '../../methods/addHuntUser';
 import bulkAddHuntUsers from '../../methods/bulkAddHuntUsers';
@@ -30,7 +31,7 @@ const UserInvitePage = () => {
   const [bulkError, setBulkError] = useState<Meteor.Error | undefined>(undefined);
 
   const canBulkInvite = useTracker(() => {
-    return userMayBulkAddToHunt(Meteor.user(), huntId);
+    return userMayBulkAddToHunt(Meteor.user(), Hunts.findOne(huntId));
   }, [huntId]);
 
   const onEmailChanged: NonNullable<FormControlProps['onChange']> = useCallback((e) => {

--- a/imports/lib/permission_stubs.ts
+++ b/imports/lib/permission_stubs.ts
@@ -1,39 +1,35 @@
 import { Meteor } from 'meteor/meteor';
 import isAdmin, { GLOBAL_SCOPE } from './isAdmin';
-import Hunts from './models/Hunts';
 import MeteorUsers from './models/MeteorUsers';
+import { HuntType } from './schemas/Hunt';
 
-function isOperatorForHunt(user: Meteor.User, huntId: string): boolean {
-  return user.roles?.[huntId]?.includes('operator') ?? false;
+function isOperatorForHunt(user: Meteor.User, hunt: HuntType): boolean {
+  return user.roles?.[hunt._id]?.includes('operator') ?? false;
 }
 
 export function listAllRolesForHunt(
   user: Meteor.User | null | undefined,
-  huntId: string
+  hunt: HuntType | null | undefined,
 ): string[] {
-  if (!user) {
-    return [];
-  }
-
-  if (!user.roles) {
+  if (!user?.roles || !hunt) {
     return [];
   }
 
   return [
     ...user.roles[GLOBAL_SCOPE] ?? [],
-    ...user.roles[huntId] ?? [],
+    ...user.roles[hunt._id] ?? [],
   ];
 }
 
 export function userIsOperatorForHunt(
   user: Meteor.User | null | undefined,
-  huntId: string
+  hunt: HuntType | null | undefined,
 ): boolean {
-  if (!user) {
+  if (!user || !hunt) {
     return false;
   }
 
-  return isOperatorForHunt(user, huntId);
+  return isOperatorForHunt(user, hunt);
 }
 
 export function userIsOperatorForAnyHunt(user: Meteor.User | null | undefined): boolean {
@@ -53,9 +49,9 @@ export function userIsOperatorForAnyHunt(user: Meteor.User | null | undefined): 
 // already and if the hunt allows open signups.
 export function userMayAddUsersToHunt(
   user: Meteor.User | null | undefined,
-  huntId: string
+  hunt: HuntType | null | undefined,
 ): boolean {
-  if (!user) {
+  if (!user || !hunt) {
     return false;
   }
 
@@ -64,7 +60,7 @@ export function userMayAddUsersToHunt(
     return true;
   }
 
-  if (isOperatorForHunt(user, huntId)) {
+  if (isOperatorForHunt(user, hunt)) {
     return true;
   }
 
@@ -74,13 +70,7 @@ export function userMayAddUsersToHunt(
     return false;
   }
 
-  if (!joinedHunts.includes(huntId)) {
-    return false;
-  }
-
-  // You can only add users to a hunt that actually exists.
-  const hunt = Hunts.findOne(huntId);
-  if (!hunt) {
+  if (!joinedHunts.includes(hunt._id)) {
     return false;
   }
 
@@ -90,9 +80,9 @@ export function userMayAddUsersToHunt(
 // Admins and operators may add announcements to a hunt.
 export function userMayAddAnnouncementToHunt(
   user: Meteor.User | null | undefined,
-  huntId: string,
+  hunt: HuntType | null | undefined,
 ): boolean {
-  if (!user) {
+  if (!user || !hunt) {
     return false;
   }
 
@@ -100,12 +90,7 @@ export function userMayAddAnnouncementToHunt(
     return true;
   }
 
-  const hunt = Hunts.findOne(huntId);
-  if (!hunt) {
-    return false;
-  }
-
-  if (isOperatorForHunt(user, huntId)) {
+  if (isOperatorForHunt(user, hunt)) {
     return true;
   }
 
@@ -114,9 +99,9 @@ export function userMayAddAnnouncementToHunt(
 
 export function userMayMakeOperatorForHunt(
   user: Meteor.User | null | undefined,
-  huntId: string,
+  hunt: HuntType | null | undefined,
 ): boolean {
-  if (!user) {
+  if (!user || !hunt) {
     return false;
   }
 
@@ -124,12 +109,7 @@ export function userMayMakeOperatorForHunt(
     return true;
   }
 
-  const hunt = Hunts.findOne(huntId);
-  if (!hunt) {
-    return false;
-  }
-
-  if (isOperatorForHunt(user, huntId)) {
+  if (isOperatorForHunt(user, hunt)) {
     return true;
   }
 
@@ -138,9 +118,9 @@ export function userMayMakeOperatorForHunt(
 
 export function userMaySeeUserInfoForHunt(
   user: Meteor.User | null | undefined,
-  huntId: string
+  hunt: HuntType | null | undefined,
 ): boolean {
-  if (!user) {
+  if (!user || !hunt) {
     return false;
   }
 
@@ -148,12 +128,7 @@ export function userMaySeeUserInfoForHunt(
     return true;
   }
 
-  const hunt = Hunts.findOne(huntId);
-  if (!hunt) {
-    return false;
-  }
-
-  if (isOperatorForHunt(user, huntId)) {
+  if (isOperatorForHunt(user, hunt)) {
     return true;
   }
 
@@ -162,9 +137,9 @@ export function userMaySeeUserInfoForHunt(
 
 export function userMayBulkAddToHunt(
   user: Meteor.User | null | undefined,
-  huntId: string
+  hunt: HuntType | null | undefined,
 ): boolean {
-  if (!user) {
+  if (!user || !hunt) {
     return false;
   }
 
@@ -172,7 +147,7 @@ export function userMayBulkAddToHunt(
     return true;
   }
 
-  if (isOperatorForHunt(user, huntId)) {
+  if (isOperatorForHunt(user, hunt)) {
     return true;
   }
 
@@ -219,15 +194,15 @@ export function userMayConfigureAssets(user: Meteor.User | null | undefined): bo
 
 export function userMayUpdateGuessesForHunt(
   user: Meteor.User | null | undefined,
-  huntId: string,
+  hunt: HuntType | null | undefined,
 ): boolean {
-  if (!user) {
+  if (!user || !hunt) {
     return false;
   }
   if (isAdmin(user)) {
     return true;
   }
-  if (isOperatorForHunt(user, huntId)) {
+  if (isOperatorForHunt(user, hunt)) {
     return true;
   }
   return false;
@@ -235,15 +210,15 @@ export function userMayUpdateGuessesForHunt(
 
 export function userMayWritePuzzlesForHunt(
   user: Meteor.User | null | undefined,
-  huntId: string,
+  hunt: HuntType | null | undefined,
 ): boolean {
-  if (!user) {
+  if (!user || !hunt) {
     return false;
   }
   if (isAdmin(user)) {
     return true;
   }
-  if (isOperatorForHunt(user, huntId)) {
+  if (isOperatorForHunt(user, hunt)) {
     return true;
   }
   return false;
@@ -253,22 +228,25 @@ export function userMayCreateHunt(user: Meteor.User | null | undefined): boolean
   return isAdmin(user);
 }
 
-export function userMayUpdateHunt(user: Meteor.User | null | undefined, _huntId: string): boolean {
+export function userMayUpdateHunt(
+  user: Meteor.User | null | undefined,
+  _hunt: HuntType | null | undefined,
+): boolean {
   // TODO: make this driven by if you're an operator of the hunt in question
   return isAdmin(user);
 }
 
 export function userMayJoinCallsForHunt(
   user: Meteor.User | null | undefined,
-  huntId: string,
+  hunt: HuntType | null | undefined,
 ): boolean {
-  if (!user) {
+  if (!user || !hunt) {
     return false;
   }
   if (isAdmin(user)) {
     return true;
   }
-  if (user.hunts?.includes(huntId)) {
+  if (user.hunts?.includes(hunt._id)) {
     return true;
   }
   return false;

--- a/imports/server/mediasoup-api.ts
+++ b/imports/server/mediasoup-api.ts
@@ -3,6 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import { Promise as MeteorPromise } from 'meteor/promise';
 import Ansible from '../Ansible';
 import Flags from '../Flags';
+import Hunts from '../lib/models/Hunts';
 import MeteorUsers from '../lib/models/MeteorUsers';
 import Servers from '../lib/models/Servers';
 import CallHistories from '../lib/models/mediasoup/CallHistories';
@@ -88,7 +89,10 @@ Meteor.publish('mediasoup:metadata', async function (hunt, call) {
     throw new Meteor.Error(401, 'Not logged in');
   }
 
-  if (!userMayJoinCallsForHunt(await MeteorUsers.findOneAsync(this.userId), hunt)) {
+  if (!userMayJoinCallsForHunt(
+    await MeteorUsers.findOneAsync(this.userId),
+    await Hunts.findOneAsync(hunt)
+  )) {
     throw new Meteor.Error(403, 'Not a member of this hunt');
   }
 
@@ -107,7 +111,10 @@ Meteor.publish('mediasoup:join', async function (hunt, call, tab) {
     throw new Meteor.Error(401, 'Not logged in');
   }
 
-  if (!userMayJoinCallsForHunt(await MeteorUsers.findOneAsync(this.userId), hunt)) {
+  if (!userMayJoinCallsForHunt(
+    await MeteorUsers.findOneAsync(this.userId),
+    await Hunts.findOneAsync(hunt),
+  )) {
     throw new Meteor.Error(403, 'Not a member of this hunt');
   }
 

--- a/imports/server/methods/addHuntUser.ts
+++ b/imports/server/methods/addHuntUser.ts
@@ -92,7 +92,7 @@ addHuntUser.define({
       throw new Meteor.Error(404, 'Unknown hunt');
     }
 
-    if (!userMayAddUsersToHunt(await MeteorUsers.findOneAsync(this.userId), huntId)) {
+    if (!userMayAddUsersToHunt(await MeteorUsers.findOneAsync(this.userId), hunt)) {
       throw new Meteor.Error(401, `User ${this.userId} may not add members to ${huntId}`);
     }
 

--- a/imports/server/methods/bulkAddHuntUsers.ts
+++ b/imports/server/methods/bulkAddHuntUsers.ts
@@ -18,15 +18,15 @@ bulkAddHuntUsers.define({
   async run({ huntId, emails }) {
     check(this.userId, String);
 
-    if (!userMayBulkAddToHunt(await MeteorUsers.findOneAsync(this.userId), huntId)) {
-      throw new Meteor.Error(401, `User ${this.userId} may not bulk-invite to hunt ${huntId}`);
-    }
-
     // We'll re-do this check but if we check it now the error reporting will be
     // better
     const hunt = await Hunts.findOneAsync(huntId);
     if (!hunt) {
       throw new Meteor.Error(404, 'Unknown hunt');
+    }
+
+    if (!userMayBulkAddToHunt(await MeteorUsers.findOneAsync(this.userId), hunt)) {
+      throw new Meteor.Error(401, `User ${this.userId} may not bulk-invite to hunt ${huntId}`);
     }
 
     const errors: { email: string, error: any }[] = [];

--- a/imports/server/methods/createPuzzle.ts
+++ b/imports/server/methods/createPuzzle.ts
@@ -4,6 +4,7 @@ import { Random } from 'meteor/random';
 import Ansible from '../../Ansible';
 import Flags from '../../Flags';
 import GdriveMimeTypes, { GdriveMimeTypesType } from '../../lib/GdriveMimeTypes';
+import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Puzzles from '../../lib/models/Puzzles';
 import { userMayWritePuzzlesForHunt } from '../../lib/permission_stubs';
@@ -31,7 +32,12 @@ createPuzzle.define({
   }) {
     check(this.userId, String);
 
-    if (!userMayWritePuzzlesForHunt(await MeteorUsers.findOneAsync(this.userId), huntId)) {
+    const hunt = await Hunts.findOneAsync(huntId);
+    if (!hunt) {
+      throw new Meteor.Error(404, 'Unknown hunt id');
+    }
+
+    if (!userMayWritePuzzlesForHunt(await MeteorUsers.findOneAsync(this.userId), hunt)) {
       throw new Meteor.Error(
         401,
         `User ${this.userId} may not create new puzzles for hunt ${huntId}`

--- a/imports/server/methods/demoteOperator.ts
+++ b/imports/server/methods/demoteOperator.ts
@@ -1,6 +1,7 @@
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import Ansible from '../../Ansible';
+import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import { removeUserFromRole, userMayMakeOperatorForHunt } from '../../lib/permission_stubs';
 import demoteOperator from '../../methods/demoteOperator';
@@ -17,7 +18,10 @@ demoteOperator.define({
   async run({ targetUserId, huntId }) {
     check(this.userId, String);
 
-    if (!userMayMakeOperatorForHunt(await MeteorUsers.findOneAsync(this.userId), huntId)) {
+    if (!userMayMakeOperatorForHunt(
+      await MeteorUsers.findOneAsync(this.userId),
+      await Hunts.findOneAsync(huntId),
+    )) {
       throw new Meteor.Error(401, 'Must be operator or inactive operator to demote operator');
     }
 

--- a/imports/server/methods/destroyPuzzle.ts
+++ b/imports/server/methods/destroyPuzzle.ts
@@ -2,6 +2,7 @@ import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import Flags from '../../Flags';
 import Documents from '../../lib/models/Documents';
+import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Puzzles from '../../lib/models/Puzzles';
 import { userMayWritePuzzlesForHunt } from '../../lib/permission_stubs';
@@ -24,7 +25,10 @@ destroyPuzzle.define({
     if (!puzzle) {
       throw new Meteor.Error(404, 'Unknown puzzle id');
     }
-    if (!userMayWritePuzzlesForHunt(await MeteorUsers.findOneAsync(this.userId), puzzle.hunt)) {
+    if (!userMayWritePuzzlesForHunt(
+      await MeteorUsers.findOneAsync(this.userId),
+      await Hunts.findOneAsync(puzzle.hunt),
+    )) {
       throw new Meteor.Error(
         401,
         `User ${this.userId} may not modify puzzles from hunt ${puzzle.hunt}`

--- a/imports/server/methods/postAnnouncement.ts
+++ b/imports/server/methods/postAnnouncement.ts
@@ -2,6 +2,7 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import Ansible from '../../Ansible';
 import Announcements from '../../lib/models/Announcements';
+import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import PendingAnnouncements from '../../lib/models/PendingAnnouncements';
 import { userMayAddAnnouncementToHunt } from '../../lib/permission_stubs';
@@ -20,7 +21,10 @@ postAnnouncement.define({
   async run({ huntId, message }) {
     check(this.userId, String);
 
-    if (!userMayAddAnnouncementToHunt(await MeteorUsers.findOneAsync(this.userId), huntId)) {
+    if (!userMayAddAnnouncementToHunt(
+      await MeteorUsers.findOneAsync(this.userId),
+      await Hunts.findOneAsync(huntId),
+    )) {
       throw new Meteor.Error(401, `User ${this.userId} may not create announcements for hunt ${huntId}`);
     }
 

--- a/imports/server/methods/promoteOperator.ts
+++ b/imports/server/methods/promoteOperator.ts
@@ -1,6 +1,7 @@
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import Ansible from '../../Ansible';
+import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import { addUserToRole, userMayMakeOperatorForHunt } from '../../lib/permission_stubs';
 import promoteOperator from '../../methods/promoteOperator';
@@ -17,7 +18,10 @@ promoteOperator.define({
   async run({ targetUserId, huntId }) {
     check(this.userId, String);
 
-    if (!userMayMakeOperatorForHunt(await MeteorUsers.findOneAsync(this.userId), huntId)) {
+    if (!userMayMakeOperatorForHunt(
+      await MeteorUsers.findOneAsync(this.userId),
+      await Hunts.findOneAsync(huntId),
+    )) {
       throw new Meteor.Error(401, 'Must be operator or inactive operator to make operator');
     }
 

--- a/imports/server/methods/setGuessState.ts
+++ b/imports/server/methods/setGuessState.ts
@@ -2,6 +2,7 @@ import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import Ansible from '../../Ansible';
 import Guesses from '../../lib/models/Guesses';
+import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import { userMayUpdateGuessesForHunt } from '../../lib/permission_stubs';
 import { GuessCodec } from '../../lib/schemas/Guess';
@@ -26,7 +27,10 @@ setGuessState.define({
       throw new Meteor.Error(404, 'No such guess');
     }
 
-    if (!userMayUpdateGuessesForHunt(await MeteorUsers.findOneAsync(this.userId), guess.hunt)) {
+    if (!userMayUpdateGuessesForHunt(
+      await MeteorUsers.findOneAsync(this.userId),
+      await Hunts.findOneAsync(guess.hunt),
+    )) {
       throw new Meteor.Error(401, 'Must be permitted to update guesses');
     }
 

--- a/imports/server/methods/undestroyPuzzle.ts
+++ b/imports/server/methods/undestroyPuzzle.ts
@@ -2,6 +2,7 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import Flags from '../../Flags';
 import Documents from '../../lib/models/Documents';
+import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Puzzles from '../../lib/models/Puzzles';
 import { userMayWritePuzzlesForHunt } from '../../lib/permission_stubs';
@@ -23,7 +24,10 @@ undestroyPuzzle.define({
     if (!puzzle) {
       throw new Meteor.Error(404, 'Unknown puzzle id');
     }
-    if (!userMayWritePuzzlesForHunt(await MeteorUsers.findOneAsync(this.userId), puzzle.hunt)) {
+    if (!userMayWritePuzzlesForHunt(
+      await MeteorUsers.findOneAsync(this.userId),
+      await Hunts.findOneAsync(puzzle.hunt),
+    )) {
       throw new Meteor.Error(
         401,
         `User ${this.userId} may not modify puzzles from hunt ${puzzle.hunt}`

--- a/imports/server/methods/updatePuzzle.ts
+++ b/imports/server/methods/updatePuzzle.ts
@@ -2,6 +2,7 @@ import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { Mongo } from 'meteor/mongo';
 import Ansible from '../../Ansible';
+import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Puzzles from '../../lib/models/Puzzles';
 import { userMayWritePuzzlesForHunt } from '../../lib/permission_stubs';
@@ -33,7 +34,8 @@ updatePuzzle.define({
     if (!oldPuzzle) {
       throw new Meteor.Error(404, 'Unknown puzzle id');
     }
-    if (!userMayWritePuzzlesForHunt(await MeteorUsers.findOneAsync(this.userId), oldPuzzle.hunt)) {
+    const hunt = await Hunts.findOneAsync(oldPuzzle.hunt);
+    if (!userMayWritePuzzlesForHunt(await MeteorUsers.findOneAsync(this.userId), hunt)) {
       throw new Meteor.Error(
         401,
         `User ${this.userId} may not modify puzzles from hunt ${oldPuzzle.hunt}`

--- a/tests/acceptance/profiles.tsx
+++ b/tests/acceptance/profiles.tsx
@@ -137,6 +137,7 @@ if (Meteor.isClient) {
         );
 
         await joinHunt.callPromise({ huntId: otherHuntId, userId });
+        await stabilize();
 
         assert.sameMembers(
           MeteorUsers.find({}, { fields: { displayName: 1 } }).map((u) => u.displayName),
@@ -174,6 +175,7 @@ if (Meteor.isClient) {
         assert.sameMembers(u2!.hunts!, [huntId], 'Should not show membership in other hunts even if user is visible');
 
         await joinHunt.callPromise({ huntId: otherHuntId, userId });
+        await stabilize();
 
         u2 = MeteorUsers.findOne(sameHuntUserId);
         assert.sameMembers(u2!.hunts!, [huntId, otherHuntId], 'Should update when hunt membership changes');
@@ -210,6 +212,8 @@ if (Meteor.isClient) {
         assert.sameMembers(operators.map((u) => u._id), [userId, sameHuntUserId], 'Should only show operators in hunt where you are an operator');
 
         await addUserToRole.callPromise({ userId, scope: otherHuntId, role: 'operator' });
+        await stabilize();
+
         operators = MeteorUsers.find().fetch().filter(userIsOperatorForAnyHunt);
         assert.sameMembers(operators.map((u) => u._id), [userId, sameHuntUserId, differentHuntUserId], 'Should update when hunt roles changes');
       });


### PR DESCRIPTION
We were still looking up hunts in permission_stubs, so this gets rid of some more synchronous calls that would run on the server-side.