### PR TITLE
Fix guess queue flicker

### DIFF
--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -73,26 +73,26 @@ const StyledHeader = styled.div`
 const StyledRow = styled.div<{ $state: GuessType['state'] }>`
   display: contents;
   margin-bottom: 8px;
+  background-color: ${(props) => guessColorLookupTable[props.$state].background};
 
-  * {
-    background-color: ${(props) => guessColorLookupTable[props.$state].background};
-  }
-
-  :hover * {
+  :hover {
     background-color: ${(props) => guessColorLookupTable[props.$state].hoverBackground};
   }
 `;
 
 const StyledCell = styled.div`
   padding: 4px;
+  background-color: inherit;
 `;
 
 const StyledGuessDirection = styled(GuessDirection)`
   padding: 4px;
+  background-color: inherit;
 `;
 
 const StyledGuessConfidence = styled(GuessConfidence)`
   padding: 4px;
+  background-color: inherit;
 `;
 
 const StyledLinkButton = styled(Button)`
@@ -102,6 +102,7 @@ const StyledLinkButton = styled(Button)`
 
 const StyledPuzzleTimestampAndSubmitter = styled.div`
   display: contents;
+  background-color: inherit;
   ${mediaBreakpointDown(compactViewBreakpoint, css`
     padding: 4px;
     display: flex;
@@ -144,6 +145,7 @@ const StyledGuessCell = styled(StyledCell)`
 
 const StyledGuessDetails = styled.div`
   display: contents;
+  background-color: inherit;
   ${mediaBreakpointDown(compactViewBreakpoint, css`
     display: flex;
   `)}

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -1147,6 +1147,7 @@ const GuessTable = styled.div`
 
 const GuessTableSmallRow = styled.div`
   display: contents;
+  background-color: inherit;
   ${mediaBreakpointDown('sm', css`
     grid-column: 1 / -1;
     display: flex;
@@ -1155,12 +1156,9 @@ const GuessTableSmallRow = styled.div`
 
 const GuessRow = styled.div<{ $state: GuessType['state'] }>`
   display: contents;
+  background-color: ${(props) => guessColorLookupTable[props.$state].background};
 
-  * {
-    background-color: ${(props) => guessColorLookupTable[props.$state].background};
-  }
-
-  :hover * {
+  :hover {
     background-color: ${(props) => guessColorLookupTable[props.$state].hoverBackground};
   }
 `;
@@ -1185,6 +1183,7 @@ const GuessSlider = styled.input`
 
 const GuessCell = styled.div`
   display: flex;
+  background-color: inherit;
   align-items: center;
   padding: 0.25rem;
   outline: 1px solid #ddd;


### PR DESCRIPTION
Apply background color only to cells of the guess queue, instead of all descendants, to fix a flicker caused by animated button backgrounds. This also restores the expected background color of the button.

@aldeka raised this issue in the Discord.