### PR TITLE
Specify a width on sparklines

### DIFF
--- a/imports/client/components/PuzzleActivity.tsx
+++ b/imports/client/components/PuzzleActivity.tsx
@@ -53,6 +53,7 @@ const PuzzleOpenTime = styled(PuzzleActivityItem)`
 
 const PuzzleActivitySparkline = styled(PuzzleActivityItem)`
   min-width: 6rem;
+  max-width: 8rem;
 
   span {
     margin-right: 0;
@@ -233,7 +234,8 @@ const PuzzleActivity = ({ huntId, puzzleId, unlockTime }: PuzzleActivityProps) =
       <OverlayTrigger placement="top" overlay={sparklineTooltip}>
         <PuzzleActivitySparkline>
           <FontAwesomeIcon icon={faPeopleGroup} fixedWidth />
-          <Sparklines data={totals} min={0} max={maxTotalCount}>
+          {/* Sparklines doesn't accept a className argument, so we can't use styled-components */}
+          <Sparklines data={totals} min={0} max={maxTotalCount} style={{ width: '100%' }}>
             <SparklinesLine />
             <SparklinesSpots spotColors={{ '-1': 'black', 0: 'black', 1: 'black' }} />
           </Sparklines>


### PR DESCRIPTION
Safari requires a width to be specified on SVG elements. Fixes #1316.

rendered at fullsize and mobile widths:

<img width="1017" alt="Screenshot 2023-01-10 at 8 05 52 AM" src="https://user-images.githubusercontent.com/28167/211559394-a4aa5573-c7be-4eaf-9f1c-9ed92b925f86.png">

<img width="575" alt="Screenshot 2023-01-10 at 8 06 10 AM" src="https://user-images.githubusercontent.com/28167/211559451-cda82a82-7658-49e9-b5c7-5a10e491d53f.png">
