### PR TITLE
Make `indexedDisplayNames` return a Map instead of a Record

### DIFF
--- a/imports/client/components/AnnouncementsPage.tsx
+++ b/imports/client/components/AnnouncementsPage.tsx
@@ -140,7 +140,7 @@ const AnnouncementsPage = () => {
   const announcements = useTracker(() => (
     loading ? [] : Announcements.find({ hunt: huntId }, { sort: { createdAt: 1 } }).fetch()
   ), [loading, huntId]);
-  const displayNames = useTracker(() => (loading ? {} : indexedDisplayNames()), [loading]);
+  const displayNames = useTracker(() => (loading ? new Map<string, string>() : indexedDisplayNames()), [loading]);
   const canCreateAnnouncements = useTracker(() => userMayAddAnnouncementToHunt(Meteor.user(), Hunts.findOne(huntId)), [huntId]);
 
   if (loading) {
@@ -159,7 +159,7 @@ const AnnouncementsPage = () => {
             <Announcement
               key={announcement._id}
               announcement={announcement}
-              displayName={displayNames[announcement.createdBy] ?? '???'}
+              displayName={displayNames.get(announcement.createdBy) ?? '???'}
             />
           );
         })}

--- a/imports/client/components/FirehosePage.tsx
+++ b/imports/client/components/FirehosePage.tsx
@@ -87,7 +87,9 @@ const FirehosePage = () => {
   const chatMessagesLoading = useSubscribe('mongo.chatmessages', { hunt: huntId });
   const loading = profilesLoading() || puzzlesLoading() || chatMessagesLoading();
 
-  const displayNames = useTracker(() => (loading ? {} : indexedDisplayNames()), [loading]);
+  const displayNames = useTracker(() => {
+    return loading ? new Map<string, string>() : indexedDisplayNames();
+  }, [loading]);
   const puzzles = useTracker(() => (
     loading ?
       new Map<string, PuzzleType>() :
@@ -243,7 +245,7 @@ const FirehosePage = () => {
                 key={msg._id}
                 msg={msg}
                 puzzle={puzzles.get(msg.puzzle)}
-                displayName={msg.sender ? displayNames[msg.sender] ?? '???' : 'jolly-roger'}
+                displayName={msg.sender ? displayNames.get(msg.sender) ?? '???' : 'jolly-roger'}
               />
             );
           })}

--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -289,7 +289,7 @@ const GuessQueuePage = () => {
   const hunt = useTracker(() => Hunts.findOne({ _id: huntId }), [huntId]);
   const guesses = useTracker(() => (loading ? [] : Guesses.find({ hunt: huntId }, { sort: { createdAt: -1 } }).fetch()), [huntId, loading]);
   const puzzles = useTracker(() => (loading ? new Map<string, PuzzleType>() : indexedById(Puzzles.find({ hunt: huntId }).fetch())), [huntId, loading]);
-  const displayNames = useTracker(() => (loading ? {} : indexedDisplayNames()), [loading]);
+  const displayNames = useTracker(() => (loading ? new Map<string, string>() : indexedDisplayNames()), [loading]);
   const canEdit = useTracker(() => userMayUpdateGuessesForHunt(Meteor.user(), hunt), [hunt]);
 
   const searchBarRef = useRef<HTMLInputElement>(null);
@@ -422,7 +422,7 @@ const GuessQueuePage = () => {
               key={guess._id}
               hunt={hunt}
               guess={guess}
-              createdByDisplayName={displayNames[guess.createdBy] ?? '???'}
+              createdByDisplayName={displayNames.get(guess.createdBy) ?? '???'}
               puzzle={puzzles.get(guess.puzzle)!}
               canEdit={canEdit}
             />

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -591,7 +591,7 @@ const NotificationCenter = () => {
   // Lookup tables to support guesses/pendingAnnouncements/chatNotifications
   const hunts = useTracker(() => (loading ? new Map<string, HuntType>() : indexedById(Hunts.find().fetch())), [loading]);
   const puzzles = useTracker(() => (loading ? new Map<string, PuzzleType>() : indexedById(Puzzles.find().fetch())), [loading]);
-  const displayNames = useTracker(() => (loading ? {} : indexedDisplayNames()), [loading]);
+  const displayNames = useTracker(() => (loading ? new Map<string, string>() : indexedDisplayNames()), [loading]);
   const announcements = useTracker(() => (loading ? new Map<string, AnnouncementType>() : indexedById(Announcements.find().fetch())), [loading]);
 
   const [recentGuessEpoch, setRecentGuessEpoch] = useState<number>(Date.now() - LINGER_PERIOD);
@@ -703,7 +703,7 @@ const NotificationCenter = () => {
       guess={g}
       puzzle={puzzles.get(g.puzzle)!}
       hunt={hunts.get(g.hunt)!}
-      guesser={displayNames[g.createdBy]!}
+      guesser={displayNames.get(g.createdBy) ?? '???'}
       onDismiss={dismissGuess}
     />);
   });
@@ -714,7 +714,7 @@ const NotificationCenter = () => {
         key={pa._id}
         id={pa._id}
         announcement={announcements.get(pa.announcement)!}
-        createdByDisplayName={displayNames[pa.createdBy]!}
+        createdByDisplayName={displayNames.get(pa.createdBy) ?? '???'}
       />
     );
   });
