### PR TITLE
Store Google account IDs in addition to emails

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,7 +58,7 @@
     ],
     "camelcase": ["error", {
       "properties": "never",
-      "allow": ["__meteor_runtime_config__", "script_v1", "drive_v3"]
+      "allow": ["__meteor_runtime_config__", "script_v1", "drive_v3", "people_v1"]
     }],
 
     "no-constant-condition": ["error", { "checkLoops": false }],

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -248,6 +248,8 @@ const GoogleAuthorizeDriveClientForm = () => {
         'https://www.googleapis.com/auth/drive',
         'https://www.googleapis.com/auth/script.projects',
         'https://www.googleapis.com/auth/script.deployments',
+        'https://www.googleapis.com/auth/user.emails.read',
+        'https://www.googleapis.com/auth/contacts.other.readonly',
       ],
       requestOfflineToken: true,
       forceApprovalPrompt: true,

--- a/imports/lib/schemas/User.ts
+++ b/imports/lib/schemas/User.ts
@@ -12,6 +12,7 @@ declare module 'meteor/meteor' {
       roles?: Record<string, string[]>; // scope -> roles
       displayName?: string;
       googleAccount?: string;
+      googleAccountId?: string;
       discordAccount?: t.TypeOf<typeof DiscordAccount>;
       phoneNumber?: string;
       dingwords?: string[];
@@ -32,6 +33,7 @@ export const UserCodec = t.type({
   hunts: t.union([t.array(t.string), t.undefined]),
   displayName: t.union([t.undefined, t.string]),
   googleAccount: t.union([t.string, t.undefined]),
+  googleAccountId: t.union([t.string, t.undefined]),
   discordAccount: t.union([DiscordAccount, t.undefined]),
   phoneNumber: t.union([t.string, t.undefined]),
   dingwords: t.union([t.array(t.string), t.undefined]),

--- a/imports/methods/configureCollectGoogleAccountIds.ts
+++ b/imports/methods/configureCollectGoogleAccountIds.ts
@@ -1,0 +1,5 @@
+import TypedMethod from './TypedMethod';
+
+export default new TypedMethod<void, void>(
+  'Settings.methods.collectGoogleAccountIds'
+);

--- a/imports/server/googleClientRefresher.ts
+++ b/imports/server/googleClientRefresher.ts
@@ -2,6 +2,7 @@ import { Mongo } from 'meteor/mongo';
 import { OAuth } from 'meteor/oauth';
 import { ServiceConfiguration, Configuration } from 'meteor/service-configuration';
 import { drive_v3, drive } from '@googleapis/drive';
+import { people, people_v1 } from '@googleapis/people';
 import { script_v1, script } from '@googleapis/script';
 import { OAuth2Client } from 'google-auth-library';
 import Settings from '../lib/models/Settings';
@@ -11,6 +12,8 @@ class GoogleClientRefresher {
   public drive?: drive_v3.Drive;
 
   public script?: script_v1.Script;
+
+  public people?: people_v1.People;
 
   private oauthClient?: OAuth2Client;
 
@@ -87,6 +90,7 @@ class GoogleClientRefresher {
     // Construct the clients, using that OAuth2 client.
     this.drive = drive({ version: 'v3', auth: this.oauthClient });
     this.script = script({ version: 'v1', auth: this.oauthClient });
+    this.people = people({ version: 'v1', auth: this.oauthClient });
   }
 }
 

--- a/imports/server/methods/configureCollectGoogleAccountIds.ts
+++ b/imports/server/methods/configureCollectGoogleAccountIds.ts
@@ -1,0 +1,57 @@
+import { check } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+import Ansible from '../../Ansible';
+import MeteorUsers from '../../lib/models/MeteorUsers';
+import { checkAdmin } from '../../lib/permission_stubs';
+import configureCollectGoogleAccountIds from '../../methods/configureCollectGoogleAccountIds';
+import GoogleClient from '../googleClientRefresher';
+
+configureCollectGoogleAccountIds.define({
+  async run() {
+    check(this.userId, String);
+    checkAdmin(await MeteorUsers.findOneAsync(this.userId));
+
+    const { people } = GoogleClient;
+    if (!people) {
+      throw new Meteor.Error(500, 'Google integration is disabled');
+    }
+
+    let pageToken: string | undefined;
+    do {
+      /* eslint-disable no-await-in-loop */
+      const resp = await people.otherContacts.list({
+        pageToken,
+        sources: ['READ_SOURCE_TYPE_CONTACT', 'READ_SOURCE_TYPE_PROFILE'],
+        readMask: 'emailAddresses,metadata',
+      });
+      pageToken = resp.data.nextPageToken ?? undefined;
+
+      await resp.data.otherContacts?.reduce(async (p, contact) => {
+        await p;
+
+        const id = contact.metadata?.sources?.find((s) => s.type === 'PROFILE')?.id ?? undefined;
+        if (!id) {
+          return;
+        }
+
+        const addresses = contact.emailAddresses?.reduce<string[]>((a, e) => {
+          if (e.value) {
+            a.push(e.value);
+          }
+          return a;
+        }, []);
+
+        Ansible.log('Storing Google account IDs on users', { id, addresses });
+        await MeteorUsers.updateAsync({
+          googleAccountId: undefined,
+          googleAccount: { $in: addresses },
+        }, {
+          $set: {
+            googleAccountId: id,
+          },
+        }, { multi: true });
+      }, Promise.resolve());
+      /* eslint-enable no-await-in-loop */
+    } while (pageToken);
+  },
+});

--- a/imports/server/methods/index.ts
+++ b/imports/server/methods/index.ts
@@ -3,6 +3,7 @@ import './addPuzzleAnswer';
 import './addPuzzleTag';
 import './bulkAddHuntUsers';
 import './configureClearGdriveCreds';
+import './configureCollectGoogleAccountIds';
 import './configureDiscordBot';
 import './configureDiscordBotGuild';
 import './configureDiscordOAuthClient';

--- a/imports/server/methods/linkUserGoogleAccount.ts
+++ b/imports/server/methods/linkUserGoogleAccount.ts
@@ -24,13 +24,19 @@ linkUserGoogleAccount.define({
     // scopes, I don't think you can do anything with it), but we do
     // want to validate it.
     const credential = Google.retrieveCredential(key, secret);
-    const email = credential.serviceData.email;
+    const { email, id } = credential.serviceData;
     Ansible.log('Linking user to Google account', {
       user: this.userId,
       email,
+      id,
     });
 
-    await MeteorUsers.updateAsync(this.userId, { $set: { googleAccount: email } });
+    await MeteorUsers.updateAsync(this.userId, {
+      $set: {
+        googleAccount: email,
+        googleAccountId: id,
+      },
+    });
 
     if (!Flags.active('disable.google') && !Flags.active('disable.gdrive_permissions')) {
       const hunts = Meteor.user()!.hunts;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1918,6 +1918,14 @@
         "googleapis-common": "^6.0.3"
       }
     },
+    "@googleapis/people": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@googleapis/people/-/people-3.0.0.tgz",
+      "integrity": "sha512-iR7ux/isGvfunoQZndE6wROR5x8ajc+6Sl52FinRL5GtPeNNbtuZdqjA8QPQsyJdPSd5n5uG/qiDGjBXj/jPkw==",
+      "requires": {
+        "googleapis-common": "^6.0.3"
+      }
+    },
     "@googleapis/script": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@googleapis/script/-/script-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@googleapis/drive": "^4.0.1",
+    "@googleapis/people": "^3.0.0",
     "@googleapis/script": "^1.0.0",
     "@popperjs/core": "^2.11.6",
     "bcrypt": "^5.1.0",


### PR DESCRIPTION
In order to cross-reference Google Drive activity with Jolly Roger users, we need their account ID, not just their email address, so start capturing it going forward.

To avoid requiring everyone to re-link their Google accounts, introduce a new "configureCollectGoogleAccountIds" Meteor method. This takes advantage of the fact that anyone who has linked their Google account shows up in the "other contacts" API, and we can mine their account ID from there. This should be purely transitional - anyone setting up Jolly Roger in the future shouldn't need to do this - so it's not especially optimized for efficiency (many of the queries are poorly indexed) and there's no UI exposure.