### PR TITLE
Fix assorted subtle chat message renderer bugs

### DIFF
--- a/imports/client/components/ChatMessageV2.tsx
+++ b/imports/client/components/ChatMessageV2.tsx
@@ -13,7 +13,7 @@ const PreWrapSpan = styled.span`
 `;
 
 const PreWrapParagraph = styled.p`
-  display: inline-block;
+  display: inline;
   white-space: pre-wrap;
   margin-bottom: 0;
 `;
@@ -80,17 +80,13 @@ const MarkdownToken = ({ token }: { token: marked.Token }) => {
   } else if (token.type === 'code') {
     return <StyledCodeBlock>{token.text}</StyledCodeBlock>;
   } else {
-    // Unhandled token types: just return the raw string
-    return <span>{token.raw}</span>;
+    // Unhandled token types: just return the raw string with pre-wrap.
+    // This covers things like bulleted or numbered lists, which we explicitly
+    // do not want to render semantically because markdown does terribly
+    // surprising things with the numbers in ordered lists and only supporting
+    // unordered lists would be confusing.
+    return <PreWrapSpan>{token.raw}</PreWrapSpan>;
   }
-};
-
-const ReadonlyMarkdownRenderer = ({ text }: { text: string }) => {
-  const tokensList = marked.lexer(text);
-  const children = tokensList.map((token, i) => {
-    return <MarkdownToken key={i} token={token} />;
-  });
-  return <PreWrapSpan>{children}</PreWrapSpan>;
 };
 
 const ChatMessageV2 = ({ message, displayNames, selfUserId }: {
@@ -108,7 +104,10 @@ const ChatMessageV2 = ({ message, displayNames, selfUserId }: {
         </MentionSpan>
       );
     } else {
-      return <ReadonlyMarkdownRenderer key={i} text={child.text} />;
+      const tokensList = marked.lexer(child.text);
+      return tokensList.map((token, j) => {
+        return <MarkdownToken key={j} token={token} />;
+      });
     }
   });
 


### PR DESCRIPTION
* Paragraphs are not allowed to be children of spans.  We had some unnecessary component nesting that caused all markdown ranges to be rendered beneath a span.  Reducing indirection here simplifies the component tree and as a bonus avoids invalid nestings.
* Paragraphs need to render as inline with pre-wrap, not inline-block. If they are inline blocks, then they will tend to refuse to share a line with a mention (which must also be an inline block) which is worse layout.  The initial version of this code rendered paragraphs as a span, which used inline layout, so this fixes a regression I introduced in cea778556903b8480edced0886a13d2e330323d0.
* Ensure that unsupported tag types are rendered as pre-wrap raw text. This helps us do a better job of not letting marked's list-handling cause us to surprise users with the rendered result -- without the pre-wrap treatment, a multi-line bulleted list (which we intentionally, explicitly do not turn into a `<ul>` and `<li>`s) would render on a single line.