### PR TITLE
Guess modal improvements

### DIFF
--- a/client/stylesheets/app.scss
+++ b/client/stylesheets/app.scss
@@ -1,7 +1,7 @@
 // Standard font
 @import url("https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital,wght@0,400;0,700;1,400;1,700&display=swap");
 // Answer monospace font
-@import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@300&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@400&display=swap');
 
 @import "theme";
 @import "../../node_modules/bootstrap/scss/bootstrap";

--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -2,16 +2,11 @@
 import { Meteor } from 'meteor/meteor';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import { faBackward } from '@fortawesome/free-solid-svg-icons/faBackward';
-import { faBan } from '@fortawesome/free-solid-svg-icons/faBan';
-import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
-import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
 import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
 import { faEraser } from '@fortawesome/free-solid-svg-icons/faEraser';
-import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclamationCircle';
 import { faForward } from '@fortawesome/free-solid-svg-icons/faForward';
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
 import { faSkullCrossbones } from '@fortawesome/free-solid-svg-icons/faSkullCrossbones';
-import { faTimesCircle } from '@fortawesome/free-solid-svg-icons/faTimesCircle';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, { useCallback, useEffect, useRef } from 'react';
 import Button from 'react-bootstrap/Button';
@@ -38,9 +33,10 @@ import { guessURL } from '../../model-helpers';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 import useSubscribeDisplayNames from '../hooks/useSubscribeDisplayNames';
 import markdown from '../markdown';
+import GuessState from './GuessState';
 import PuzzleAnswer from './PuzzleAnswer';
 import Breakable from './styling/Breakable';
-import { NavBarHeight } from './styling/constants';
+import { guessColorLookupTable, NavBarHeight } from './styling/constants';
 import { Breakpoint, mediaBreakpointDown } from './styling/responsive';
 
 const compactViewBreakpoint: Breakpoint = 'lg';
@@ -80,43 +76,11 @@ const StyledRow = styled.div<{ $state: GuessType['state'] }>`
   margin-bottom: 8px;
 
   * {
-    background-color:
-      ${(props) => {
-    switch (props.$state) {
-      case 'correct':
-        return '#f0fff0';
-      case 'intermediate':
-        return '#fffff0';
-      case 'incorrect':
-        return '#fff0f0';
-      case 'rejected':
-        return '#f0f0f0';
-      case 'pending':
-        return '#f0f0ff';
-      default:
-        return '#fff';
-    }
-  }};
+    background-color: ${(props) => guessColorLookupTable[props.$state].background};
   }
 
   :hover * {
-    background-color:
-      ${(props) => {
-    switch (props.$state) {
-      case 'correct':
-        return '#d0ffd0';
-      case 'intermediate':
-        return '#ffffd0';
-      case 'incorrect':
-        return '#ffd0d0';
-      case 'rejected':
-        return '#d0d0d0';
-      case 'pending':
-        return '#d0d0ff';
-      default:
-        return '#fff';
-    }
-  }};
+    background-color: ${(props) => guessColorLookupTable[props.$state].hoverBackground};
   }
 `;
 
