### PR TITLE
Configure Bugsnag client- and server-side error reporting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -93,6 +93,9 @@
       "newlines-between": "never"
     }],
 
+    // Some modules are included with Meteor
+    "import/no-unresolved": ["error", { "ignore": ["fibers"] }],
+
     // Files with default exports should be named to match them
     "filenames/match-exported": "error",
 

--- a/client/main.ts
+++ b/client/main.ts
@@ -1,3 +1,6 @@
+// First thing's first: setup error reporting
+import '../imports/client/bugsnag';
+
 // explicitly import all the stuff from lib/ since mainModule skips autoloading
 // things
 import '../imports/lib/config/accounts';

--- a/imports/client/bugsnag.ts
+++ b/imports/client/bugsnag.ts
@@ -1,0 +1,15 @@
+import { Meteor } from 'meteor/meteor';
+import Bugsnag from '@bugsnag/js';
+import BugsnagPluginReact from '@bugsnag/plugin-react';
+
+if (__meteor_runtime_config__.bugsnagApiKey) {
+  Bugsnag.start({
+    apiKey: __meteor_runtime_config__.bugsnagApiKey,
+    appVersion: Meteor.gitCommitHash,
+    plugins: [new BugsnagPluginReact()],
+    onError: (event) => {
+      const user = Meteor.user();
+      event.setUser(user?._id, user?.emails?.[0]?.address, user?.displayName);
+    },
+  });
+}

--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -1,5 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
+import Bugsnag from '@bugsnag/js';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons/faExclamationTriangle';
 import { faUser } from '@fortawesome/free-solid-svg-icons/faUser';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -18,7 +19,7 @@ import Navbar from 'react-bootstrap/Navbar';
 import NavbarBrand from 'react-bootstrap/NavbarBrand';
 import Button from 'react-bootstrap/esm/Button';
 import Container from 'react-bootstrap/esm/Container';
-import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
+import { ErrorBoundary as ReactErrorBoundary, FallbackProps } from 'react-error-boundary';
 import * as RRBS from 'react-router-bootstrap';
 import { useNavigate, Link } from 'react-router-dom';
 import StackTrace, { StackFrame } from 'stacktrace-js';
@@ -87,7 +88,7 @@ const Brand = styled.img`
   height: ${NavBarHeight};
 `;
 
-const ErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+const ErrorFallback = ({ error, clearError }: { error: Error, clearError: () => void }) => {
   const [frames, setFrames] = useState<StackFrame[] | undefined>(undefined);
 
   useEffect(() => {
@@ -136,7 +137,7 @@ const ErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
         </p>
 
         <p>
-          <Button type="button" onClick={resetErrorBoundary}>
+          <Button type="button" onClick={clearError}>
             Reset
           </Button>
           {' '}
@@ -153,6 +154,10 @@ const ErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
       </Alert>
     </Container>
   );
+};
+
+const ReactErrorBoundaryFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+  return <ErrorFallback error={error} clearError={resetErrorBoundary} />;
 };
 
 const AppNavbar = () => {
@@ -250,16 +255,35 @@ const AppNavbar = () => {
   );
 };
 
