### PR TITLE
Fix race condition in ProfilePage

### DIFF
--- a/imports/client/components/ProfilePage.tsx
+++ b/imports/client/components/ProfilePage.tsx
@@ -13,15 +13,19 @@ const ResolvedProfilePage = ({ userId, isSelf }: { userId: string, isSelf: boole
   const profileLoading = useSubscribe('profile', userId);
   const loading = profileLoading();
 
-  const user = useTracker(() => MeteorUsers.findOne(userId)!, [userId]);
+  const user = useTracker(() => {
+    return loading ? undefined : MeteorUsers.findOne(userId);
+  }, [userId, loading]);
 
   useBreadcrumb({
-    title: loading ? 'loading...' : user.displayName ?? 'Profile settings',
+    title: loading ? 'loading...' : user?.displayName ?? 'Profile settings',
     path: `/users/${userId}`,
   });
 
   if (loading) {
     return <div>loading...</div>;
+  } else if (!user) {
+    return <div>{`No user ${userId} found.`}</div>;
   } else if (isSelf) {
     return <OwnProfilePage initialUser={user} />;
   }


### PR DESCRIPTION
`loading` can turn true, but since the `useTracker` block does not directly depend on `loading`, `user` could still be cached as `undefined` when React does a rerender until the Tracker autoruns again.

There are several things we can do to be more resilient here:

* don't lie in the type assertion
* handle the case where no user gets loaded at all, which could happen if the URL was incorrect or referred to a non-existent user id.
* put `loading` in the deps list of the `useTracker` block so that a recomputation is forced when loading goes from true to false and a rerender is triggered

Fixing this because I encountered it in production: 
<img width="1047" alt="Screenshot 2023-01-07 at 2 23 04 AM" src="https://user-images.githubusercontent.com/307325/211145637-282c99e1-6042-46cc-b002-a7e029a1985f.png">