@@ -726,7 +726,7 @@ const NotificationCenter = () => {
         cn={cn}
         hunt={hunts.get(cn.hunt)!}
         puzzle={puzzles.get(cn.puzzle)!}
-        senderDisplayName={displayNames[cn.sender]!}
+        senderDisplayName={displayNames.get(cn.sender) ?? '???'}
       />
     );
   });

--- a/imports/client/components/PuzzleDeleteModal.tsx
+++ b/imports/client/components/PuzzleDeleteModal.tsx
@@ -62,7 +62,7 @@ const PuzzleDeleteModal = React.forwardRef((
     ...callers.map(({ createdBy }) => createdBy),
   ])]
     .map((u) => {
-      return { id: u, name: displayNames[u] ?? 'Unknown viewer' };
+      return { id: u, name: displayNames.get(u) ?? 'Unknown viewer' };
     });
 
   const [replacementId, setReplacementId] = useState<PuzzleSelectOption | null>(null);

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -318,7 +318,7 @@ const ChatHistory = React.forwardRef(({
   puzzleId, displayNames,
 }: {
   puzzleId: string;
-  displayNames: Record<string, string>;
+  displayNames: Map<string, string>;
 }, forwardedRef: React.Ref<ChatHistoryHandle>) => {
   const chatMessages: FilteredChatMessageType[] = useTracker(
     () => ChatMessages.find(
@@ -446,7 +446,7 @@ const ChatHistory = React.forwardRef(({
         </ChatMessageDiv>
       ) : undefined}
       {chatMessages.map((msg, index, messages) => {
-        const displayName = msg.sender !== undefined ? displayNames[msg.sender] : 'jolly-roger';
+        const displayName = msg.sender !== undefined ? displayNames.get(msg.sender) ?? '???' : 'jolly-roger';
         // Only suppress sender and timestamp if:
         // * this is not the first message
         // * this message was sent by the same person as the previous message
@@ -571,7 +571,7 @@ const ChatSection = React.forwardRef(({
 }: {
   chatDataLoading: boolean;
   puzzleDeleted: boolean;
-  displayNames: Record<string, string>;
+  displayNames: Map<string, string>;
   puzzleId: string;
   huntId: string;
   callState: CallState;
@@ -931,7 +931,7 @@ const PuzzlePageMetadata = ({
   puzzle, displayNames, document, isDesktop,
 }: {
   puzzle: PuzzleType;
-  displayNames: Record<string, string>;
+  displayNames: Map<string, string>;
   document?: DocumentType;
   isDesktop: boolean;
 }) => {
@@ -1250,7 +1250,7 @@ const PuzzleGuessModal = React.forwardRef(({
 }: {
   puzzle: PuzzleType;
   guesses: GuessType[];
-  displayNames: Record<string, string>;
+  displayNames: Map<string, string>;
 }, forwardedRef: React.Ref<PuzzleGuessModalHandle>) => {
   const [guessInput, setGuessInput] = useState<string>('');
   const [directionInput, setDirectionInput] = useState<number>(0);
@@ -1488,7 +1488,7 @@ const PuzzleGuessModal = React.forwardRef(({
                   </GuessAnswerCell>
                 </GuessTableSmallRow>
                 <GuessTimestampCell>{calendarTimeFormat(guess.createdAt)}</GuessTimestampCell>
-                <GuessSubmitterCell><Breakable>{displayNames[guess.createdBy]}</Breakable></GuessSubmitterCell>
+                <GuessSubmitterCell><Breakable>{displayNames.get(guess.createdBy) ?? '???'}</Breakable></GuessSubmitterCell>
                 <GuessDirectionCell>
                   <GuessDirection value={guess.direction} />
                 </GuessDirectionCell>
@@ -1769,7 +1769,7 @@ const PuzzlePage = React.memo(() => {
 
   const displayNames = useTracker(() => (
     puzzleDataLoading && chatDataLoading ?
-      {} :
+      new Map<string, string>() :
       indexedDisplayNames()
   ), [puzzleDataLoading, chatDataLoading]);
   // Sort by created at so that the "first" document always has consistent meaning

--- a/imports/lib/models/MeteorUsers.ts
+++ b/imports/lib/models/MeteorUsers.ts
@@ -5,13 +5,14 @@ import UserSchema from '../schemas/User';
 Meteor.users.deny({ update: () => true });
 Meteor.users.attachSchema(UserSchema);
 
-export function indexedDisplayNames(): Record<string, string> {
-  return Object.fromEntries(Meteor.users.find({
+export function indexedDisplayNames(): Map<string, string> {
+  const res = new Map<string, string>();
+  Meteor.users.find({
     displayName: { $ne: undefined },
   }, {
     fields: { displayName: 1 },
-  })
-    .map((u) => [u._id, u.displayName!]));
+  }).forEach((u) => res.set(u._id, u.displayName!));
+  return res;
 }
 
 // Re-export Meteor.users. We should require this instead of using Meteor.users


### PR DESCRIPTION
Consumers of `indexedDisplayNames` need to handle the case where the display name for that user is unset (due to incomplete onboarding, etc.) anyway, and `Map.get()` helps enforce that neatly via return type.