### PR TITLE
Use `computeSolvedness()` when relying on solve state

### DIFF
--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 import { faEdit } from '@fortawesome/free-solid-svg-icons/faEdit';
 import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
@@ -209,7 +208,7 @@ const Puzzle = React.memo(({
         <Link to={linkTarget}>{puzzle.title}</Link>
       </PuzzleTitleColumn>
       <PuzzleActivityColumn>
-        {!(puzzle.answers.length >= puzzle.expectedAnswerCount) && <PuzzleActivity huntId={puzzle.hunt} puzzleId={puzzle._id} unlockTime={puzzle.createdAt} />}
+        {(solvedness === 'unsolved') && <PuzzleActivity huntId={puzzle.hunt} puzzleId={puzzle._id} unlockTime={puzzle.createdAt} />}
       </PuzzleActivityColumn>
       <PuzzleLinkColumn>
         {puzzle.url ? (

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -32,6 +32,7 @@ import Tags from '../../lib/models/Tags';
 import { userMayWritePuzzlesForHunt } from '../../lib/permission_stubs';
 import { filteredPuzzleGroups, puzzleGroupsByRelevance } from '../../lib/puzzle-sort-and-group';
 import { PuzzleType } from '../../lib/schemas/Puzzle';
+import { computeSolvedness } from '../../lib/solvedness';
 import createPuzzle from '../../methods/createPuzzle';
 import {
   useHuntPuzzleListCollapseGroups,
@@ -226,8 +227,8 @@ const PuzzleListView = ({
       return puzzles.filter((puzzle) => {
         // Items with no expected answer are always shown, since they're
         // generally pinned administrivia.
-        return puzzle.expectedAnswerCount === 0 ||
-          puzzle.answers.length < puzzle.expectedAnswerCount;
+        const solvedness = computeSolvedness(puzzle);
+        return solvedness !== 'solved';
       });
     }
   }, [showSolved]);

--- a/imports/lib/puzzle-sort-and-group.ts
+++ b/imports/lib/puzzle-sort-and-group.ts
@@ -1,6 +1,7 @@
 import { indexedById } from './listUtils';
 import { PuzzleType } from './schemas/Puzzle';
 import { TagType } from './schemas/Tag';
+import { computeSolvedness } from './solvedness';
 
 interface PuzzleGroup {
   sharedTag?: TagType;
@@ -104,8 +105,8 @@ function interestingnessOfGroup(
   let hasUnsolvedOtherMeta = false;
   let hasUnsolvedPuzzles = false;
   puzzles.forEach((puzzle) => {
-    const isSolved = puzzle.answers.length >= puzzle.expectedAnswerCount;
-    if (!isSolved) {
+    const solvedness = computeSolvedness(puzzle);
+    if (solvedness === 'unsolved') {
       hasUnsolvedPuzzles = true;
     }
     puzzle.tags.forEach((tagId) => {
@@ -117,12 +118,12 @@ function interestingnessOfGroup(
 
         if (metaForTag && tag.name === metaForTag) {
           // This puzzle is meta-for: the group.
-          if (isSolved) {
+          if (solvedness === 'solved') {
             hasSolvedMetaForSharedGroup = true;
           } else {
             hasUnsolvedMetaForSharedGroup = true;
           }
-        } else if ((tag.name === 'is:meta' || tag.name.lastIndexOf('meta-for:', 0) === 0) && !isSolved) {
+        } else if ((tag.name === 'is:meta' || tag.name.lastIndexOf('meta-for:', 0) === 0) && solvedness === 'unsolved') {
           hasUnsolvedOtherMeta = true;
         }
       }

--- a/imports/server/hooks/DiscordHooks.ts
+++ b/imports/server/hooks/DiscordHooks.ts
@@ -7,6 +7,7 @@ import Puzzles from '../../lib/models/Puzzles';
 import Settings from '../../lib/models/Settings';
 import Tags from '../../lib/models/Tags';
 import { ChatMessageContentType, nodeIsText } from '../../lib/schemas/ChatMessage';
+import { computeSolvedness } from '../../lib/solvedness';
 import { DiscordBot } from '../discord';
 import Hookset from './Hookset';
 
@@ -79,9 +80,18 @@ const DiscordHooks: Hookset = {
       const url = Meteor.absoluteUrl(`hunts/${puzzle.hunt}/puzzles/${puzzle._id}`);
       const answers = puzzle.answers.map((answer) => `\`${answer}\``).join(', ');
       const answerLabel = `Answer${puzzle.expectedAnswerCount > 1 ? 's' : ''}`;
-      const completed = puzzle.answers.length === puzzle.expectedAnswerCount;
-      const color = completed ? 0x00ff00 : 0xffff00;
-      const title = `${puzzle.title} ${completed ? '' : 'partially'} solved`;
+      const solvedness = computeSolvedness(puzzle);
+      const color = {
+        solved: 0x00ff00,
+        unsolved: 0xffff00,
+        noAnswers: 0,
+      }[solvedness];
+      const solvedStr = {
+        solved: 'solved',
+        unsolved: 'partially solved',
+        noAnswers: '',
+      }[solvedness];
+      const title = `${puzzle.title} ${solvedStr}`;
       const messageObj = {
         embed: {
           color,

--- a/imports/server/hooks/TagCleanupHooks.ts
+++ b/imports/server/hooks/TagCleanupHooks.ts
@@ -1,5 +1,6 @@
 import Puzzles from '../../lib/models/Puzzles';
 import Tags from '../../lib/models/Tags';
+import { computeSolvedness } from '../../lib/solvedness';
 import Hookset from './Hookset';
 
 const TagCleanupHooks: Hookset = {
@@ -8,7 +9,8 @@ const TagCleanupHooks: Hookset = {
     if (!puzzle) return;
 
     // If a puzzle is now fully solved, remove any `needs:*` tags from it.
-    if (puzzle.answers.length >= puzzle.expectedAnswerCount) {
+    const solvedness = computeSolvedness(puzzle);
+    if (solvedness === 'solved') {
       const tags = await Tags.find({ _id: { $in: puzzle.tags } }).fetchAsync();
 
       const needsTags = tags.filter((tag) => tag.name.startsWith('needs:'));


### PR DESCRIPTION
Helps keep the logic about "is this puzzle solved or not?" in one place rather than scattering it across a bunch of
`answers.length > expectedAnswerCount` invocations across the codebase.