### PR TITLE
Remove "deafen" button for regular users, update mute icons on chatpeople

### DIFF
--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -530,7 +530,7 @@ const CallSection = ({
           <div>
             You were muted by
             {' '}
-            {mutedBy ?? 'someone'}
+            {mutedBy ?? 'someone else'}
             . This usually happens when it seemed like you had stepped away from your computer
             without muting yourself, but your microphone was still on. You can unmute yourself
             at any time.

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -31,23 +31,28 @@ import {
 } from './styling/PeopleComponents';
 
 const CallStateIcon = styled.span`
-  font-size: 12px;
-  width: 16px;
-  height: 16px;
+  font-size: 10px;
+  width: 12px;
+  height: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
   color: red; // TODO: lift $danger from react-bootstrap somehow?
   position: absolute;
   right: 0;
+  background: white;
 `;
 
 const MutedIcon = styled(CallStateIcon)`
   top: 0;
+  border-bottom-left-radius: 6px;
 `;
 
 const DeafenedIcon = styled(CallStateIcon)`
   bottom: 0;
+  border-top-left-radius: 6px;
+  font-size: 8px;
+  text-align: right;
 `;
 
 const RemoteMuteButton = styled.div`

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -500,13 +500,15 @@ const CallSection = ({
         >
           {muted ? 'Un\u00ADmute' : 'Mute self'}
         </AVButton>
-        <AVButton
-          variant={deafened ? 'secondary' : 'light'}
-          size="sm"
-          onClick={onToggleDeafen}
-        >
-          {deafened ? 'Un\u00ADdeafen' : 'Deafen self'}
-        </AVButton>
+        {Meteor.isDevelopment && (
+          <AVButton
+            variant={deafened ? 'secondary' : 'light'}
+            size="sm"
+            onClick={onToggleDeafen}
+          >
+            {deafened ? 'Un\u00ADdeafen' : 'Deafen self'}
+          </AVButton>
+        )}
         <AVButton variant="danger" size="sm" onClick={onLeaveCall}>Leave call</AVButton>
       </AVActions>
       <Overlay target={muteRef.current} show={callState.allowInitialPeerStateNotification && muted} placement="bottom">


### PR DESCRIPTION
New "badges" for mute/deafen icons:

![Screen Shot 2023-01-06 at 21 52 52](https://user-images.githubusercontent.com/689247/211133483-46233d35-a4d7-458f-8e7a-3fc0ddab3a96.png)

![Screen Shot 2023-01-06 at 21 52 58](https://user-images.githubusercontent.com/689247/211133477-21bd69a1-7640-4396-a061-928a40b00825.png)

The deafen button will still appear if you're in dev mode.