### PR TITLE
Improve button flow on guess notifications

### DIFF
--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -59,38 +59,28 @@ const StyledNotificationActionBar = styled.ul`
   display: flex;
   list-style-type: none;
   margin: 0;
+  padding: 0;
+  flex-flow: wrap row;
+  gap: 0.5rem;
 
   &:not(:last-child) {
     margin-bottom: 0.5rem;
   }
-
-  padding: 0;
-  flex-flow: wrap row;
 `;
 
-const StyledNotificationActionItem = styled.li`
-  margin-right: 0.5rem;
-  display: inline-block;
+const StyledNotificationActionItem = styled.li<{grow?: boolean}>`
+  display: flex;
+  flex-grow: ${(props) => (props.grow ? 1 : 0)};
 `;
 
 const StyledNotificationRow = styled.div`
-  margin: 0;
-
   &:not(:last-child) {
     margin-bottom: 0.5rem;
   }
-
-  padding: 0;
 `;
 
-const StyledGuessDetails = styled.div`
-  display: flex;
-  flex-grow: 1;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-end;
-  text-align: end;
-  gap: 8px;
+const StyledGuessDetails = styled.li`
+  display: contents;
 `;
 
 const StyledGuessHeader = styled.strong`
@@ -275,17 +265,17 @@ const GuessMessage = React.memo(({
           </StyledGuessDetails>
         </StyledNotificationActionBar>
         <StyledNotificationActionBar>
-          <StyledNotificationActionItem>
-            <Button variant={correctButtonVariant} size="sm" disabled={disableForms} onClick={markCorrect}>Correct</Button>
+          <StyledNotificationActionItem grow>
+            <Button variant={correctButtonVariant} size="sm" className="flex-grow-1" disabled={disableForms} onClick={markCorrect}>Correct</Button>
           </StyledNotificationActionItem>
-          <StyledNotificationActionItem>
-            <Button variant={intermediateButtonVariant} size="sm" disabled={disableForms} active={nextState === 'intermediate'} onClick={toggleStateIntermediate}>Intermediate…</Button>
+          <StyledNotificationActionItem grow>
+            <Button variant={intermediateButtonVariant} size="sm" className="flex-grow-1" disabled={disableForms} active={nextState === 'intermediate'} onClick={toggleStateIntermediate}>Intermediate…</Button>
           </StyledNotificationActionItem>
-          <StyledNotificationActionItem>
-            <Button variant={incorrectButtonVariant} size="sm" disabled={disableForms} onClick={markIncorrect}>Incorrect</Button>
+          <StyledNotificationActionItem grow>
+            <Button variant={incorrectButtonVariant} size="sm" className="flex-grow-1" disabled={disableForms} onClick={markIncorrect}>Incorrect</Button>
           </StyledNotificationActionItem>
-          <StyledNotificationActionItem>
-            <Button variant={rejectButtonVariant} size="sm" disabled={disableForms} active={nextState === 'rejected'} onClick={toggleStateRejected}>Reject…</Button>
+          <StyledNotificationActionItem grow>
+            <Button variant={rejectButtonVariant} size="sm" className="flex-grow-1" disabled={disableForms} active={nextState === 'rejected'} onClick={toggleStateRejected}>Reject…</Button>
           </StyledNotificationActionItem>
         </StyledNotificationActionBar>
         {guess.state !== 'pending' && guess.additionalNotes && (


### PR DESCRIPTION
Let guess response buttons expand to fill the row, with consistent gaps across the notification. Also fix a div that was a child of a ul.

Does not conflict with #1302, which mostly deals with the header, except that I believe this eliminates the need for the guess detail wrappers proposed there.

Old:
<img src="https://user-images.githubusercontent.com/2136874/211874572-8f33530a-00f9-4a0e-98f7-965d8120baa1.png" alt="old" width="412px"/>
New:
<img src="https://user-images.githubusercontent.com/2136874/211874576-988bd4f0-1717-403f-b3af-f1c9d67138b5.png" alt="new" width="412px"/>
Old (Mobile):
<img src="https://user-images.githubusercontent.com/2136874/211874594-5cbfa65b-de43-4ac9-893b-f90434b65360.png" alt="old (narrow)" width="320px"/>
New (Mobile):
<img src="https://user-images.githubusercontent.com/2136874/211874604-ec4c51b5-aaf9-431a-8fcd-d7282c62f516.png" alt="new (narrow)" width="320px"/>
