### PR TITLE
Prevent rerendering entire chat history

### DIFF
--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
-import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
+import { useFind, useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons/faArrowLeft';
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons/faArrowRight';
 import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
@@ -342,11 +342,11 @@ const ChatHistory = React.forwardRef(({
   displayNames: Map<string, string>;
   selfUserId: string;
 }, forwardedRef: React.Ref<ChatHistoryHandle>) => {
-  const chatMessages: FilteredChatMessageType[] = useTracker(
+  const chatMessages: FilteredChatMessageType[] = useFind(
     () => ChatMessages.find(
       { puzzle: puzzleId },
       { sort: { timestamp: 1 } },
-    ).fetch(),
+    ),
     [puzzleId]
   );
 


### PR DESCRIPTION
Whenever the data returned by a useTracker changes, the entire data set is replaced. This means that even if (e.g.) the only change was adding a new element to an array, all other elements of that array will return new objects, which won't compare as equal to the old objects (even if they have the same contents).

This means in practice that any time (e.g.) a new chat message is created, the entire chat history has to be re-rendered.

By using the useFind hook instead, we can significantly decrease the amount of work required. In my testing, this reduced render time by factor of roughly 10.