+const BugsnagErrorBoundary = Bugsnag.isStarted() ?
+  Bugsnag.getPlugin('react')?.createErrorBoundary(React) :
+  undefined;
+
 const App = ({ children }: { children: React.ReactNode }) => {
+  // If Bugsnag is configured, use its error boundary. But if it's not
+  // configured, Bugsnag.getPlugin will return undefined, so we need to fallback
+  // on react-error-boundary, whose UI behavior is more or less the same.
+  let errorBoundary;
+  if (BugsnagErrorBoundary) {
+    errorBoundary = (
+      <BugsnagErrorBoundary FallbackComponent={ErrorFallback}>
+        {children}
+      </BugsnagErrorBoundary>
+    );
+  } else {
+    errorBoundary = (
+      <ReactErrorBoundary FallbackComponent={ReactErrorBoundaryFallback}>
+        {children}
+      </ReactErrorBoundary>
+    );
+  }
   return (
     <div>
       <NotificationCenter />
       <AppNavbar />
       <ConnectionStatus />
       <ContentContainer className="container-fluid pt-2">
-        <ErrorBoundary FallbackComponent={ErrorFallback}>
-          {children}
-        </ErrorBoundary>
+        {errorBoundary}
       </ContentContainer>
     </div>
   );

--- a/imports/client/lookupUrl.ts
+++ b/imports/client/lookupUrl.ts
@@ -3,14 +3,6 @@ import BlobMappings from '../lib/models/BlobMappings';
 
 const blobMappingsSub = Meteor.subscribe('mongo.blob_mappings');
 
-declare global {
-  // eslint-disable-next-line camelcase,no-underscore-dangle
-  const __meteor_runtime_config__: {
-    blobMappings?: { [assetName: string]: string };
-    defaultBlobMappings: { [assetName: string]: string };
-  };
-}
-
 // A convenience function for the most common usage pattern of looking up the
 // url for a particular image asset. This always checks the Mongo record first
 // (to create a reactive dependency), but if we haven't fully loaded the

--- a/imports/server/addRuntimeConfig.ts
+++ b/imports/server/addRuntimeConfig.ts
@@ -1,0 +1,20 @@
+// Work around a bug in Meteor's runtime config hooks (which will only run a
+// single hook) by accumulating our own list
+
+import { WebApp } from 'meteor/webapp';
+
+type Config = Record<string, any>;
+
+const hooks: (() => Config)[] = [];
+
+export default function addRuntimeConfig(hook: () => Config) {
+  hooks.push(hook);
+}
+
+WebApp.addRuntimeConfigHook(({ encodedCurrentConfig }) => {
+  let config = WebApp.decodeRuntimeConfig(encodedCurrentConfig) as Config;
+  for (const hook of hooks) {
+    config = { ...config, ...hook() };
+  }
+  return WebApp.encodeRuntimeConfig(config);
+});

--- a/imports/server/addUsersToDiscordRole.ts
+++ b/imports/server/addUsersToDiscordRole.ts
@@ -1,3 +1,4 @@
+import Bugsnag from '@bugsnag/js';
 import Ansible from '../Ansible';
 import Flags from '../Flags';
 import Hunts from '../lib/models/Hunts';
@@ -49,6 +50,9 @@ export default async (userIds: string[], huntId: string) => {
       Ansible.log('Successfully added user to Discord role', { userId, huntId, roleId });
     } catch (e) {
       Ansible.log('Error while adding user to Discord role', { err: e instanceof Error ? e.message : e });
+      if (e instanceof Error && Bugsnag.isStarted()) {
+        Bugsnag.notify(e);
+      }
     }
   }, Promise.resolve());
 };

--- a/imports/server/assets.ts
+++ b/imports/server/assets.ts
@@ -8,6 +8,7 @@ import { WebApp } from 'meteor/webapp';
 import express from 'express';
 import mime from 'mime-types';
 import BlobMappings from '../lib/models/BlobMappings';
+import addRuntimeConfig from './addRuntimeConfig';
 import expressAsyncWrapper from './expressAsyncWrapper';
 import Blobs from './models/Blobs';
 import UploadTokens from './models/UploadTokens';
@@ -73,16 +74,11 @@ Meteor.publish('mongo.blob_mappings', () => {
   return BlobMappings.find({});
 });
 
-interface JollyRogerRuntimeConfig {
-  blobMappings: Record<string, string>;
-  defaultBlobMappings: Record<string, string>;
-}
-
-WebApp.addRuntimeConfigHook(({ encodedCurrentConfig }) => {
-  const config = WebApp.decodeRuntimeConfig(encodedCurrentConfig) as JollyRogerRuntimeConfig;
-  config.blobMappings = Object.fromEntries(cachedDBMappings);
-  config.defaultBlobMappings = Object.fromEntries(defaultMappings);
-  return WebApp.encodeRuntimeConfig(config);
+addRuntimeConfig(() => {
+  return {
+    blobMappings: Object.fromEntries(cachedDBMappings),
+    defaultBlobMappings: Object.fromEntries(defaultMappings),
+  };
 });
 
 // Keep the current set of assets in memory for faster access.

--- a/imports/server/bugsnag.ts
+++ b/imports/server/bugsnag.ts
@@ -1,0 +1,32 @@
+import { Meteor } from 'meteor/meteor';
+import Bugsnag from '@bugsnag/js';
+import Fiber from 'fibers';
+import addRuntimeConfig from './addRuntimeConfig';
+
+const apiKey = process.env.BUGSNAG_API_KEY;
+
+if (apiKey) {
+  Bugsnag.start({
+    apiKey,
+    appVersion: Meteor.gitCommitHash,
+    redactedKeys: [
+      'password',
+      'token',
+      'clientId',
+      'clientSecret',
+      'key',
+      'secret',
+      'dtlsParameters',
+    ],
+    onError: (event) => {
+      if (Fiber.current) {
+        const user = Meteor.user();
+        event.setUser(user?._id, user?.emails?.[0]?.address, user?.displayName);
+      }
+    },
+  });
+
+  addRuntimeConfig(() => {
+    return { bugsnagApiKey: apiKey };
+  });
+}

--- a/imports/server/mediasoup.ts
+++ b/imports/server/mediasoup.ts
@@ -1,6 +1,7 @@
 import { promises as dns } from 'dns';
 import { networkInterfaces } from 'os';
 import { Meteor } from 'meteor/meteor';
+import Bugsnag from '@bugsnag/js';
 import { Address6 } from 'ip-address';
 import { createWorker, types } from 'mediasoup';
 import { AudioLevelObserver } from 'mediasoup/node/lib/AudioLevelObserver';
@@ -278,6 +279,16 @@ class SFU {
         producer: producer.id,
         error: e instanceof Error ? e.message : e,
       });
+      if (e instanceof Error && Bugsnag.isStarted()) {
+        Bugsnag.notify(e, (event) => {
+          event.addMetadata('call', {
+            call: producerAppData.call,
+            peer: producerAppData.peer,
+            transport: consumerTransport.id,
+            producer: producer.id,
+          });
+        });
+      }
     }
   }
 
