### PR TITLE
Grant commenter permission on hunt folders

### DIFF
--- a/imports/lib/schemas/FolderPermission.ts
+++ b/imports/lib/schemas/FolderPermission.ts
@@ -8,6 +8,7 @@ const FolderPermissionFields = t.type({
   user: t.string,
   // This can change, so capture which one we gave permissions to
   googleAccount: t.string,
+  permissionLevel: t.union([t.undefined, t.literal('reader'), t.literal('commenter')]),
 });
 
 const FolderPermissionFieldsOverrides: Overrides<t.TypeOf<typeof FolderPermissionFields>> = {

--- a/imports/server/gdrive.ts
+++ b/imports/server/gdrive.ts
@@ -216,13 +216,14 @@ export async function ensureHuntFolderPermission(
     folder,
     user: userId,
     googleAccount,
+    permissionLevel: 'commenter' as const,
   };
   if (await FolderPermissions.findOneAsync(perm)) {
     return;
   }
 
   Ansible.log('Granting permissions to folder', perm);
-  await grantPermission(folder, googleAccount, 'reader');
+  await grantPermission(folder, googleAccount, 'commenter');
   await ignoringDuplicateKeyErrors(async () => {
     await FolderPermissions.insertAsync(perm);
   });

--- a/imports/server/migrations/45-folder-permission-level.ts
+++ b/imports/server/migrations/45-folder-permission-level.ts
@@ -1,0 +1,16 @@
+import FolderPermissions from '../../lib/models/FolderPermissions';
+import Migrations from './Migrations';
+
+Migrations.add({
+  version: 45,
+  name: 'Add permission level to FolderPermissions index',
+  async up() {
+    await FolderPermissions.createIndexAsync({
+      folder: 1,
+      user: 1,
+      googleAccount: 1,
+      permissionLevel: 1,
+    }, { unique: true });
+    await FolderPermissions.dropIndexAsync('folder_1_user_1_googleAccount_1');
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -43,3 +43,4 @@ import './41-document-activities';
 import './42-document-by-external-id';
 import './43-puzzle-activity';
 import './44-better-puzzle-activity';
+import './45-folder-permission-level';


### PR DESCRIPTION
As it turns out, granting commenter permission is sufficient for edits to a document to be attributed to that user, instead of being attributed to the owner of the document.