### PR TITLE
Improve puzzle list page controls

### DIFF
--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -45,13 +45,13 @@ import PuzzleModalForm, {
 import RelatedPuzzleGroup from './RelatedPuzzleGroup';
 import { mediaBreakpointDown } from './styling/responsive';
 
-const ViewControls = styled.div<{ canAdd?: boolean }>`
+const ViewControls = styled.div<{ $canAdd?: boolean }>`
   display: grid;
   grid-template-columns: auto auto auto 1fr;
   align-items: end;
   gap: 1em;
   margin-bottom: 1em;
-  ${(props) => props.canAdd && mediaBreakpointDown('xs', css`
+  ${(props) => props.$canAdd && mediaBreakpointDown('xs', css`
     grid-template-columns: 1fr 1fr;
   `)}
   @media (max-width: 359px) {
@@ -66,15 +66,15 @@ const ViewControls = styled.div<{ canAdd?: boolean }>`
   }
 `;
 
-const SearchFormGroup = styled(FormGroup)<{ canAdd?: boolean }>`
-  grid-column: ${(props) => (props.canAdd ? 1 : 3)} / -1;
+const SearchFormGroup = styled(FormGroup)<{ $canAdd?: boolean }>`
+  grid-column: ${(props) => (props.$canAdd ? 1 : 3)} / -1;
   ${mediaBreakpointDown('sm', css`
     grid-column: 1 / -1;
   `)}
 `;
 
-const SearchFormLabel = styled(FormLabel)<{ canAdd?: boolean }>`
-  display: ${(props) => (props.canAdd ? 'none' : 'inline-block')};
+const SearchFormLabel = styled(FormLabel)<{ $canAdd?: boolean }>`
+  display: ${(props) => (props.$canAdd ? 'none' : 'inline-block')};
   ${mediaBreakpointDown('sm', css`
     display: none;
   `)}
@@ -417,7 +417,7 @@ const PuzzleListView = ({
 
   return (
     <div>
-      <ViewControls canAdd={canAdd}>
+      <ViewControls $canAdd={canAdd}>
         <FormGroup>
           <FormLabel>Organize by</FormLabel>
           <ButtonToolbar>
@@ -437,8 +437,8 @@ const PuzzleListView = ({
           </ButtonToolbar>
         </FormGroup>
         {addPuzzleContent}
-        <SearchFormGroup canAdd={canAdd}>
-          <SearchFormLabel canAdd={canAdd}>Search</SearchFormLabel>
+        <SearchFormGroup $canAdd={canAdd}>
+          <SearchFormLabel $canAdd={canAdd}>Search</SearchFormLabel>
           <InputGroup>
             <FormControl
               id="jr-puzzle-search"


### PR DESCRIPTION
- Fix wrapping and spacing
- Replace show solved toggle button with button group choices
- Replace operator interface toggle button (formerly appended to add puzzle) with button group choices
- Move filter results below filters and above results, providing a logical flow
- Improve styling in very narrow viewports (e.g. iPad Split View)

Wrapping and breakpoints:
- For operators, the search bar always gets its own line to make room for extra controls. For other users, this doesn't happen until the sm breakpoint.
- For operators, controls are rearranged into a grid below the xs breakpoint.
- Below 360px, controls are presented one per row.

Tested in Safari, Chrome, Firefox.

**Old Desktop-Operator**
<img src="https://user-images.githubusercontent.com/2136874/212194149-f11da9a9-b021-4133-a091-7823e0a7d998.png" width="768px"/>
**Old Mobile-Operator**
<img src="https://user-images.githubusercontent.com/2136874/212194288-30fd5eac-6de6-4955-979f-8e45e73f2643.png" width="390px"/>

**New Desktop-Operator**
<img src="https://user-images.githubusercontent.com/2136874/212194363-e44aec81-69bb-430c-a3c5-03d27eb44f8f.png" width="768px"/>
**New Mobile-Operator**
<img src="https://user-images.githubusercontent.com/2136874/212194418-d79fb1ac-56da-4535-9a60-1785704f50f3.png" width="390px"/>
**New Narrow-Operator**
<img src="https://user-images.githubusercontent.com/2136874/212194469-832775cd-0ff0-415f-86d7-050a996621e9.png" width="320px"/>

**New Desktop-User**
<img src="https://user-images.githubusercontent.com/2136874/212194541-3910b68d-d888-4765-8ed0-e59f5daec0a0.png" width="768px"/>
**New Mobile-User**
<img src="https://user-images.githubusercontent.com/2136874/212194588-1dcea27d-ed08-49dc-9720-65b91b1cf963.png" width="390px"/>
**New Narrow-User**
<img src="https://user-images.githubusercontent.com/2136874/212194639-073dd150-eb97-44cf-b00d-9cf91f58c822.png" width="320px"/>