@@ -544,6 +555,13 @@ class SFU {
       await router;
     } catch (e) {
       Ansible.error('Error creating router', { call: room.call, error: e instanceof Error ? e.message : e });
+      if (e instanceof Error && Bugsnag.isStarted()) {
+        Bugsnag.notify(e, (event) => {
+          event.addMetadata('call', {
+            call: room.call,
+          });
+        });
+      }
     }
   }
 
@@ -591,6 +609,15 @@ class SFU {
       await transports;
     } catch (e) {
       Ansible.error('Error creating transport', { transport_request: transportRequest._id, error: e instanceof Error ? e.message : e });
+      if (e instanceof Error && Bugsnag.isStarted()) {
+        Bugsnag.notify(e, (event) => {
+          event.addMetadata('call', {
+            id: transportRequest.call,
+            peer: transportRequest.peer,
+            transportRequest: transportRequest._id,
+          });
+        });
+      }
     }
   }
 
@@ -624,6 +651,16 @@ class SFU {
       });
     } catch (e) {
       Ansible.error('Error connecting transport', { transport: transport.id, error: e instanceof Error ? e.message : e });
+      if (e instanceof Error && Bugsnag.isStarted()) {
+        Bugsnag.notify(e, (event) => {
+          event.addMetadata('call', {
+            id: connectRequest.call,
+            peer: connectRequest.peer,
+            transportRequest: connectRequest.transportRequest,
+            transport: connectRequest.transport,
+          });
+        });
+      }
     }
   }
 
@@ -654,6 +691,15 @@ class SFU {
       await mediasoupProducer;
     } catch (e) {
       Ansible.error('Error creating producer', { producer: producer._id, error: e instanceof Error ? e.message : e });
+      if (e instanceof Error && Bugsnag.isStarted()) {
+        Bugsnag.notify(e, (event) => {
+          event.addMetadata('call', {
+            id: producer.call,
+            peer: producer.peer,
+            producer: producer._id,
+          });
+        });
+      }
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1684,6 +1684,63 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@bugsnag/browser": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.18.0.tgz",
+      "integrity": "sha512-lIdM6+mazFkkPwYSbfcBDFMLJ7++WoCuWnaVeaV3HcA7V9RHC+l5CmRSEyRatsiv2xfLPAIasTxAbCCc4WPgCg==",
+      "requires": {
+        "@bugsnag/core": "^7.18.0"
+      }
+    },
+    "@bugsnag/core": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.18.0.tgz",
+      "integrity": "sha512-j5YVnbrQbs2WUFnhXERPm68XooUrdNrbJISsiK5+mnbWJrdGkIw8+p5sROV72fiuuQlLtV3jiEJHlSErZggLBw==",
+      "requires": {
+        "@bugsnag/cuid": "^3.0.0",
+        "@bugsnag/safe-json-stringify": "^6.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "0.0.2",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "@bugsnag/cuid": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.1.tgz",
+      "integrity": "sha512-ZWOywEsXGWMBb9PULGGbP2S/mUDp30ZjaozrOy/pv2xyFoCFiCdk5PB2HA3muH4W/ppb9pXr3b5f7al74qZ5sg=="
+    },
+    "@bugsnag/js": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.18.0.tgz",
+      "integrity": "sha512-engv7itP6E5VcqapikA/ZPgnnImxZLMRZMyu14dgld/RCjCm3XFLhGcscnN8jJkTmp366e5Xqo8Lq7y9aI6Yhw==",
+      "requires": {
+        "@bugsnag/browser": "^7.18.0",
+        "@bugsnag/node": "^7.18.0"
+      }
+    },
+    "@bugsnag/node": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.18.0.tgz",
+      "integrity": "sha512-jXFIJ3DF4AJZ16j5WsUF+Fe8zgtPdBOryRoqdNvTMWBHI6mVtTyn2clTPYjasocV9rdi9hC3cWxilLGlLacnaQ==",
+      "requires": {
+        "@bugsnag/core": "^7.18.0",
+        "byline": "^5.0.0",
+        "error-stack-parser": "^2.0.2",
+        "iserror": "^0.0.2",
+        "pump": "^3.0.0",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "@bugsnag/plugin-react": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/plugin-react/-/plugin-react-7.18.0.tgz",
+      "integrity": "sha512-i4FYauv/8G1ZRH4dTegYPzw5+xt76ubt1GCr4wRieD8q5QBKcvHIqaNrnM9yQ/QNmWnz24LeCCDUVdIb5SrhPA=="
+    },
+    "@bugsnag/safe-json-stringify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
+      "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA=="
+    },
     "@csstools/selector-specificity": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
