### PR TITLE
Prevent content spills

### DIFF
--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -37,6 +37,7 @@ const Breadcrumb = styled.nav`
   align-items: center;
   height: ${NavBarHeight};
   flex: 1;
+  min-width: 0;
 `;
 
 const ContentContainer = styled.div`
@@ -46,14 +47,21 @@ const ContentContainer = styled.div`
   padding-right: max(env(safe-area-inset-right, 0px), 15px);
 `;
 
+/* Using some prefixed styles with widespread support and graceful failure */
+/* stylelint-disable value-no-vendor-prefix */
 const BreadcrumbList = styled.ol`
   list-style: none;
   display: block;
+  display: -webkit-box;
   max-height: 100%;
   overflow: hidden;
+  text-overflow: ellipsis;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   margin: 0;
   padding: 0;
 `;
+/* stylelint-enable value-no-vendor-prefix */
 
 const BreadcrumbItem = styled.li`
   display: inline;

--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -44,15 +44,15 @@ const StyledTable = styled.div`
   display: grid;
   grid-template-columns:
     [timestamp] auto
-    [submitter] auto
-    [puzzle] auto
-    [answer] auto
+    [submitter] minmax(auto, 8em)
+    [puzzle] minmax(10em, auto)
+    [answer] minmax(10em, auto)
     [direction] minmax(5em, auto)
     [confidence] minmax(7em, auto)
     [status] auto
     [actions] auto;
   ${mediaBreakpointDown(compactViewBreakpoint, css`
-    grid-template-columns: auto;
+    grid-template-columns: 100%;
   `)}
 `;
 
@@ -81,6 +81,7 @@ const StyledRow = styled.div<{ $state: GuessType['state'] }>`
 `;
 
 const StyledCell = styled.div`
+  overflow: hidden;
   padding: 4px;
   background-color: inherit;
 `;
@@ -135,6 +136,7 @@ const StyledPuzzleCell = styled(StyledCell)`
 const StyledGuessCell = styled(StyledCell)`
   display: flex;
   align-items: start;
