### PR TITLE
Handle websockets in cluster children processes

### DIFF
--- a/imports/server/WorkerPool.ts
+++ b/imports/server/WorkerPool.ts
@@ -21,6 +21,12 @@ if (process.env.CLUSTER_WORKER_ID) {
       });
     }
   });
+
+  process.on('message', (message, socket) => {
+    if (message.type === 'proxy-ws') {
+      WebApp.httpServer.emit('upgrade', message.req, socket, Buffer.from(message.head, 'utf8'));
+    }
+  });
 }
 
 export default class WorkerPool {


### PR DESCRIPTION
In cluster mode, the coordinator process sends incoming websocket connections to a worker process via child_process.send. However, when we ported this code away from meteorhacks:cluster, we didn't add a listener in the child to handle that message. This meant that if we had clustering enabled, we would just silently drop websocket connections. This didn't _break_ things, because we would fall back on XHR, but it's definitely not great.

Bring back a handler for the IPC message in the child.