### PR TITLE
Improve our handling of empty strings

### DIFF
--- a/imports/client/components/AccountForm.tsx
+++ b/imports/client/components/AccountForm.tsx
@@ -137,9 +137,16 @@ const AccountForm = (props: AccountFormProps) => {
   }, [password]);
 
   const tryEnroll = useCallback((token: string) => {
+    const trimmedDisplayName = displayName.trim();
+    if (trimmedDisplayName === '') {
+      setSubmitState(AccountFormSubmitState.FAILED);
+      setErrorMessage('Display name cannot be blank.');
+      return;
+    }
+
     const newProfile = {
-      displayName,
-      phoneNumber,
+      displayName: trimmedDisplayName,
+      phoneNumber: phoneNumber !== '' ? phoneNumber : undefined,
       dingwords: [],
     };
 

--- a/imports/client/components/HuntEditPage.tsx
+++ b/imports/client/components/HuntEditPage.tsx
@@ -277,7 +277,7 @@ const HuntEditPage = () => {
     const state: HuntSubmit = {
       name,
       mailingLists: splitLists(mailingLists),
-      signupMessage,
+      signupMessage: signupMessage === '' ? undefined : signupMessage,
       openSignups,
       hasGuessQueue,
       homepageUrl: homepageUrl === '' ? undefined : homepageUrl,

--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -308,13 +308,20 @@ const OwnProfilePage = ({ initialUser }: { initialUser: Meteor.User }) => {
   }, []);
 
   const handleSaveForm = useCallback(() => {
+    const trimmedDisplayName = displayName.trim();
+    if (trimmedDisplayName === '') {
+      setSubmitError('Display name must not be empty');
+      setSubmitState(OwnProfilePageSubmitState.ERROR);
+      return;
+    }
+
     setSubmitState(OwnProfilePageSubmitState.SUBMITTING);
     const dingwords = dingwordsFlat.split(',').map((x) => {
       return x.trim().toLowerCase();
     }).filter((x) => x.length > 0);
     const newProfile = {
-      displayName,
-      phoneNumber,
+      displayName: trimmedDisplayName,
+      phoneNumber: phoneNumber !== '' ? phoneNumber : undefined,
       dingwords,
     };
     updateProfile.call(newProfile, (error) => {

--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -58,8 +58,8 @@ const PuzzleModalForm = React.forwardRef(({
     return tagIds.map((t) => tagNames[t] ?? t);
   }, [propsTags]);
 
-  const [title, setTitle] = useState<string>(puzzle ? puzzle.title : '');
-  const [url, setUrl] = useState<string | undefined>(puzzle ? puzzle.url : '');
+  const [title, setTitle] = useState<string>(puzzle?.title ?? '');
+  const [url, setUrl] = useState<string>(puzzle?.url ?? '');
   const [tags, setTags] = useState<string[]>(puzzle ? tagNamesForIds(puzzle.tags) : []);
   const [docType, setDocType] =
     useState<GdriveMimeTypesType | undefined>(puzzle ? undefined : 'spreadsheet');
@@ -120,7 +120,7 @@ const PuzzleModalForm = React.forwardRef(({
     const payload: PuzzleModalFormSubmitPayload = {
       huntId,
       title,
-      url: url ?? undefined, // Make sure we send undefined if url is falsy
+      url: url !== '' ? url : undefined, // Make sure we send undefined if url is falsy
       tags,
       expectedAnswerCount,
     };

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -143,7 +143,10 @@ const GoogleOAuthForm = ({ isConfigured, initialClientId }: {
       setState({
         submitState: SubmitState.SUBMITTING,
       });
-      configureGoogleOAuthClient.call({ clientId: trimmedClientId, secret: trimmedClientSecret }, (err) => {
+      configureGoogleOAuthClient.call({
+        clientId: trimmedClientId !== '' ? trimmedClientId : undefined,
+        secret: trimmedClientSecret !== '' ? trimmedClientSecret : undefined,
+      }, (err) => {
         if (err) {
           setState({
             submitState: SubmitState.ERROR,
@@ -500,10 +503,9 @@ const GoogleScriptForm = ({ app }: {
 
   const saveEndpointUrl = useCallback((e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    if (!endpointUrl) return;
 
     setState({ submitState: SubmitState.SUBMITTING });
-    configureGoogleScriptUrl.call({ url: endpointUrl }, (error) => {
+    configureGoogleScriptUrl.call({ url: endpointUrl !== '' ? endpointUrl : undefined }, (error) => {
       if (error) {
         setState({ submitState: SubmitState.ERROR, error });
       } else {
@@ -863,11 +865,11 @@ const EmailConfigForm = ({ initialConfig }: {
     const trimmedExistingJoinMessage = existingJoinMessage.trim();
     setSubmitState(SubmitState.SUBMITTING);
     configureEmailBranding.call({
-      from: trimmedFrom,
-      enrollSubject: trimmedEnrollAccountMessageSubject,
-      enrollMessage: trimmedEnrollAccountMessage,
-      joinSubject: trimmedExistingJoinMessageSubject,
-      joinMessage: trimmedExistingJoinMessage,
+      from: trimmedFrom !== '' ? trimmedFrom : undefined,
+      enrollSubject: trimmedEnrollAccountMessageSubject !== '' ? trimmedEnrollAccountMessageSubject : undefined,
+      enrollMessage: trimmedEnrollAccountMessage !== '' ? trimmedEnrollAccountMessage : undefined,
+      joinSubject: trimmedExistingJoinMessageSubject !== '' ? trimmedExistingJoinMessageSubject : undefined,
+      joinMessage: trimmedExistingJoinMessage !== '' ? trimmedExistingJoinMessage : undefined,
     }, (error) => {
       if (error) {
         setSubmitError(error.message);
@@ -1196,8 +1198,8 @@ const DiscordOAuthForm = ({ oauthSettings }: {
     } else {
       setSubmitState(SubmitState.SUBMITTING);
       configureDiscordOAuthClient.call({
-        clientId: trimmedClientId,
-        clientSecret: trimmedClientSecret,
+        clientId: trimmedClientId !== '' ? trimmedClientId : undefined,
+        clientSecret: trimmedClientSecret !== '' ? trimmedClientSecret : undefined,
       }, (err) => {
         if (err) {
           setSubmitError(err.message);
@@ -1278,7 +1280,9 @@ const DiscordBotForm = ({ botToken: initialBotToken }: { botToken?: string }) =>
     const trimmedBotToken = botToken.trim();
 
     setSubmitState(SubmitState.SUBMITTING);
-    configureDiscordBot.call({ token: trimmedBotToken }, (err) => {
+    configureDiscordBot.call({
+      token: trimmedBotToken !== '' ? trimmedBotToken : undefined,
+    }, (err) => {
       if (err) {
         setSubmitError(err.message);
         setSubmitState(SubmitState.ERROR);
@@ -1566,7 +1570,9 @@ const BrandingTeamName = () => {
   const onSubmit = useCallback((e: React.FormEvent<any>) => {
     e.preventDefault();
     setSubmitState(SubmitState.SUBMITTING);
-    configureTeamName.call({ teamName }, (err) => {
+    configureTeamName.call({
+      teamName: teamName !== '' ? teamName : undefined,
+    }, (err) => {
       if (err) {
         setSubmitError(err.message);
         setSubmitState(SubmitState.ERROR);

--- a/imports/client/components/TagList.tsx
+++ b/imports/client/components/TagList.tsx
@@ -125,7 +125,6 @@ const TagList = React.memo((props: TagListProps) => {
   }, [onRemoveTag]);
 
   const showControls = props.showControls ?? true;
-  const emptyMessage = props.emptyMessage ?? '';
 
   const tags = sortedTagsForSinglePuzzle(props.tags);
   const components = [];
@@ -143,9 +142,9 @@ const TagList = React.memo((props: TagListProps) => {
     );
   });
 
-  if (tags.length === 0 && emptyMessage) {
+  if (tags.length === 0 && props.emptyMessage) {
     components.push(
-      <TagListEmptyLabel key="noTagLabel">{emptyMessage}</TagListEmptyLabel>
+      <TagListEmptyLabel key="noTagLabel">{props.emptyMessage}</TagListEmptyLabel>
     );
   }
 

--- a/imports/methods/configureDiscordBot.ts
+++ b/imports/methods/configureDiscordBot.ts
@@ -1,5 +1,5 @@
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<{ token: string }, void>(
+export default new TypedMethod<{ token?: string }, void>(
   'Setup.methods.configureDiscordBot'
 );

--- a/imports/methods/configureDiscordOAuthClient.ts
+++ b/imports/methods/configureDiscordOAuthClient.ts
@@ -1,5 +1,5 @@
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<{ clientId: string, clientSecret: string }, void>(
+export default new TypedMethod<{ clientId?: string, clientSecret?: string }, void>(
   'Setup.methods.configureDiscordOAuthClient'
 );

--- a/imports/methods/configureGoogleOAuthClient.ts
+++ b/imports/methods/configureGoogleOAuthClient.ts
@@ -1,5 +1,5 @@
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<{ clientId: string, secret: string }, void>(
+export default new TypedMethod<{ clientId?: string, secret?: string }, void>(
   'Setup.methods.configureGoogleOAuthClient',
 );

--- a/imports/methods/configureGoogleScriptUrl.ts
+++ b/imports/methods/configureGoogleScriptUrl.ts
@@ -1,5 +1,5 @@
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<{ url: string }, void>(
+export default new TypedMethod<{ url?: string }, void>(
   'Setup.methods.configureGoogleScriptUrl'
 );

--- a/imports/methods/updateProfile.ts
+++ b/imports/methods/updateProfile.ts
@@ -2,6 +2,6 @@ import TypedMethod from './TypedMethod';
 
 export default new TypedMethod<{
   displayName: string,
-  phoneNumber: string,
+  phoneNumber?: string,
   dingwords: string[],
 }, void>('Users.methods.updateProfile');

--- a/imports/server/methods/configureDiscordBot.ts
+++ b/imports/server/methods/configureDiscordBot.ts
@@ -1,4 +1,4 @@
-import { check } from 'meteor/check';
+import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import Ansible from '../../Ansible';
 import MeteorUsers from '../../lib/models/MeteorUsers';
@@ -9,7 +9,7 @@ import configureDiscordBot from '../../methods/configureDiscordBot';
 configureDiscordBot.define({
   validate(arg) {
     check(arg, {
-      token: String,
+      token: Match.Optional(String),
     });
     return arg;
   },

--- a/imports/server/methods/configureDiscordOAuthClient.ts
+++ b/imports/server/methods/configureDiscordOAuthClient.ts
@@ -1,4 +1,4 @@
-import { check } from 'meteor/check';
+import { check, Match } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { ServiceConfiguration } from 'meteor/service-configuration';
 import Ansible from '../../Ansible';
@@ -10,8 +10,8 @@ import configureDiscordOAuthClient from '../../methods/configureDiscordOAuthClie
 configureDiscordOAuthClient.define({
   validate(arg) {
     check(arg, {
-      clientId: String,
-      clientSecret: String,
+      clientId: Match.Optional(String),
+      clientSecret: Match.Optional(String),
     });
     return arg;
   },

--- a/imports/server/methods/destroyPuzzle.ts
+++ b/imports/server/methods/destroyPuzzle.ts
@@ -44,7 +44,7 @@ destroyPuzzle.define({
 
     await Puzzles.updateAsync(puzzleId, {
       $set: {
-        replacedBy: replacedBy ?? undefined,
+        replacedBy,
         deleted: true,
       },
     });


### PR DESCRIPTION
Historically, we've played fairly fast and loose with the distinction between empty strings and undefined - both were false-y, so we'd often treat both equivalently (e.g. by running them through the `||` operator). This was often motivated by React, where having an input with an undefined value is problematic (since React treats it as uncontrolled), so we'd often cast undefined to an empty string.

Of course, they're not equivalent. This has popped up in various ways, including switching more broadly to the nullish-coalescing operator in 4eab028a.

This commit generally looks for places where we cast undefined to empty strings, and ensures that we cast those empty strings back to undefined when we pass them to server code. There were also a few cases where the server code didn't correctly handle false-y values (e.g. by using `$set` instead of `$unset`); those are fixed as well.

Finally, we introduce a requirement that user's are no longer allowed to set their displayName to an empty string, which would previously have been allowed. We additionally enforce that it must not start with whitespace. This is in anticipation of supporting @-mentions in the future, where whitespace at the start of the display name would make it difficult to auto-complete the name.