### PR TITLE
Fix issue preventing updating Hunt/Puzzle when url absent

### DIFF
--- a/imports/lib/schemas/validators.ts
+++ b/imports/lib/schemas/validators.ts
@@ -3,6 +3,7 @@ import type { TypeDefinitionProps } from 'simpl-schema/dist/esm/types';
 const ValidUrl: TypeDefinitionProps['custom'] = function () {
   // Tests if a URL is valid by attempting to construct a URL object from it.
   if (!this.isSet) return undefined;
+  if (this.operator === '$unset') return undefined;
   try {
     void new URL(this.value);
   } catch (err) {


### PR DESCRIPTION
Both Hunt and Puzzle contain a field which is optional, but if present, should be a valid URL.  For both of these objects, when we would perform updates on the object, we `$set` the provided keys and `$unset` the others.  Our custom validator was failing since `this.isSet` was true, and empty-string does not parse as a valid URL.  When `this.operator` is `$unset`, though, we don't care about the value -- unsetting the field is always valid.