### PR TITLE
Graphical indicator for Guess Direction

### DIFF
--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -33,7 +33,7 @@ import useSubscribeDisplayNames from '../hooks/useSubscribeDisplayNames';
 import GuessState from './GuessState';
 import Markdown from './Markdown';
 import PuzzleAnswer from './PuzzleAnswer';
-import { GuessConfidence, GuessDirection } from './guessDetails';
+import { GuessConfidence, GuessDirection, formatGuessDirection } from './guessDetails';
 import Breakable from './styling/Breakable';
 import { guessColorLookupTable, NavBarHeight } from './styling/constants';
 import { Breakpoint, mediaBreakpointDown } from './styling/responsive';
@@ -47,8 +47,8 @@ const StyledTable = styled.div`
     [submitter] minmax(auto, 8em)
     [puzzle] minmax(10em, auto)
     [answer] minmax(10em, auto)
-    [direction] minmax(5em, auto)
-    [confidence] minmax(7em, auto)
+    [direction] minmax(6em, auto)
+    [confidence] minmax(6em, auto)
     [status] auto
     [actions] auto;
   ${mediaBreakpointDown(compactViewBreakpoint, css`
@@ -89,11 +89,19 @@ const StyledCell = styled.div`
 const StyledGuessDirection = styled(GuessDirection)`
   padding: 4px;
   background-color: inherit;
+  ${mediaBreakpointDown(compactViewBreakpoint, css`
+    padding: 0;
+    max-width: 200px;
+  `)}
 `;
 
 const StyledGuessConfidence = styled(GuessConfidence)`
   padding: 4px;
   background-color: inherit;
+  ${mediaBreakpointDown(compactViewBreakpoint, css`
+    padding: 0;
+    max-width: 200px;
+  `)}
 `;
 
 const StyledLinkButton = styled(Button)`