@@ -2224,6 +2281,12 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
+    },
+    "@types/fibers": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/fibers/-/fibers-3.1.1.tgz",
+      "integrity": "sha512-yHoUi46uika0snoTpNcVqUSvgbRndaIps4TUCotrXjtc0DHDoPQckmyXEZ2bX3e4mpJmyEW3hRhCwQa/ISCPaA==",
+      "dev": true
     },
     "@types/history": {
       "version": "4.7.11",
@@ -3912,6 +3975,11 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
+    "byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q=="
+    },
     "bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -4496,7 +4564,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -7028,6 +7095,11 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true
+    },
+    "iserror": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
+      "integrity": "sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw=="
     },
     "isexe": {
       "version": "2.0.0",
@@ -9803,7 +9875,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.20.7",
+    "@bugsnag/js": "^7.18.0",
+    "@bugsnag/plugin-react": "^7.18.0",
     "@fortawesome/fontawesome-svg-core": "^6.2.1",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
@@ -72,6 +74,7 @@
     "@types/dompurify": "^2.4.0",
     "@types/element-resize-detector": "^1.1.3",
     "@types/express": "^4.17.15",
+    "@types/fibers": "^3.1.1",
     "@types/http-proxy": "^1.17.9",
     "@types/jsbn": "^1.2.30",
     "@types/logfmt": "^1.2.2",

--- a/scripts/run_jolly_roger.sh
+++ b/scripts/run_jolly_roger.sh
@@ -27,6 +27,9 @@ fi
 if [ -z "${MAIL_URL+set}" ]; then
     export MAIL_URL="$(credstash get mailgun)"
 fi
+if [ -z "${BUGSNAG_API_KEY+set}" ]; then
+    export BUGSNAG_API_KEY="$(credstash get bugsnag)"
+fi
 
 credstash get krb5.keytab | openssl base64 -d > /krb5.keytab
 

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,3 +1,6 @@
+// First thing's first: setup error reporting
+import '../imports/server/bugsnag';
+
 // explicitly import all the stuff from lib/ since mainModule skips autoloading
 // things
 import '../imports/lib/config/accounts';

--- a/types/meteor-runtime-config.d.ts
+++ b/types/meteor-runtime-config.d.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line no-underscore-dangle
+declare const __meteor_runtime_config__: {
+  blobMappings?: { [assetName: string]: string };
+  defaultBlobMappings: { [assetName: string]: string };
+  bugsnagApiKey?: string;
+};

--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -1,0 +1,5 @@
+declare module 'meteor/meteor' {
+  namespace Meteor {
+    const gitCommitHash: string;
+  }
+}


### PR DESCRIPTION
This sets up a basic Bugsnag configuration on both the server (pulling API key from the environment) and client (pulling API key from `__meteor_runtime_config__` shipped by the server). I setup more detailed integration in a few specific places:
- We grab user information when it's available to us
- We use Bugsnag's React error boundary, which captures additional React component information
- We wire up reporting to TypedMethod
- We explicitly report a few exceptions that we previously were logging and otherwise throwing away.

This is probably not everything that we want from a Bugsnag integration. We definitely are not currently getting any reporting on exceptions thrown by publish methods (because wildly Meteor more or less completely throws those exceptions away!). We also _may_ have issues with source maps, especially on server-side code, although things may just work - I'm not entirely sure.

In any case, this seems like a good enough starting point, and I was feeling motivated to do something after seeing #1287, which I only caught because I happened to be looking at logs when someone hit it.

Before merging, I'll need to run `credstash --profile jolly-roger -r us-east-1 put -a bugsnag <API KEY>` to make sure it's in place before the new Docker container starts up.

Fixes #109.