@@ -268,57 +232,6 @@ const GuessBlock = React.memo(({
     </Tooltip>
   );
 
-  let displayState;
-  switch (guess.state) {
-    case 'correct':
-      displayState = (
-        <>
-          <FontAwesomeIcon icon={faCheckCircle} color="#00ff00" fixedWidth />
-          {' '}
-          Correct
-        </>
-      );
-      break;
-    case 'intermediate':
-      displayState = (
-        <>
-          <FontAwesomeIcon icon={faExclamationCircle} color="#dddd00" fixedWidth />
-          {' '}
-          Intermediate answer
-        </>
-      );
-      break;
-    case 'incorrect':
-      displayState = (
-        <>
-          <FontAwesomeIcon icon={faTimesCircle} color="#ff0000" fixedWidth />
-          {' '}
-          Incorrect
-        </>
-      );
-      break;
-    case 'rejected':
-      displayState = (
-        <>
-          <FontAwesomeIcon icon={faBan} color="#000000" fixedWidth />
-          {' '}
-          Rejected
-        </>
-      );
-      break;
-    case 'pending':
-      displayState = (
-        <>
-          <FontAwesomeIcon icon={faClock} color="#0000ff" fixedWidth />
-          {' '}
-          Pending
-        </>
-      );
-      break;
-    default:
-      displayState = 'unknown';
-  }
-
   return (
     <StyledRow $state={guess.state}>
       <StyledPuzzleTimestampAndSubmitter>
@@ -396,7 +309,7 @@ const GuessBlock = React.memo(({
         </StyledGuessSliderWithLabel>
       </StyledGuessSliders>
       <StyledCell>
-        {displayState}
+        <GuessState id={`guess-${guess._id}-state`} state={guess.state} />
       </StyledCell>
       <StyledCell>
         {canEdit && guess.state !== 'pending' && (

--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -1,10 +1,8 @@
 /* eslint-disable max-len */
 import { Meteor } from 'meteor/meteor';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
-import { faBackward } from '@fortawesome/free-solid-svg-icons/faBackward';
 import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
 import { faEraser } from '@fortawesome/free-solid-svg-icons/faEraser';
-import { faForward } from '@fortawesome/free-solid-svg-icons/faForward';
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
 import { faSkullCrossbones } from '@fortawesome/free-solid-svg-icons/faSkullCrossbones';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -35,11 +33,12 @@ import useSubscribeDisplayNames from '../hooks/useSubscribeDisplayNames';
 import markdown from '../markdown';
 import GuessState from './GuessState';
 import PuzzleAnswer from './PuzzleAnswer';
+import { GuessConfidence, GuessDirection } from './guessDetails';
 import Breakable from './styling/Breakable';
 import { guessColorLookupTable, NavBarHeight } from './styling/constants';
 import { Breakpoint, mediaBreakpointDown } from './styling/responsive';
 
-const compactViewBreakpoint: Breakpoint = 'lg';
+const compactViewBreakpoint: Breakpoint = 'md';
 
 const StyledTable = styled.div`
   display: grid;
@@ -48,8 +47,8 @@ const StyledTable = styled.div`
     [submitter] auto
     [puzzle] auto
     [answer] auto
-    [direction] minmax(200px, auto)
-    [confidence] minmax(200px, auto)
+    [direction] minmax(5em, auto)
+    [confidence] minmax(7em, auto)
     [status] auto
     [actions] auto;
   ${mediaBreakpointDown(compactViewBreakpoint, css`
@@ -85,6 +84,14 @@ const StyledRow = styled.div<{ $state: GuessType['state'] }>`
 `;
 
 const StyledCell = styled.div`
+  padding: 4px;
+`;
+
+const StyledGuessDirection = styled(GuessDirection)`
+  padding: 4px;
+`;
+
+const StyledGuessConfidence = styled(GuessConfidence)`
   padding: 4px;
 `;
 
@@ -135,20 +142,14 @@ const StyledGuessCell = styled(StyledCell)`
   `)}
 `;
 
-const StyledGuessSliders = styled.div`
+const StyledGuessDetails = styled.div`
   display: contents;
   ${mediaBreakpointDown(compactViewBreakpoint, css`
     display: flex;
   `)}
 `;
 
-const StyledGuessSliderCell = styled(StyledCell)`
-  display: flex;
-  align-items: center;
-  flex-grow: 1;
-`;
-
-const StyledGuessSliderWithLabel = styled(StyledCell)`
+const StyledGuessDetailWithLabel = styled(StyledCell)`
   display: contents;
   ${mediaBreakpointDown(compactViewBreakpoint, css`
     display: flex;
@@ -158,23 +159,8 @@ const StyledGuessSliderWithLabel = styled(StyledCell)`
   `)}
 `;
 
-const StyledGuessSliderLabel = styled.span`
+const StyledGuessDetailLabel = styled.span`
   display: none;
-  ${mediaBreakpointDown(compactViewBreakpoint, css`
-    display: inline;
-  `)}
-`;
-
-const StyledSlider = styled.input`
-  ${mediaBreakpointDown(compactViewBreakpoint, css`
-    width: 1px;
-    flex-grow: 1;
-  `)}
-`;
-
-const StyledTooltipCompact = styled.span`
-  display: none;
-  white-space: pre;
   ${mediaBreakpointDown(compactViewBreakpoint, css`
     display: inline;
   `)}
@@ -213,24 +199,6 @@ const GuessBlock = React.memo(({
       Copy to clipboard
     </Tooltip>
   );
-  const directionTooltip = (
-    <Tooltip id={`guess-${guess._id}-direction-tooltip`}>
-      <StyledTooltipCompact>
-        Solve direction:
-        {' '}
-      </StyledTooltipCompact>
-      {guess.direction}
-    </Tooltip>
-  );
-  const confidenceTooltip = (
-    <Tooltip id={`guess-${guess._id}-confidence-tooltip`}>
-      <StyledTooltipCompact>
-        Confidence:
-        {' '}
-      </StyledTooltipCompact>
-      {guess.confidence}
-    </Tooltip>
-  );
 
   return (
     <StyledRow $state={guess.state}>
@@ -266,48 +234,20 @@ const GuessBlock = React.memo(({
         {' '}
         <PuzzleAnswer answer={guess.guess} />
       </StyledGuessCell>
-      <StyledGuessSliders>
-        <StyledGuessSliderWithLabel>
-          <StyledGuessSliderLabel>
+      <StyledGuessDetails>
+        <StyledGuessDetailWithLabel>
+          <StyledGuessDetailLabel>
             Solve direction
-          </StyledGuessSliderLabel>
-          <OverlayTrigger placement="top" overlay={directionTooltip}>
-            <StyledGuessSliderCell>
-              <FontAwesomeIcon icon={faBackward} fixedWidth />
-              {' '}
-              <StyledSlider type="range" min="-10" max="10" value={guess.direction} disabled list={`guess-${guess._id}-direction-data`} />
-              <datalist id={`guess-${guess._id}-direction-data`}>
-                <option value="-10">-10</option>
-                <option value="0">0</option>
-                <option value="10">10</option>
-              </datalist>
-              {' '}
-              <FontAwesomeIcon icon={faForward} fixedWidth />
-            </StyledGuessSliderCell>
-          </OverlayTrigger>
-        </StyledGuessSliderWithLabel>
-        <StyledGuessSliderWithLabel>
-          <StyledGuessSliderLabel>
+          </StyledGuessDetailLabel>
+          <StyledGuessDirection value={guess.direction} />
+        </StyledGuessDetailWithLabel>
+        <StyledGuessDetailWithLabel>
+          <StyledGuessDetailLabel>
             Confidence
-          </StyledGuessSliderLabel>
-          <OverlayTrigger placement="top" overlay={confidenceTooltip}>
-            <StyledGuessSliderCell>
-              0%
-              {' '}
-              <StyledSlider type="range" min="0" max="100" value={guess.confidence} disabled list={`guess-${guess._id}-confidence-data`} />
-              <datalist id={`guess-${guess._id}-confidence-data`}>
-                <option value="0">0%</option>
-                <option value="25">25%</option>
-                <option value="50">50%</option>
-                <option value="75">75%</option>
-                <option value="100">100%</option>
-              </datalist>
-              {' '}
-              100%
-            </StyledGuessSliderCell>
-          </OverlayTrigger>
-        </StyledGuessSliderWithLabel>
-      </StyledGuessSliders>
+          </StyledGuessDetailLabel>
+          <StyledGuessConfidence id={`guess-${guess._id}-confidence`} value={guess.confidence} />
+        </StyledGuessDetailWithLabel>
+      </StyledGuessDetails>
       <StyledCell>
         <GuessState id={`guess-${guess._id}-state`} state={guess.state} />
       </StyledCell>

--- a/imports/client/components/GuessState.tsx
+++ b/imports/client/components/GuessState.tsx
@@ -1,0 +1,66 @@
+import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import { faBan } from '@fortawesome/free-solid-svg-icons/faBan';
+import { faCheckCircle } from '@fortawesome/free-solid-svg-icons/faCheckCircle';
+import { faClock } from '@fortawesome/free-solid-svg-icons/faClock';
+import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons/faExclamationCircle';
+import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons/faQuestionCircle';
+import { faTimesCircle } from '@fortawesome/free-solid-svg-icons/faTimesCircle';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React from 'react';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+import { GuessType } from '../../lib/schemas/Guess';
+import { guessColorLookupTable } from './styling/constants';
+
+const iconLookupTable: Record<GuessType['state'], IconProp> = {
+  correct: faCheckCircle,
+  intermediate: faExclamationCircle,
+  incorrect: faTimesCircle,
+  rejected: faBan,
+  pending: faClock,
+};
+
+const stateDescriptionTable: Record<GuessType['state'], string> = {
+  correct: 'Correct',
+  intermediate: 'Intermediate answer',
+  incorrect: 'Incorrect',
+  rejected: 'Rejected',
+  pending: 'Pending',
+};
+
+const GuessState = ({ id, state, short = false }: {
+  id: string;
+  state: GuessType['state'];
+  short?: boolean;
+}) => {
+  if (!short) {
+    return (
+      <>
+        <FontAwesomeIcon
+          icon={iconLookupTable[state] ?? faQuestionCircle}
+          color={guessColorLookupTable[state].icon ?? '#fff'}
+          fixedWidth
+        />
+        {' '}
+        {stateDescriptionTable[state] ?? 'unknown'}
+      </>
+    );
+  }
+
+  const tooltip = (
+    <Tooltip id={`${id}-tooltip`}>
+      {stateDescriptionTable[state] ?? 'unknown'}
+    </Tooltip>
+  );
+  return (
+    <OverlayTrigger placement="top" overlay={tooltip}>
+      <FontAwesomeIcon
+        icon={iconLookupTable[state] ?? faQuestionCircle}
+        color={guessColorLookupTable[state].icon ?? '#fff'}
+        fixedWidth
+      />
+    </OverlayTrigger>
+  );
+};
+
+export default GuessState;

--- a/imports/client/components/ModalForm.tsx
+++ b/imports/client/components/ModalForm.tsx
@@ -2,10 +2,11 @@ import React, {
   useCallback, useEffect, useImperativeHandle, useRef, useState,
 } from 'react';
 import Button from 'react-bootstrap/Button';
-import Modal from 'react-bootstrap/Modal';
+import Modal, { ModalProps } from 'react-bootstrap/Modal';
 
 interface ModalFormProps {
   title: string;
+  size?: ModalProps['size'];
   submitLabel?: string;
   submitStyle?: string;
   submitDisabled?: boolean;
@@ -61,7 +62,7 @@ const ModalForm = React.forwardRef((
   const submitStyle = props.submitStyle ?? 'primary';
 
   return (
-    <Modal show={isShown} onHide={hide}>
+    <Modal show={isShown} onHide={hide} size={props.size}>
       <form className="form-horizontal" onSubmit={submit}>
         <Modal.Header closeButton>
           <Modal.Title>

--- a/imports/client/components/PuzzleAnswer.tsx
+++ b/imports/client/components/PuzzleAnswer.tsx
@@ -5,7 +5,7 @@ import { MonospaceFontFamily } from './styling/constants';
 const PuzzleAnswerSpan = styled.span`
   text-transform: uppercase;
   font-family: ${MonospaceFontFamily};
-  font-weight: 300;
+  font-weight: 400;
 `;
 
 const PuzzleAnswerSegment = styled.span`

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -1246,6 +1246,7 @@ const PuzzleGuessModal = React.forwardRef(({
       title={`${puzzle.answers.length >= puzzle.expectedAnswerCount ? 'Guess history for' : 'Submit answer to'} ${puzzle.title}`}
       onSubmit={onSubmitGuess}
       submitLabel={confirmingSubmit ? 'Confirm Submit' : 'Submit'}
+      size="lg"
     >
       <FormGroup as={Row} className="mb-3">
         <FormLabel column xs={3} htmlFor="jr-puzzle-guess">

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -205,7 +205,7 @@ const PuzzleMetadata = styled.div`
 const PuzzleMetadataAnswer = styled.span`
   text-transform: uppercase;
   font-family: ${MonospaceFontFamily};
-  font-weight: 300;
+  font-weight: 400;
   background-color: ${SolvedPuzzleBackgroundColor};
   color: #000;
 
@@ -275,7 +275,7 @@ const StyledTagList = styled(TagList)`
 const AnswerFormControl = styled(FormControl)`
   text-transform: uppercase;
   font-family: ${MonospaceFontFamily};
-  font-weight: 300;
+  font-weight: 400;
 `;
 
 const ChatMessage = React.memo(({
@@ -1121,7 +1121,7 @@ const PuzzlePageMetadata = ({
 const AnswerTableCell = styled.td`
   text-transform: uppercase;
   font-family: ${MonospaceFontFamily};
-  font-weight: 300;
+  font-weight: 400;
   word-break: break-all;
 `;
 

--- a/imports/client/components/guessDetails.tsx
+++ b/imports/client/components/guessDetails.tsx
@@ -1,0 +1,71 @@
+import { faArrowLeft } from '@fortawesome/free-solid-svg-icons/faArrowLeft';
+import { faArrowRight } from '@fortawesome/free-solid-svg-icons/faArrowRight';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React from 'react';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+import styled from 'styled-components';
+import { GuessType } from '../../lib/schemas/Guess';
+
+const GuessDetail = styled.div`
+  display: flex;
+  align-items: center;
+  flex-grow: 1;
+`;
+
+const GuessConfidenceProgress = styled.div`
+  && {
+    flex-grow: 1;
+    height: 1em;
+    background-color: white;
+    border: 1px black solid;
+  }
+`;
+
+const GuessConfidenceProgressBar = styled.div<{ $value: number }>`
+  &&& {
+    background-color: grey;
+    width: ${({ $value }) => $value}%;
+    height: 100%;
+  }
+`;
+
+const GuessDirection = ({ value, className }: {
+  value: GuessType['direction'];
+  className?: string;
+}) => {
+  return (
+    <GuessDetail className={className}>
+      <FontAwesomeIcon icon={(value ?? 0) < 0 ? faArrowLeft : faArrowRight} fixedWidth />
+      {' '}
+      {value ?? 0}
+    </GuessDetail>
+  );
+};
+
+const GuessConfidence = ({ id, value, className }: {
+  id: string;
+  value: GuessType['confidence'];
+  className?: string;
+}) => {
+  const tooltip = (
+    <Tooltip id={`${id}-tooltip`}>
+      <strong>Confidence:</strong>
+      {' '}
+      {value}
+      %
+    </Tooltip>
+  );
+
+  return (
+    <OverlayTrigger placement="top" overlay={tooltip}>
+      <GuessDetail className={className}>
+        <GuessConfidenceProgress>
+          <GuessConfidenceProgressBar $value={value ?? 0} />
+        </GuessConfidenceProgress>
+      </GuessDetail>
+    </OverlayTrigger>
+  );
+};
+
+export { GuessDirection, GuessConfidence };

--- a/imports/client/components/styling/constants.tsx
+++ b/imports/client/components/styling/constants.tsx
@@ -1,3 +1,4 @@
+import { GuessType } from '../../../lib/schemas/Guess';
 import type { Solvedness } from '../../../lib/solvedness';
 
 export const NavBarHeight = '50px';
@@ -14,4 +15,32 @@ export const backgroundColorLookupTable: Record<Solvedness, string> = {
   noAnswers: ExpectsNoAnswersPuzzleBackgroundColor,
   solved: SolvedPuzzleBackgroundColor,
   unsolved: UnsolvedPuzzleBackgroundColor,
+};
+
+export const guessColorLookupTable: Record<GuessType['state'], { background: string, hoverBackground: string, icon: string }> = {
+  correct: {
+    background: '#f0fff0',
+    hoverBackground: '#d0ffd0',
+    icon: '#00ff00',
+  },
+  intermediate: {
+    background: '#fffff0',
+    hoverBackground: '#ffffd0',
+    icon: '#dddd00',
+  },
+  incorrect: {
+    background: '#fff0f0',
+    hoverBackground: '#ffd0d0',
+    icon: '#ff0000',
+  },
+  rejected: {
+    background: '#f0f0f0',
+    hoverBackground: '#d0d0d0',
+    icon: '#000000',
+  },
+  pending: {
+    background: '#f0f0ff',
+    hoverBackground: '#d0d0ff',
+    icon: '#0000ff',
+  },
 };


### PR DESCRIPTION
A quick breakdown of what this changes:

- Increases the weight for Source Code Pro from 300 to 400 (i.e. "normal") across the board to give answer displays just a little more weight
- Switches away from displaying direction and confidence on the guess queue page as sliders:

  <img width="265" alt="Screenshot 2023-01-02 at 10 29 04 PM" src="https://user-images.githubusercontent.com/28167/210309241-ca562d90-10f0-4f76-9f22-5b2b666cccdd.png">
  
  This also lets us stick with the full-sized layout down to the "medium" screen size cutoff, instead of "large", so there's less no-man's-land in the middle sizes where the mobile layout looks huuge.
- Dramatically improves how the sliders in the guess modal are rendered. As it turns out, `FormControl type="range"` isn't really intended to work. Here's the before:

  <img width="523" alt="Screenshot 2023-01-02 at 10 30 26 PM" src="https://user-images.githubusercontent.com/28167/210309373-28268780-43dd-419c-aafb-d33722e513d6.png">

  and after:

  <img width="819" alt="Screenshot 2023-01-02 at 10 31 21 PM" src="https://user-images.githubusercontent.com/28167/210309473-dc41adf3-beae-41c9-b9e1-70f34c515b01.png">
- More or less completely redoes the table of historical guess submissions in the modal on the puzzle page, taking advantage of some of the design language we developed on the guess queue page:

  <img width="812" alt="Screenshot 2023-01-02 at 10 32 53 PM" src="https://user-images.githubusercontent.com/28167/210309641-b3e83ca9-fd18-49be-9839-d6a64748cd00.png">

  and here's what it looks like at mobile sizes:

  <img width="512" alt="Screenshot 2023-01-02 at 10 34 02 PM" src="https://user-images.githubusercontent.com/28167/210309734-af4d96a8-a3fb-442f-8491-e228c4bf1bba.png">