+  overflow: hidden;
   ${mediaBreakpointDown(compactViewBreakpoint, css`
     &::before {
       content: "Guess: ";
@@ -221,7 +223,7 @@ const GuessBlock = React.memo(({
           </Link>
         </OverlayTrigger>
         {' '}
-        {puzzle.title}
+        <Breakable>{puzzle.title}</Breakable>
       </StyledPuzzleCell>
       <StyledGuessCell>
         <OverlayTrigger placement="top" overlay={copyTooltip}>
@@ -234,7 +236,7 @@ const GuessBlock = React.memo(({
           )}
         </OverlayTrigger>
         {' '}
-        <PuzzleAnswer answer={guess.guess} />
+        <PuzzleAnswer answer={guess.guess} breakable indented />
       </StyledGuessCell>
       <StyledGuessDetails>
         <StyledGuessDetailWithLabel>

--- a/imports/client/components/ModalForm.tsx
+++ b/imports/client/components/ModalForm.tsx
@@ -3,6 +3,13 @@ import React, {
 } from 'react';
 import Button from 'react-bootstrap/Button';
 import Modal, { ModalProps } from 'react-bootstrap/Modal';
+import styled from 'styled-components';
+
+const StyledModalTitle = styled(Modal.Title)`
+  overflow: hidden;
+  overflow-wrap: break-word;
+  hyphens: auto;
+`;
 
 interface ModalFormProps {
   title: string;
@@ -65,9 +72,9 @@ const ModalForm = React.forwardRef((
     <Modal show={isShown} onHide={hide} size={props.size}>
       <form className="form-horizontal" onSubmit={submit}>
         <Modal.Header closeButton>
-          <Modal.Title>
+          <StyledModalTitle>
             {props.title}
-          </Modal.Title>
+          </StyledModalTitle>
         </Modal.Header>
         <Modal.Body>
           {props.children}

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -48,7 +48,6 @@ import markdown from '../markdown';
 import PuzzleAnswer from './PuzzleAnswer';
 import SpinnerTimer from './SpinnerTimer';
 import { GuessConfidence, GuessDirection } from './guessDetails';
-import Breakable from './styling/Breakable';
 
 // How long to keep showing guess notifications after actioning.
 // Note that this cannot usefully exceed the linger period implemented by the
@@ -90,6 +89,13 @@ const StyledGuessDetails = styled.div`
   align-items: center;
   justify-content: flex-end;
   text-align: end;
+`;
+
+const StyledGuessHeader = styled.strong`
+  overflow-wrap: break-word;
+  overflow: hidden;
+  hyphens: auto;
+  margin-right: auto;
 `;
 
 const StyledNotificationTimestamp = styled.small`
@@ -214,7 +220,7 @@ const GuessMessage = React.memo(({
   return (
     <Toast onClose={dismissGuess}>
       <Toast.Header>
-        <strong className="me-auto">
+        <StyledGuessHeader>
           Guess for
           {' '}
           <a href={linkTarget} target="_blank" rel="noopener noreferrer">
@@ -224,9 +230,9 @@ const GuessMessage = React.memo(({
           from
           {' '}
           <a href={`/users/${guess.createdBy}`} target="_blank" rel="noopener noreferrer">
-            <Breakable>{guesser}</Breakable>
+            {guesser}
           </a>
-        </strong>
+        </StyledGuessHeader>
         <StyledNotificationTimestamp>
           {calendarTimeFormat(guess.createdAt)}
         </StyledNotificationTimestamp>
@@ -242,7 +248,7 @@ const GuessMessage = React.memo(({
       </Toast.Header>
       <Toast.Body>
         <StyledNotificationRow>
-          <PuzzleAnswer answer={guess.guess} />
+          <PuzzleAnswer answer={guess.guess} breakable />
         </StyledNotificationRow>
         <StyledNotificationActionBar>
           <StyledNotificationActionItem>

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -23,6 +23,7 @@ import PuzzleAnswer from './PuzzleAnswer';
 import PuzzleDeleteModal from './PuzzleDeleteModal';
 import PuzzleModalForm, { PuzzleModalFormSubmitPayload } from './PuzzleModalForm';
 import TagList from './TagList';
+import Breakable from './styling/Breakable';
 import { backgroundColorLookupTable } from './styling/constants';
 import { mediaBreakpointDown } from './styling/responsive';
 
@@ -49,6 +50,7 @@ const PuzzleColumn = styled.div`
   padding: 0 2px;
   display: inline-block;
   flex: none;
+  overflow: hidden;
 `;
 
 const PuzzleEditButtonsColumn = styled(PuzzleColumn)`
@@ -66,7 +68,7 @@ const StyledButton = styled(Button)`
   }
 `;
 
-const PuzzleTitleColumn = styled(PuzzleColumn)`
+const PuzzleTitleColumn = styled(Breakable)`
   flex: 4;
 `;
 
@@ -86,18 +88,10 @@ const PuzzleLinkColumn = styled(PuzzleColumn)`
 
 const PuzzleAnswerColumn = styled(PuzzleColumn)`
   flex: 3;
-  overflow-wrap: break-word;
-  overflow: hidden;
   ${mediaBreakpointDown('xs', css`
     // Push to take whole row in narrow views
     flex: 0 0 100%;
   `)}
-`;
-
-const StyledPuzzleAnswer = styled(PuzzleAnswer)`
-  display: block;
-  text-indent: -1.2em;
-  padding-left: 1.2em;
 `;
 
 const TagListColumn = styled(TagList)`
@@ -186,7 +180,7 @@ const Puzzle = React.memo(({
   const answers = puzzle.answers.map((answer, i) => {
     return (
       // eslint-disable-next-line react/no-array-index-key
-      <StyledPuzzleAnswer key={`${i}-${answer}`} answer={answer} respace={segmentAnswers} />
+      <PuzzleAnswer key={`${i}-${answer}`} answer={answer} respace={segmentAnswers} breakable={!segmentAnswers} indented={!segmentAnswers} />
     );
   });
 

--- a/imports/client/components/PuzzleAnswer.tsx
+++ b/imports/client/components/PuzzleAnswer.tsx
@@ -1,16 +1,29 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { MonospaceFontFamily } from './styling/constants';
 
-const PuzzleAnswerSpan = styled.span`
+const PuzzleAnswerSpan = styled.span<{ breakable: boolean, indented: boolean }>`
   text-transform: uppercase;
   font-family: ${MonospaceFontFamily};
   font-weight: 400;
+  ${({ breakable }) => breakable && css`
+    overflow-wrap: break-word;
+    overflow: hidden;
+  `}
+  ${({ indented }) => indented && css`
+    display: block;
+    min-width: 0;
+    text-indent: -1.2em;
+    padding-left: 1.2em;
+  `}
 `;
 
 const PuzzleAnswerSegment = styled.span`
-  & + & {
-    margin-left: 0.4em;
+  overflow-wrap: normal;
+  margin-right: 0.4em;
+
+  :last-child {
+    margin-right: 0;
   }
 `;
 
@@ -22,7 +35,7 @@ function removePunctuation(answer: string) {
 }
 
 const PuzzleAnswer = React.memo(({
-  answer, className, respace = false, segmentSize = 5,
+  answer, className, respace = false, segmentSize = 5, indented = false, breakable = false,
 }: {
   answer: string;
   className?: string;
@@ -31,6 +44,8 @@ const PuzzleAnswer = React.memo(({
   // strip spaces and punctuation.
   respace?: boolean;
   segmentSize?: number;
+  breakable?: boolean;
+  indented?: boolean;
 }) => {
   let formattedAnswer: React.ReactNode = answer;
   if (respace && segmentSize > 0) {
@@ -51,11 +66,12 @@ const PuzzleAnswer = React.memo(({
       // eslint-disable-next-line react/no-array-index-key
       <PuzzleAnswerSegment key={`segment-${i}`}>
         {segment}
+        <wbr />
       </PuzzleAnswerSegment>
     ));
   }
   return (
-    <PuzzleAnswerSpan className={className}>
+    <PuzzleAnswerSpan breakable={breakable} indented={indented} className={className}>
       {formattedAnswer}
     </PuzzleAnswerSpan>
   );

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -89,6 +89,7 @@ import PuzzleModalForm, { PuzzleModalFormSubmitPayload } from './PuzzleModalForm
 import SplitPanePlus from './SplitPanePlus';
 import TagList from './TagList';
 import { GuessConfidence, GuessDirection } from './guessDetails';
+import Breakable from './styling/Breakable';
 import FixedLayout from './styling/FixedLayout';
 import { guessColorLookupTable, MonospaceFontFamily, SolvedPuzzleBackgroundColor } from './styling/constants';
 import { mediaBreakpointDown } from './styling/responsive';
@@ -211,11 +212,9 @@ const PuzzleMetadata = styled.div`
 `;
 
 const PuzzleMetadataAnswer = styled.span`
-  text-transform: uppercase;
-  font-family: ${MonospaceFontFamily};
-  font-weight: 400;
   background-color: ${SolvedPuzzleBackgroundColor};
   color: #000;
+  overflow: hidden;
 
   // Tag-like
   display: inline-flex;
@@ -268,6 +267,7 @@ const PuzzleMetadataAnswers = styled.span`
   align-items: flex-start;
   align-content: flex-start;
   flex-wrap: wrap;
+  overflow: hidden;
 `;
 
 const PuzzleMetadataExternalLink = styled.a`
@@ -1016,7 +1016,7 @@ const PuzzlePageMetadata = ({
       {
         correctGuesses.map((guess) => (
           <PuzzleMetadataAnswer key={`answer-${guess._id}`}>
-            <span>{guess.guess}</span>
+            <PuzzleAnswer answer={guess.guess} breakable />
             {!hasGuessQueue && (
               <AnswerRemoveButton variant="success" onClick={() => onRemoveAnswer(guess._id)}>
                 <FontAwesomeIcon fixedWidth icon={faTimes} />
@@ -1183,6 +1183,7 @@ const GuessSlider = styled.input`
 
 const GuessCell = styled.div`
   display: flex;
+  overflow: hidden;
   background-color: inherit;
   align-items: center;
   padding: 0.25rem;
@@ -1224,7 +1225,6 @@ const GuessConfidenceCell = styled(GuessCell)`
 
 const AdditionalNotesCell = styled(GuessCell)`
   grid-column: 1 / -1;
-  overflow: hidden;
   overflow-wrap: break-word;
   ${mediaBreakpointDown('sm', css`
     order: 1;
@@ -1484,11 +1484,11 @@ const PuzzleGuessModal = React.forwardRef(({
                       )}
                     </OverlayTrigger>
                     {' '}
-                    <PuzzleAnswer answer={guess.guess} />
+                    <PuzzleAnswer answer={guess.guess} breakable indented />
                   </GuessAnswerCell>
                 </GuessTableSmallRow>
                 <GuessTimestampCell>{calendarTimeFormat(guess.createdAt)}</GuessTimestampCell>
-                <GuessSubmitterCell>{displayNames[guess.createdBy]}</GuessSubmitterCell>
+                <GuessSubmitterCell><Breakable>{displayNames[guess.createdBy]}</Breakable></GuessSubmitterCell>
                 <GuessDirectionCell>
                   <GuessDirection value={guess.direction} />
                 </GuessDirectionCell>

--- a/imports/client/components/PuzzleTable.tsx
+++ b/imports/client/components/PuzzleTable.tsx
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components';
 import { PuzzleType } from '../../lib/schemas/Puzzle';
 import { Solvedness, computeSolvedness } from '../../lib/solvedness';
 import PuzzleAnswer from './PuzzleAnswer';
+import Breakable from './styling/Breakable';
 import { backgroundColorLookupTable } from './styling/constants';
 
 const PuzzleTableEl = styled.table`
@@ -21,9 +22,13 @@ const PuzzleTableTr = styled.tr<{
   `}
 `;
 
+// It's difficult to make table cells overflow. Setting a max-width in vw works pretty well, with
+// few compromises. 43vw was chosen to work on the narrowest mobile devices.
 const PuzzleTableCell = styled.td`
   padding: 0 4px;
   vertical-align: baseline;
+  overflow: hidden;
+  max-width: 43vw;
 `;
 
 const PuzzleTableRow = ({ puzzle, segmentAnswers }: {
@@ -34,7 +39,7 @@ const PuzzleTableRow = ({ puzzle, segmentAnswers }: {
   const answers = puzzle.answers.map((answer, i) => {
     return (
       // eslint-disable-next-line react/no-array-index-key
-      <PuzzleAnswer key={`${i}-${answer}`} answer={answer} respace={segmentAnswers} />
+      <PuzzleAnswer key={`${i}-${answer}`} answer={answer} respace={segmentAnswers} breakable={!segmentAnswers} indented={!segmentAnswers} />
     );
   });
 
@@ -43,7 +48,7 @@ const PuzzleTableRow = ({ puzzle, segmentAnswers }: {
   return (
     <PuzzleTableTr solvedness={solvedness}>
       <PuzzleTableCell>
-        <Link to={linkTarget}>{puzzle.title}</Link>
+        <Breakable><Link to={linkTarget}>{puzzle.title}</Link></Breakable>
       </PuzzleTableCell>
       <PuzzleTableCell>
         {answers}

--- a/imports/client/components/styling/Breakable.tsx
+++ b/imports/client/components/styling/Breakable.tsx
@@ -2,4 +2,5 @@ import styled from 'styled-components';
 
 export default styled.span`
   overflow-wrap: break-word;
+  overflow: hidden;
 `;


### PR DESCRIPTION
In many places, long titles and answers (notably those with very long words) can spill out, especially at mobile widths. Since these potentially unwieldy strings are beyond our control, we need to deal with them gracefully. Quite a few examples are currently affecting past hunts in production.

Affected interfaces (and fields with potential breaks):
- Breadcrumbs
  - Breadcrumbs are wrapped to at most two lines and are truncated with an ellipsis if the title overflows vertically or a word overflows horizontally
- Puzzle page (answer)
- Operator guess toasts (title, answer, submitter)
  - Toast header breaks with hyphens if possible, but breaks arbitrarily if necessary
- Puzzle list (title, answer)
  - Wrapped lines of answers are indented for legibility
- Related puzzles (title, answer)
  - Wrapped lines of unrespaced answers are indented for legibility
  - Respaced answers are broken only between segments
- Guess queue (title, answer, submitter)
  - Wrapped lines of answers are indented for legibility
- Puzzle guess history (title, answer, submitter)
  - Modal title breaks with hyphens if possible, but breaks arbitrarily if necessary (affects all modals)
  - Wrapped lines of answers are indented for legibility
  
There are two small oddities in the implementation:
- Truncating breadcrumbs with an ellipsis on vertical overflow makes use of prefixed, but widely supported, styles (and fails gracefully without them).
- Controlling overflow behavior in a table is tricky. The puzzle table makes use of a column max-width set in vw. While that's not ideal, it looks pretty good and arguably we should constrain the distance between the columns for legibility reasons anyway.

Tested at mobile and desktop widths with contrived bad cases.