### PR TITLE
Guess notification styling tweaks

### DIFF
--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -91,15 +91,37 @@ const StyledGuessDetails = styled.div`
   text-align: end;
 `;
 
+const StyledGuessNotificationHeader = styled.div`
+  display: flex;
+  align-items: baseline;
+  flex: 1;
+
+  > * + * {
+    margin-left: 0.25rem;
+  }
+`;
+
 const StyledGuessHeader = styled.strong`
   overflow-wrap: break-word;
   overflow: hidden;
   hyphens: auto;
   margin-right: auto;
+  flex: 1;
 `;
 
 const StyledNotificationTimestamp = styled.small`
   text-align: end;
+  flex: 0 1 auto;
+`;
+
+const GuessDirectionWrapper = styled.span`
+  margin-right: 0.5rem;
+`;
+
+const GuessConfidenceWrapper = styled.span`
+  flex: 1;
+  display: flex;
+  max-width: 200px;
 `;
 
 const GuessMessage = React.memo(({
@@ -220,6 +242,7 @@ const GuessMessage = React.memo(({
   return (
     <Toast onClose={dismissGuess}>
       <Toast.Header>
+        <StyledGuessNotificationHeader>
         <StyledGuessHeader>
           Guess for
           {' '}
@@ -245,6 +268,7 @@ const GuessMessage = React.memo(({
             endTime={guess.updatedAt!.getTime() + LINGER_PERIOD}
           />
         )}
+        </StyledGuessNotificationHeader>
       </Toast.Header>
       <Toast.Body>
         <StyledNotificationRow>
@@ -268,8 +292,12 @@ const GuessMessage = React.memo(({
             </OverlayTrigger>
           </StyledNotificationActionItem>
           <StyledGuessDetails>
-            <GuessDirection value={guess.direction} />
-            <GuessConfidence id={`notification-guess-${guess._id}-confidence`} value={guess.confidence} />
+            <GuessDirectionWrapper>
+              <GuessDirection value={guess.direction} />
+            </GuessDirectionWrapper>
+            <GuessConfidenceWrapper>
+              <GuessConfidence id={`notification-guess-${guess._id}-confidence`} value={guess.confidence} />
+            </GuessConfidenceWrapper>
           </StyledGuessDetails>
         </StyledNotificationActionBar>
         <StyledNotificationActionBar>

--- a/imports/client/components/SpinnerTimer.tsx
+++ b/imports/client/components/SpinnerTimer.tsx
@@ -87,6 +87,7 @@ const SpinnerTimer = ({
       ref={canvasRef}
       width={width}
       height={height}
+      style={{ alignSelf: "center"}}
     />
   );
 };


### PR DESCRIPTION
Made the solve direction appear next to solve confidence.

Top bar is aligned on baseline now, except for the spinner (which doesn't have a baseline).

![Screen Shot 2023-01-06 at 23 09 14](https://user-images.githubusercontent.com/689247/211138716-e51ff00c-7aad-461e-83e8-07f113c2a08e.png)

![Screen Shot 2023-01-06 at 23 09 18](https://user-images.githubusercontent.com/689247/211138722-fc9436db-f198-401b-b46d-5b177fe338d9.png)
