### PR TITLE
Block code reloads when it would destroy state

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,7 +56,7 @@
         "allow": [
           "_id", "_this", "_dropIndex", "_redirectUri", "_postRequest",
           "_anyMethodsAreOutstanding", "_schemaKeys", "_schema", "_retrieveCredentialSecret",
-          "_loginStyle", "_stateParam", "_name", "_allSubscriptionsReady"
+          "_loginStyle", "_stateParam", "_name", "_allSubscriptionsReady", "_onMigrate"
         ]
       }
     ],

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -44,6 +44,7 @@ import { guessURL } from '../../model-helpers';
 import GoogleScriptInfo from '../GoogleScriptInfo';
 import { requestDiscordCredential } from '../discord';
 import { useOperatorActionsHidden } from '../hooks/persisted-state';
+import { useBlockReasons } from '../hooks/useBlockUpdate';
 import ChatMessageV2 from './ChatMessageV2';
 import Markdown from './Markdown';
 import PuzzleAnswer from './PuzzleAnswer';
@@ -551,6 +552,45 @@ const ChatNotificationMessage = ({
   );
 };
 
+const ReloadRequiredNotification = ({ reasons }: { reasons: string[] }) => {
+  const reload = useCallback(() => window.location.reload(), []);
+
+  return (
+    <Toast>
+      <Toast.Header closeButton={false}>
+        <strong className="me-auto">
+          Jolly Roger update pending
+        </strong>
+      </Toast.Header>
+      <Toast.Body>
+        <StyledNotificationRow>
+          There is a new version of Jolly Roger available, but we&apos;re delaying the update
+          because:
+          <ul>
+            {reasons.map((reason) => (
+              <li key={reason}>{reason}</li>
+            ))}
+          </ul>
+          We don&apos;t want to interrupt your work, but it is important that you update as soon as
+          is reasonable, so when you&apos;re at a breaking point, please reload the page. (Or if
+          these blockers all go away, we will do so automatically.)
+        </StyledNotificationRow>
+        <StyledNotificationActionBar>
+          <StyledNotificationActionItem>
+            <Button
+              variant="outline-danger"
+              onClick={reload}
+              size="sm"
+            >
+              Reload
+            </Button>
+          </StyledNotificationActionItem>
+        </StyledNotificationActionBar>
+      </Toast.Body>
+    </Toast>
+  );
+};
+
 const StyledToastContainer = styled(ToastContainer)`
   z-index: 1050;
 
@@ -570,6 +610,8 @@ const NotificationCenter = () => {
   const showUpdateGoogleScript = useTracker(() => {
     return showGoogleScriptInfo ? GoogleScriptInfo.findOne()?.outOfDate : false;
   }, [showGoogleScriptInfo]);
+
+  const [pendingUpdate, blockReasons] = useBlockReasons();
 
   const fetchPendingGuesses = useTracker(() => userIsOperatorForAnyHunt(Meteor.user()), []);
   const pendingGuessesLoading = useSubscribe(fetchPendingGuesses ? 'pendingGuesses' : undefined);
@@ -684,6 +726,10 @@ const NotificationCenter = () => {
 
   // Build a list of uninstantiated messages with their props, then create them
   const messages = [] as JSX.Element[];
+
+  if (pendingUpdate && blockReasons.length > 0) {
+    messages.push(<ReloadRequiredNotification reasons={blockReasons} />);
+  }
 
   if (showUpdateGoogleScript && !hideUpdateGoogleScriptMessage) {
     messages.push(<UpdateGoogleScriptMessage

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -78,6 +78,7 @@ import undestroyPuzzle from '../../methods/undestroyPuzzle';
 import updatePuzzle from '../../methods/updatePuzzle';
 import GoogleScriptInfo from '../GoogleScriptInfo';
 import { useBreadcrumb } from '../hooks/breadcrumb';
+import useBlockUpdate from '../hooks/useBlockUpdate';
 import useCallState, { Action, CallState } from '../hooks/useCallState';
 import useDocumentTitle from '../hooks/useDocumentTitle';
 import useSubscribeDisplayNames from '../hooks/useSubscribeDisplayNames';
@@ -667,6 +668,7 @@ const ChatInput = React.memo(({
   const hasNonTrivialContent = useNewInput ?
     hasNonTrivialV2Content :
     text.length > 0;
+  useBlockUpdate(hasNonTrivialContent ? "You're in the middle of typing a message." : undefined);
 
   return (
     <ChatInputRow>

--- a/imports/client/hooks/useBlockUpdate.tsx
+++ b/imports/client/hooks/useBlockUpdate.tsx
@@ -1,0 +1,112 @@
+import { Reload } from 'meteor/reload';
+import React, {
+  useContext, useEffect, useRef, useState,
+} from 'react';
+
+// BlockHandle is basically used as a sentinel object, generated for each
+// invocation of useBlockUpdate to ensure that we track it consistently as the
+// invoker re-renders
+type BlockHandle = Record<string, never>
+
+type BlockStatus = [blocked: boolean, reasons: string[]];
+type BlockSubscriber = (status: BlockStatus) => void;
+
+class BlockManager {
+  private blockers: Map<BlockHandle, string | undefined> = new Map();
+
+  private subscribers: Set<BlockSubscriber> = new Set();
+
+  private unblock?: () => void;
+
+  isBlocked() {
+    return [...this.blockers.values()].some((b) => b);
+  }
+
+  checkUnblocked() {
+    if (!this.isBlocked()) {
+      this.unblock?.();
+      this.unblock = undefined;
+    }
+  }
+
+  onMigrate(retry: () => void) {
+    if (this.isBlocked()) {
+      this.unblock = retry;
+      this.updateSubscribers();
+      return [false] as const;
+    }
+    return [true] as const;
+  }
+
+  updateBlocker(blocker: BlockHandle, reason: string | undefined) {
+    this.blockers.set(blocker, reason);
+    this.checkUnblocked();
+    this.updateSubscribers();
+  }
+
+  clearBlocker(blocker: BlockHandle) {
+    this.blockers.delete(blocker);
+    this.checkUnblocked();
+    this.updateSubscribers();
+  }
+
+  updateSubscribers() {
+    const pendingUpdate = !!this.unblock;
+    const reasons = [...this.blockers.values()].filter<string>((b): b is string => !!b);
+    this.subscribers.forEach((s) => s([pendingUpdate, reasons]));
+  }
+
+  subscribe(subscriber: BlockSubscriber) {
+    this.subscribers.add(subscriber);
+  }
+
+  unsubscribe(subscriber: BlockSubscriber) {
+    this.subscribers.delete(subscriber);
+  }
+}
+
+const blockManager = new BlockManager();
+Reload._onMigrate((retry, { immediateMigration }) => {
+  if (immediateMigration) {
+    // no point in stalling
+    return [true];
+  }
+
+  return blockManager.onMigrate(retry);
+});
+
+const BlockUpdateContext = React.createContext(blockManager);
+
+const useBlockUpdate = (reason: string | undefined) => {
+  const ctx = useContext(BlockUpdateContext);
+  const blocker = useRef<BlockHandle>({});
+
+  useEffect(() => {
+    ctx.updateBlocker(blocker.current, reason);
+  }, [reason, ctx]);
+
+  // Only remove blocker when unmounted
+  useEffect(() => {
+    const { current } = blocker;
+    return () => {
+      ctx.clearBlocker(current);
+    };
+  }, [ctx]);
+};
+
+export default useBlockUpdate;
+
+const useBlockReasons = (): BlockStatus => {
+  const ctx = useContext(BlockUpdateContext);
+  const [status, setStatus] = useState<BlockStatus>([false, []]);
+  useEffect(() => {
+    ctx.subscribe(setStatus);
+    return () => {
+      ctx.unsubscribe(setStatus);
+    };
+  }, [ctx]);
+
+  return status;
+};
+
+export { useBlockReasons };

--- a/imports/client/hooks/useCallState.ts
+++ b/imports/client/hooks/useCallState.ts
@@ -20,6 +20,7 @@ import mediasoupAckPeerRemoteMute from '../../methods/mediasoupAckPeerRemoteMute
 import mediasoupConnectTransport from '../../methods/mediasoupConnectTransport';
 import mediasoupSetPeerState from '../../methods/mediasoupSetPeerState';
 import mediasoupSetProducerPaused from '../../methods/mediasoupSetProducerPaused';
+import useBlockUpdate from './useBlockUpdate';
 
 const logger = defaultLogger.child({ label: 'useCallState' });
 
@@ -407,6 +408,11 @@ const useCallState = ({ huntId, puzzleId, tabId }: {
   tabId: string,
 }): [CallState, React.Dispatch<Action>] => {
   const [state, dispatch] = useReducer(reducer, INITIAL_STATE);
+
+  // If we're currently in a call, block code pushes
+  useBlockUpdate(state.callState !== CallJoinState.CHAT_ONLY ?
+    "You're currently in an audio call" :
+    undefined);
 
   useEffect(() => {
     // If huntId, puzzleId, or tabId change (but mostly puzzleId), reset

--- a/types/meteor/reload.d.ts
+++ b/types/meteor/reload.d.ts
@@ -1,0 +1,13 @@
+declare module 'meteor/reload' {
+  namespace Reload {
+    function _onMigrate(
+      cb: (retry: () => void, options: { immediateMigration?: boolean }) =>
+        readonly [false] | readonly [ready: true, data?: any]
+    ): void;
+    function _onMigrate(
+      name: string,
+      cb: (retry: () => void, options: { immediateMigration?: boolean }) =>
+        readonly [false] | readonly [ready: true, data?: any]
+    ): void;
+  }
+}


### PR DESCRIPTION
When a user is in a call or in the middle of composing a chat message, that's a particularly unfortunate time to reload the page due to a new code push.

So, introduce a new hook that can hold code updates. So long as a non-undefined string is passed to `useBlockUpdate`, any new code push will cause a notification to pop up, but the page won't refresh.

Fixes #1314.