### PR TITLE
Upload client source maps to Bugsnag

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,6 +46,8 @@
 
     // sometimes else after a return reads more clearly
     "no-else-return": "off",
+    // same for continue
+    "no-continue": "off",
 
      // We sometimes use these in various forms
     "no-underscore-dangle": ["error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6279,6 +6279,16 @@
         "is-callable": "^1.1.3"
       }
     },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "dompurify": "^2.4.3",
     "element-resize-detector": "^1.2.4",
     "express": "^4.18.2",
+    "form-data": "^4.0.0",
     "fp-ts": "^2.13.1",
     "glob": "^8.0.3",
     "google-auth-library": "^8.6.0",


### PR DESCRIPTION
In theory, Bugsnag should be able to fetch these on its own, but in practice it doesn't seem to be happening.

I think there may still be followup work for dynamically imported files - they ship source maps in a different format. Specifically, for the main JS bundle, Meteor uses the `sourceMap` and `sourceMapUrl` properties in the manifest to generate `X-SourceMap` headers. For dynamically imported files, the contents of the files include a `sourceMappingURL` comment, which refers to a file that's served independently. I tried to write some code to upload those as well, but couldn't get it working in the amount of time I had allotted myself to work on this today. I think this is still a useful incremental improvement, though, and worth landing in the interim.