@@ -243,7 +251,7 @@ const GuessBlock = React.memo(({
           <StyledGuessDetailLabel>
             Solve direction
           </StyledGuessDetailLabel>
-          <StyledGuessDirection value={guess.direction} />
+          <StyledGuessDirection id={`guess-${guess._id}-direction`} value={guess.direction} />
         </StyledGuessDetailWithLabel>
         <StyledGuessDetailWithLabel>
           <StyledGuessDetailLabel>
@@ -367,7 +375,11 @@ const GuessQueuePage = () => {
 
   const directionTooltip = (
     <Tooltip id="direction-tooltip">
-      Direction this puzzle was solved, ranging from completely backsolved (-10) to completely forward solved (10)
+      Direction this puzzle was solved, ranging from completely backsolved (
+      {formatGuessDirection(-10)}
+      ) to completely forward solved (
+      {formatGuessDirection(10)}
+      )
     </Tooltip>
   );
   const confidenceTooltip = (

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -269,7 +269,7 @@ const GuessMessage = React.memo(({
             </OverlayTrigger>
           </StyledNotificationActionItem>
           <StyledGuessDetails>
-            <GuessDirection value={guess.direction} />
+            <GuessDirection id={`notification-guess-${guess._id}-direction`} value={guess.direction} />
             <GuessConfidence id={`notification-guess-${guess._id}-confidence`} value={guess.confidence} />
           </StyledGuessDetails>
         </StyledNotificationActionBar>

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -93,7 +93,12 @@ import PuzzleAnswer from './PuzzleAnswer';
 import PuzzleModalForm, { PuzzleModalFormSubmitPayload } from './PuzzleModalForm';
 import SplitPanePlus from './SplitPanePlus';
 import TagList from './TagList';
-import { GuessConfidence, GuessDirection } from './guessDetails';
+import {
+  GuessConfidence,
+  GuessDirection,
+  formatGuessDirection,
+  formatConfidence,
+} from './guessDetails';
 import Breakable from './styling/Breakable';
 import FixedLayout from './styling/FixedLayout';
 import { guessColorLookupTable, MonospaceFontFamily, SolvedPuzzleBackgroundColor } from './styling/constants';
@@ -1255,8 +1260,8 @@ const GuessTable = styled.div`
     [answer] auto
     [timestamp] auto
     [submitter] auto
-    [direction] 3.5em
-    [confidence] 3.5em;
+    [direction] 4em
+    [confidence] 4em;
   ${mediaBreakpointDown('sm', css`
     grid-template-columns: minmax(0, auto) minmax(0, auto);
   `)}
@@ -1459,15 +1464,14 @@ const PuzzleGuessModal = React.forwardRef(({
     <Tooltip id="jr-puzzle-guess-direction-tooltip">
       <strong>Solve direction:</strong>
       {' '}
-      {directionInput}
+      {formatGuessDirection(directionInput)}
     </Tooltip>
   );
   const confidenceTooltip = (
     <Tooltip id="jr-puzzle-guess-confidence-tooltip">
       <strong>Confidence:</strong>
       {' '}
-      {confidenceInput}
-      %
+      {formatConfidence(confidenceInput)}
     </Tooltip>
   );
   const copyTooltip = (
@@ -1613,7 +1617,7 @@ const PuzzleGuessModal = React.forwardRef(({
                 <GuessTimestampCell>{calendarTimeFormat(guess.createdAt)}</GuessTimestampCell>
                 <GuessSubmitterCell><Breakable>{displayNames.get(guess.createdBy) ?? '???'}</Breakable></GuessSubmitterCell>
                 <GuessDirectionCell>
-                  <GuessDirection value={guess.direction} />
+                  <GuessDirection id={`guess-${guess._id}-direction`} value={guess.direction} />
                 </GuessDirectionCell>
                 <GuessConfidenceCell>
                   <GuessConfidence id={`guess-${guess._id}-confidence`} value={guess.confidence} />

--- a/imports/client/components/guessDetails.tsx
+++ b/imports/client/components/guessDetails.tsx
@@ -1,6 +1,3 @@
-import { faArrowLeft } from '@fortawesome/free-solid-svg-icons/faArrowLeft';
-import { faArrowRight } from '@fortawesome/free-solid-svg-icons/faArrowRight';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React from 'react';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
@@ -30,17 +27,91 @@ const GuessConfidenceProgressBar = styled.div<{ $value: number }>`
   }
 `;
 
-const GuessDirection = ({ value, className }: {
+const GuessDirectionSvg = styled.svg`
+  flex-grow: 1;
+  width: 1px;
+  height: 1em;
+  fill: grey;
+
+  line {
+    stroke: black;
+    stroke-width: 1;
+    vector-effect: non-scaling-stroke;
+  }
+`;
+
+const formatGuessDirection = (value: GuessType['direction']) => {
+  if (value === undefined) {
+    return 'Unspecified';
+  }
+  if (value === 0) {
+    return 'Neutral';
+  }
+  const directionStr = value > 0 ? 'Forward' : 'Back';
+  return `${directionStr} ${Math.abs(value)}`;
+};
+
+const GuessDirection = ({ id, value, className }: {
+  id: string;
   value: GuessType['direction'];
   className?: string;
 }) => {
+  const arrowShaftWidth = 0.3;
+  const arrowHeadWidth = 1.0; // 0 < arrowHeadWidth <= 1
+  const arrowHeadBaseDepth = 1.0; // 0 < arrowHeadBaseDepth <= 1
+  const arrowHeadFullDepth = 1.5; // arrowHeadBaseDepth <= arrowHeadFullDepth
+
+  const tooltip = (
+    <Tooltip id={`${id}-tooltip`}>
+      <strong>Solve directon:</strong>
+      {' '}
+      {formatGuessDirection(value)}
+    </Tooltip>
+  );
+  const arrowHeadEnd = value ?? 0;
+  const arrowHeadBase = arrowHeadEnd - Math.sign(arrowHeadEnd) * arrowHeadBaseDepth;
+  const arrowHeadStart = arrowHeadEnd - Math.sign(arrowHeadEnd) * arrowHeadFullDepth;
   return (
     <GuessDetail className={className}>
-      <FontAwesomeIcon icon={(value ?? 0) < 0 ? faArrowLeft : faArrowRight} fixedWidth />
-      {' '}
-      {value ?? 0}
+      <OverlayTrigger placement="top" overlay={tooltip}>
+        <GuessDirectionSvg xmlns="htp://www.w3.org/2000/svg">
+          <svg viewBox="-10 -1 20 2" preserveAspectRatio="none">
+            <line x1="-10" y1="0" x2="10" y2="0" />
+            {value && (
+              <polygon points={`
+                0, ${arrowShaftWidth}
+                ${arrowHeadBase}, ${arrowShaftWidth}
+                ${arrowHeadStart}, ${arrowHeadWidth}
+                ${arrowHeadEnd}, 0
+                ${arrowHeadStart}, ${-arrowHeadWidth}
+                ${arrowHeadBase}, ${-arrowShaftWidth}
+                0, ${-arrowShaftWidth}`}
+              />
+            )}
+          </svg>
+          {value === 0 && (
+            <svg
+              viewBox="-1 -1 2 2"
+              preserveAspectRatio="xMidYMid meet"
+              width="100%"
+              height={`${arrowShaftWidth * 100}%`}
+              x="0"
+              y={`${(1 - arrowShaftWidth) * 50}%`}
+            >
+              <circle cx="0" cy="0" r="1" />
+            </svg>
+          )}
+        </GuessDirectionSvg>
+      </OverlayTrigger>
     </GuessDetail>
   );
+};
+
+const formatConfidence = (value: GuessType['confidence']) => {
+  if (value === undefined) {
+    return 'Unspecified';
+  }
+  return `${value}%`;
 };
 
 const GuessConfidence = ({ id, value, className }: {
@@ -52,20 +123,24 @@ const GuessConfidence = ({ id, value, className }: {
     <Tooltip id={`${id}-tooltip`}>
       <strong>Confidence:</strong>
       {' '}
-      {value}
-      %
+      {formatConfidence(value)}
     </Tooltip>
   );
 
   return (
-    <OverlayTrigger placement="top" overlay={tooltip}>
-      <GuessDetail className={className}>
+    <GuessDetail className={className}>
+      <OverlayTrigger placement="top" overlay={tooltip}>
         <GuessConfidenceProgress>
           <GuessConfidenceProgressBar $value={value ?? 0} />
         </GuessConfidenceProgress>
-      </GuessDetail>
-    </OverlayTrigger>
+      </OverlayTrigger>
+    </GuessDetail>
   );
 };
 
-export { GuessDirection, GuessConfidence };
+export {
+  GuessDirection,
+  GuessConfidence,
+  formatGuessDirection,
+  formatConfidence,
+};


### PR DESCRIPTION
Improvements to guess details:
- Replace numeric Guess Direction indicator with a graphical one to parallel the existing Guess Confidence gauge
- Improve text descriptions of both direction and confidence and standardize throughout the app
- Very minor adjustments to sizing of guess details in charts, including setting a maximum width in the Guess Queue compact view (chosen to be essentially the natural choice on an iPhone Plus/Max)

Guess Direction indicators at three different aspect ratios (typical for puzzle page modal, guess queue, and compact guess queue) showings values of undefined, -10..-1, 0, and 1..10
<img width="364" alt="Depictions of all values of guess direction at various widths" src="https://user-images.githubusercontent.com/2136874/211675156-d624620a-8860-4bea-b952-c57f321d231f.png">

Ideally, I'd like the arrowheads to responsively get proportionately shorter (and/or use less overhang) as the aspect ratio increases, but that gets surprisingly messy and, over the range of sizes that naturally occur, it isn't critical. I might revisit that sometime.