### PR TITLE
Automatically re-join calls after code-push-triggered reload

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,7 +56,8 @@
         "allow": [
           "_id", "_this", "_dropIndex", "_redirectUri", "_postRequest",
           "_anyMethodsAreOutstanding", "_schemaKeys", "_schema", "_retrieveCredentialSecret",
-          "_loginStyle", "_stateParam", "_name", "_allSubscriptionsReady"
+          "_onMigrate", "_migrationData", "_loginStyle", "_stateParam", "_name",
+          "_allSubscriptionsReady"
         ]
       }
     ],

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -78,6 +78,7 @@ import undestroyPuzzle from '../../methods/undestroyPuzzle';
 import updatePuzzle from '../../methods/updatePuzzle';
 import GoogleScriptInfo from '../GoogleScriptInfo';
 import { useBreadcrumb } from '../hooks/breadcrumb';
+import { useTabId } from '../hooks/persisted-state';
 import useCallState, { Action, CallState } from '../hooks/useCallState';
 import useDocumentTitle from '../hooks/useDocumentTitle';
 import useSubscribeDisplayNames from '../hooks/useSubscribeDisplayNames';
@@ -101,8 +102,6 @@ import { mediaBreakpointDown } from './styling/responsive';
 
 // Shows a state dump as an in-page overlay when enabled.
 const DEBUG_SHOW_CALL_STATE = false;
-
-const tabId = Random.id();
 
 const FilteredChatFields = ['_id', 'puzzle', 'text', 'content', 'sender', 'timestamp'] as const;
 type FilteredChatMessageType = Pick<ChatMessageType, typeof FilteredChatFields[number]>
@@ -1824,6 +1823,12 @@ const PuzzleDeletedModal = ({
 };
 
 const PuzzlePage = React.memo(() => {
+  const [tabId, setTabId] = useTabId(() => Random.id());
+  // Ensure that tabId is persisted when initially populated
+  useEffect(() => {
+    setTabId(tabId);
+  }, [tabId, setTabId]);
+
   const puzzlePageDivRef = useRef<HTMLDivElement | null>(null);
   const chatSectionRef = useRef<ChatSectionHandle | null>(null);
   const [sidebarWidth, setSidebarWidth] = useState<number>(DefaultSidebarWidth);

--- a/types/meteor/reload.d.ts
+++ b/types/meteor/reload.d.ts
@@ -1,0 +1,14 @@
+declare module 'meteor/reload' {
+  namespace Reload {
+    function _onMigrate(
+      cb: (retry: () => void, options: { immediateMigration?: boolean }) =>
+        [false] | [ready: true, data?: any]
+    ): void;
+    function _onMigrate(
+      name: string,
+      cb: (retry: () => void, options: { immediateMigration?: boolean }) =>
+        [false] | [ready: true, data?: any]
+    ): void;
+    function _migrationData(name: string): unknown;
+  }
+}


### PR DESCRIPTION
If Meteor triggers a page reload due to out-of-date code, stash the current state of whatever call we're in in sessionStorage, and use that to automatically re-join the call afterwards. We do some shenanigans to ensure that this only happens when Meteor triggers a page reload (as opposed to the user refreshing the page on their own).

Fixes #1314 

This doesn't 100% work yet - it doesn't suppress `allowInitialPeerStateNotification`, so if you're muted and the page refreshes for a code push, you'll get the large call popup. It's also somewhat annoying to test in development mode, because hot-module-replacement completely prevents Meteor-drive page reloads. I temporarily ran `meteor remove hot-module-replacement` temporarily in my local copy for testing, although I think that completely stopping and restarting the Meteor server might also trigger a full-page refresh.