### PR TITLE
Use Mediasoup to heartbeat between servers

### DIFF
--- a/imports/lib/models/mediasoup/MonitorConnectAcks.ts
+++ b/imports/lib/models/mediasoup/MonitorConnectAcks.ts
@@ -1,0 +1,7 @@
+import { Mongo } from 'meteor/mongo';
+import type { MonitorConnectAckType } from '../../schemas/mediasoup/MonitorConnectAck';
+import MonitorConnectAckSchema from '../../schemas/mediasoup/MonitorConnectAck';
+
+const MonitorConnectAcks = new Mongo.Collection<MonitorConnectAckType>('jr_mediasoup_monitor_connect_acks');
+MonitorConnectAcks.attachSchema(MonitorConnectAckSchema);
+export default MonitorConnectAcks;

--- a/imports/lib/models/mediasoup/MonitorConnectRequests.ts
+++ b/imports/lib/models/mediasoup/MonitorConnectRequests.ts
@@ -1,0 +1,7 @@
+import { Mongo } from 'meteor/mongo';
+import type { MonitorConnectRequestType } from '../../schemas/mediasoup/MonitorConnectRequest';
+import MonitorConnectRequestSchema from '../../schemas/mediasoup/MonitorConnectRequest';
+
+const MonitorConnectRequests = new Mongo.Collection<MonitorConnectRequestType>('jr_mediasoup_monitor_connect_requests');
+MonitorConnectRequests.attachSchema(MonitorConnectRequestSchema);
+export default MonitorConnectRequests;

--- a/imports/lib/schemas/mediasoup/MonitorConnectAck.ts
+++ b/imports/lib/schemas/mediasoup/MonitorConnectAck.ts
@@ -1,0 +1,46 @@
+import * as t from 'io-ts';
+import { Id } from '../regexes';
+import type { Overrides } from '../typedSchemas';
+import { buildSchema } from '../typedSchemas';
+
+const MonitorConnectAckCodec = t.type({
+  _id: t.string,
+  initiatingServer: t.string,
+  receivingServer: t.string,
+  transportId: t.string,
+  ip: t.string,
+  port: t.number,
+  srtpParameters: t.union([t.undefined, t.string]), /* JSON-serialized if present */
+});
+
+export type MonitorConnectAckType = t.TypeOf<typeof MonitorConnectAckCodec>;
+
+const MonitorConnectAckOverrides: Overrides<MonitorConnectAckType> = {
+  _id: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  initiatingServer: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  receivingServer: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  transportId: {
+    regEx: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i,
+    denyUpdate: true,
+  },
+  ip: {
+    denyUpdate: true,
+  },
+  port: {
+    denyUpdate: true,
+  },
+  srtpParameters: {
+    denyUpdate: true,
+  },
+};
+
+export default buildSchema(MonitorConnectAckCodec, MonitorConnectAckOverrides);

--- a/imports/lib/schemas/mediasoup/MonitorConnectRequest.ts
+++ b/imports/lib/schemas/mediasoup/MonitorConnectRequest.ts
@@ -1,0 +1,50 @@
+import * as t from 'io-ts';
+import { Id } from '../regexes';
+import type { Overrides } from '../typedSchemas';
+import { buildSchema } from '../typedSchemas';
+
+const MonitorConnectRequestCodec = t.type({
+  _id: t.string,
+  initiatingServer: t.string,
+  receivingServer: t.string,
+  transportId: t.string,
+  ip: t.string,
+  port: t.number,
+  srtpParameters: t.union([t.undefined, t.string]), /* JSON-serialized if present */
+  producerId: t.string,
+  producerSctpStreamParameters: t.union([t.undefined, t.string]), /* JSON-serialized if present */
+  producerLabel: t.union([t.undefined, t.string]),
+  producerProtocol: t.union([t.undefined, t.string]),
+});
+
+export type MonitorConnectRequestType = t.TypeOf<typeof MonitorConnectRequestCodec>;
+
+const MonitorConnectRequestOverrides: Overrides<MonitorConnectRequestType> = {
+  _id: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  initiatingServer: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  receivingServer: {
+    regEx: Id,
+    denyUpdate: true,
+  },
+  transportId: {
+    regEx: /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i,
+    denyUpdate: true,
+  },
+  ip: {
+    denyUpdate: true,
+  },
+  port: {
+    denyUpdate: true,
+  },
+  srtpParameters: {
+    denyUpdate: true,
+  },
+};
+
+export default buildSchema(MonitorConnectRequestCodec, MonitorConnectRequestOverrides);


### PR DESCRIPTION
I don't plan to merge this until after this weekend, but I'll open this as a draft for feedback in case you have time to read through it.

Instead of heartbeating through MongoDB writes, we can use Mediasoup data producers and consumers to heartbeat between servers directly.

Each server creates a dedicated router for handling heartbeats; a DirectTransport, which allows the Meteor process to send data packets back and forth to the Mediasoup worker without a full WebRTC negotiation; and a DataProducer over that DirectTransport, which emits a heartbeat packet every 100ms (+/- jitter).

Then, whenever a server notices another server in the list of servers, it establishes a PipeTransport connection to that other server and pipes the heartbeat producer over that transport. It creates a MonitorConnectRequest record with the details of its half of the transport. Finally, it sets a watchdog - if it does not receive a heartbeat from the other server, it will mark that server as dead (and trigger the garbage collection cleanup hooks). The watchdog has an extra grace period before receiving the first heartbeat to allow for any potential delays in setting up the connection.

When a server observes a new MonitorConnectRequest record, it creates and connects its half of the PipeTransport and writes out a MonitorConnectAck so that the initiating server can connect, too. Then it resets the watchdog every time it receives a heartbeat packet.

Two notes about how Mediasoup works in this configuration:

First, as a reminder, Mediasoup's use of "producer" and "consumer" is from the perspective of a client, which makes it especially confusing here, because the sender of the heartbeats creates a "consumer" on the pipe transport, and the receiver creates a "producer".

Second, since PipeTransports don't use ICE to negotiation a connection, so you have to provide a single IP address, rather than a list of potential IP addresses, so we just grab the first one. In production, since we only use publicly-routable addresses for ICE, this should be fine.

Since this should allow us to detect dying servers at an acceptable pace for recovering WebRTC calls, we can also significantly relax the MongoDB-based heartbeats back to their previous frequency (heartbeats every 15 seconds with a 120 second expiration window).

Fixes #1205.