### PR TITLE
Fix early returns from promise conversion

### DIFF
--- a/imports/server/addUsersToDiscordRole.ts
+++ b/imports/server/addUsersToDiscordRole.ts
@@ -40,7 +40,7 @@ export default async (userIds: string[], huntId: string) => {
     const user = await MeteorUsers.findOneAsync(userId);
     if (!user?.discordAccount) {
       Logger.info('Can not add users to Discord role because user has not linked their Discord account', { userIds, huntId });
-      return;
+      continue;
     }
     try {
       await discord.addUserToRole(user.discordAccount.id, guild.id, roleId);

--- a/imports/server/methods/configureCollectGoogleAccountIds.ts
+++ b/imports/server/methods/configureCollectGoogleAccountIds.ts
@@ -28,7 +28,7 @@ configureCollectGoogleAccountIds.define({
       for (const contact of resp.data.otherContacts ?? []) {
         const id = contact.metadata?.sources?.find((s) => s.type === 'PROFILE')?.id ?? undefined;
         if (!id) {
-          return;
+          continue;
         }
 
         const addresses = contact.emailAddresses?.reduce<string[]>((a, e) => {

--- a/imports/server/methods/configureEnsureGoogleScript.ts
+++ b/imports/server/methods/configureEnsureGoogleScript.ts
@@ -79,7 +79,7 @@ configureEnsureGoogleScript.define({
       for (const d of deployments) {
         if (!d.deploymentConfig?.versionNumber) {
           // No version number means this is a HEAD deployment
-          return;
+          continue;
         }
 
         await script.projects.deployments.update({


### PR DESCRIPTION
When we were reducing over promises, we would "continue" through the loop with early return, but that doesn't do what we want now that we don't have an iteration function anymore.

Fixes some bugs introduced in #1318, although fortunately I don't think any of these are especially urgent.