### PR TITLE
Strip list of emails in bulk invite

### DIFF
--- a/imports/client/components/UserInvitePage.tsx
+++ b/imports/client/components/UserInvitePage.tsx
@@ -59,7 +59,7 @@ const UserInvitePage = () => {
     e.preventDefault();
     setSubmitting(true);
     setBulkError(undefined);
-    const emails = bulkEmails.split('\n');
+    const emails = bulkEmails.trim().split('\n').map((addr) => addr.trim());
     bulkAddHuntUsers.call({ huntId, emails }, (bulkInviteError) => {
       setSubmitting(false);
       if (bulkInviteError) {


### PR DESCRIPTION
Otherwise a trailing newline results in us trying to invite the email address "", which goes about as well as you'd expect.

cc @flipdog 