### PR TITLE
Collect additional data in Bugsnag reports

### DIFF
--- a/imports/client/bugsnag.ts
+++ b/imports/client/bugsnag.ts
@@ -1,6 +1,8 @@
 import { Meteor } from 'meteor/meteor';
 import Bugsnag from '@bugsnag/js';
 import BugsnagPluginReact from '@bugsnag/plugin-react';
+import isAdmin from '../lib/isAdmin';
+import { userIsOperatorForAnyHunt } from '../lib/permission_stubs';
 
 if (__meteor_runtime_config__.bugsnagApiKey) {
   Bugsnag.start({
@@ -9,7 +11,13 @@ if (__meteor_runtime_config__.bugsnagApiKey) {
     plugins: [new BugsnagPluginReact()],
     onError: (event) => {
       const user = Meteor.user();
-      event.setUser(user?._id, user?.emails?.[0]?.address, user?.displayName);
+      if (user) {
+        event.setUser(user._id, user.emails?.[0]?.address, user.displayName);
+        event.addMetadata('user', {
+          admin: isAdmin(user),
+          operator: userIsOperatorForAnyHunt(user),
+        });
+      }
     },
   });
 }

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -1838,8 +1838,10 @@ const PuzzlePage = React.memo(() => {
   }, [onResize]);
 
   useEffect(() => {
-    ensurePuzzleDocument.call({ puzzleId });
-  }, [puzzleId]);
+    if (activePuzzle && !activePuzzle.deleted) {
+      ensurePuzzleDocument.call({ puzzleId: activePuzzle._id });
+    }
+  }, [activePuzzle]);
 
   trace('PuzzlePage render', { puzzleDataLoading, chatDataLoading });
 

--- a/imports/server/bugsnag.ts
+++ b/imports/server/bugsnag.ts
@@ -1,6 +1,8 @@
 import { Meteor } from 'meteor/meteor';
 import Bugsnag from '@bugsnag/js';
 import Fiber from 'fibers';
+import isAdmin from '../lib/isAdmin';
+import { userIsOperatorForAnyHunt } from '../lib/permission_stubs';
 import addRuntimeConfig from './addRuntimeConfig';
 
 const apiKey = process.env.BUGSNAG_API_KEY;
@@ -21,7 +23,13 @@ if (apiKey) {
     onError: (event) => {
       if (Fiber.current) {
         const user = Meteor.user();
-        event.setUser(user?._id, user?.emails?.[0]?.address, user?.displayName);
+        if (user) {
+          event.setUser(user._id, user.emails?.[0]?.address, user.displayName);
+          event.addMetadata('user', {
+            admin: isAdmin(user),
+            operator: userIsOperatorForAnyHunt(user),
+          });
+        }
       }
     },
   });


### PR DESCRIPTION
...and fix a (harmless) bug that @flipdog discovered in `ensurePuzzleDocument`.

I still need to figure out how to get our application source code into Bugsnag. Right now, we see file+line numbers, but they aren't expandable, even though some NPM modules do:

<img width="1485" alt="Screenshot 2023-01-05 at 3 35 51 PM" src="https://user-images.githubusercontent.com/28167/210900257-f01926e5-b7b6-4ae4-8da9-9582b4c88006.png">
