### PR TITLE
Add a bit of padding to puzzle activity UI

### DIFF
--- a/imports/client/components/PuzzleActivity.tsx
+++ b/imports/client/components/PuzzleActivity.tsx
@@ -38,6 +38,7 @@ const PuzzleActivityItem = styled.span`
 
   span {
     margin-right: 0.25rem;
+    margin-left: 0.125rem;
   }
 
   ${mediaBreakpointDown('xs', css`
@@ -52,17 +53,25 @@ const PuzzleOpenTime = styled(PuzzleActivityItem)`
 
 const PuzzleActivitySparkline = styled(PuzzleActivityItem)`
   min-width: 6rem;
+
+  span {
+    margin-right: 0;
+  }
 `;
 
 const PuzzleActivityDetail = styled.div`
   display: grid;
   grid-template-columns: auto auto 1fr 2em;
   align-items: center;
+  margin-bottom: 0.5rem;
+  column-gap: 0.25rem;
+  row-gap: 0.125rem;
 `;
 
 const PuzzleActivityDetailTimeRange = styled.div`
   display: flex;
   justify-content: space-between;
+  font-size: 12px;
 `;
 
 interface PuzzleActivityProps {
@@ -140,7 +149,7 @@ const PuzzleActivity = ({ huntId, puzzleId, unlockTime }: PuzzleActivityProps) =
 
   const unlockTooltip = (
     <Tooltip id={`puzzle-activity-unlock-${puzzleId}`}>
-      Puzzle unlocked at
+      Puzzle unlocked:
       {' '}
       {calendarTimeFormat(unlockTime)}
     </Tooltip>
@@ -153,7 +162,7 @@ const PuzzleActivity = ({ huntId, puzzleId, unlockTime }: PuzzleActivityProps) =
   const sparklineTooltip = (
     <Tooltip id={`puzzle-activity-sparkline-${puzzleId}`}>
       <div>
-        How many are working on this puzzle based on:
+        People working on this puzzle:
       </div>
       <PuzzleActivityDetailTimeRange>
         <div>
@@ -228,7 +237,7 @@ const PuzzleActivity = ({ huntId, puzzleId, unlockTime }: PuzzleActivityProps) =
             <SparklinesLine />
             <SparklinesSpots spotColors={{ '-1': 'black', 0: 'black', 1: 'black' }} />
           </Sparklines>
-          {displayNumber(totals)}
+          <span>{displayNumber(totals)}</span>
         </PuzzleActivitySparkline>
       </OverlayTrigger>
     </PuzzleActivityItems>


### PR DESCRIPTION
A bit between the door and the time.

A bit between the activity count and the sparkline.

The sparkline tooltip now has space on the bottom. I also made the title fit on one line and the time legend is in smaller text.

One thing I'd like but haven't done is make the sparkline labels' baseline match the base of the sparklines. TBD.

Before:
![Screen Shot 2023-01-02 at 22 38 59](https://user-images.githubusercontent.com/689247/210310227-8089986f-73b5-4fd5-be4f-ac6946615c72.png)

After:
![Screen Shot 2023-01-02 at 22 38 42](https://user-images.githubusercontent.com/689247/210310237-28168200-dcd5-4f6b-b50a-a09634aa79db.png)
