### PR TITLE
Cache Discord permission grants to limit rate limiting

### DIFF
--- a/imports/lib/models/DiscordRoleGrants.ts
+++ b/imports/lib/models/DiscordRoleGrants.ts
@@ -1,0 +1,10 @@
+import DiscordRoleGrantSchema, { DiscordRoleGrantType } from '../schemas/DiscordRoleGrant';
+import Base from './Base';
+
+const DiscordRoleGrants = new Base<DiscordRoleGrantType>('discord_role_grants');
+DiscordRoleGrants.attachSchema(DiscordRoleGrantSchema);
+DiscordRoleGrants.publish((userId) => {
+  return { user: userId };
+});
+
+export default DiscordRoleGrants;

--- a/imports/lib/models/facade.ts
+++ b/imports/lib/models/facade.ts
@@ -4,6 +4,7 @@ import BlobMappings from './BlobMappings';
 import ChatMessages from './ChatMessages';
 import ChatNotifications from './ChatNotifications';
 import DiscordCache from './DiscordCache';
+import DiscordRoleGrants from './DiscordRoleGrants';
 import DocumentActivities from './DocumentActivities';
 import Documents from './Documents';
 import FeatureFlags from './FeatureFlags';
@@ -36,6 +37,7 @@ const Models = {
   ChatMessages,
   ChatNotifications,
   DiscordCache,
+  DiscordRoleGrants,
   DocumentActivities,
   Documents,
   FeatureFlags,

--- a/imports/lib/schemas/DiscordRoleGrant.ts
+++ b/imports/lib/schemas/DiscordRoleGrant.ts
@@ -1,0 +1,40 @@
+import * as t from 'io-ts';
+import { BaseCodec, BaseOverrides } from './Base';
+import { Id } from './regexes';
+import { buildSchema, inheritSchema, Overrides } from './typedSchemas';
+
+const DiscordRoleGrantFields = t.type({
+  guild: t.string,
+  role: t.string,
+  user: t.string,
+  discordAccountId: t.string,
+});
+
+const DiscordRoleGrantFieldsOverrides: Overrides<t.TypeOf<typeof DiscordRoleGrantFields>> = {
+  guild: {
+    regEx: /[0-9]+/,
+  },
+  role: {
+    regEx: /[0-9]+/,
+  },
+  user: {
+    regEx: Id,
+  },
+  discordAccountId: {
+    regEx: /[0-9]+/,
+  },
+};
+
+const [DiscordRoleGrantCodec, DiscordRoleGrantOverrides] = inheritSchema(
+  BaseCodec,
+  DiscordRoleGrantFields,
+  BaseOverrides,
+  DiscordRoleGrantFieldsOverrides,
+);
+
+export { DiscordRoleGrantCodec };
+export type DiscordRoleGrantType = t.TypeOf<typeof DiscordRoleGrantCodec>;
+
+const DiscordRoleGrant = buildSchema(DiscordRoleGrantCodec, DiscordRoleGrantOverrides);
+
+export default DiscordRoleGrant;

--- a/imports/lib/schemas/facade.ts
+++ b/imports/lib/schemas/facade.ts
@@ -4,6 +4,7 @@ import BlobMapping from './BlobMapping';
 import ChatMessage from './ChatMessage';
 import ChatNotification from './ChatNotification';
 import DiscordCache from './DiscordCache';
+import DiscordRoleGrant from './DiscordRoleGrant';
 import DocumentSchema from './Document';
 import DocumentActivity from './DocumentActivity';
 import FeatureFlag from './FeatureFlag';
@@ -37,6 +38,7 @@ const Schemas = {
   ChatMessage,
   ChatNotification,
   DiscordCache,
+  DiscordRoleGrant,
   FolderPermission,
   Document: DocumentSchema,
   DocumentActivity,

--- a/imports/server/addUsersToDiscordRole.ts
+++ b/imports/server/addUsersToDiscordRole.ts
@@ -1,11 +1,16 @@
 import Flags from '../Flags';
 import Logger from '../Logger';
+import DiscordRoleGrants from '../lib/models/DiscordRoleGrants';
 import Hunts from '../lib/models/Hunts';
 import MeteorUsers from '../lib/models/MeteorUsers';
 import Settings from '../lib/models/Settings';
 import { DiscordBot } from './discord';
 
-export default async (userIds: string[], huntId: string) => {
+export default async (
+  userIds: string[],
+  huntId: string,
+  { force = true }: { force?: boolean } = {}
+) => {
   if (Flags.active('disable.discord')) {
     Logger.info('Can not add users to Discord role because Discord is disabled by feature flag', { userIds, huntId });
     return;
@@ -39,12 +44,34 @@ export default async (userIds: string[], huntId: string) => {
   for (const userId of userIds) {
     const user = await MeteorUsers.findOneAsync(userId);
     if (!user?.discordAccount) {
-      Logger.info('Can not add users to Discord role because user has not linked their Discord account', { userIds, huntId });
+      Logger.info('Can not add users to Discord role because user has not linked their Discord account', { userId, huntId });
       continue;
     }
+
+    if (!force && await DiscordRoleGrants.findOneAsync({
+      guild: guild.id,
+      role: roleId,
+      user: userId,
+      discordAccountId: user.discordAccount.id,
+    })) {
+      Logger.info('User already has Discord role', { userId, huntId, roleId });
+      continue;
+    }
+
     try {
       await discord.addUserToRole(user.discordAccount.id, guild.id, roleId);
       Logger.info('Successfully added user to Discord role', { userId, huntId, roleId });
+      // Upsert so that if the record already exists we'll touch updatedAt
+      await DiscordRoleGrants.upsertAsync({
+        guild: guild.id,
+        role: roleId,
+        user: userId,
+        discordAccountId: user.discordAccount.id,
+      }, {});
+
+      // Discord has a rate limit of 50 requests per second; we'll consume at
+      // most half of that
+      await new Promise((r) => { setTimeout(r, 1000 / 25); });
     } catch (error) {
       Logger.warn('Error while adding user to Discord role', {
         error, userId, huntId, roleId,

--- a/imports/server/configureLogger.ts
+++ b/imports/server/configureLogger.ts
@@ -4,18 +4,26 @@ import logfmt from 'logfmt';
 import { format, transports } from 'winston';
 import { logger } from '../Logger';
 
+const userIdSymbol = Symbol('userId');
+
+declare module 'logform' {
+  interface TransformableInfo {
+    [userIdSymbol]?: string | null;
+  }
+}
+
 logger.format = format.combine(
   format.colorize({ level: true }),
   format((info) => {
     try {
       const userId = Meteor.userId();
-      return { ...info, userId };
+      return { ...info, [userIdSymbol]: userId };
     } catch {
       return info;
     }
   })(),
   format.printf(({
-    level, label, message, userId, error,
+    level, label, message, [userIdSymbol]: userId, error,
     ...rest
   }) => {
     return `${level}: ${

--- a/imports/server/methods/syncHuntDiscordRole.ts
+++ b/imports/server/methods/syncHuntDiscordRole.ts
@@ -19,6 +19,6 @@ syncHuntDiscordRole.define({
     }
 
     const userIds = (await MeteorUsers.find({ hunts: huntId }).fetchAsync()).map((u) => u._id);
-    await addUsersToDiscordRole(userIds, huntId);
+    await addUsersToDiscordRole(userIds, huntId, { force: false });
   },
 });

--- a/imports/server/methods/updateHunt.ts
+++ b/imports/server/methods/updateHunt.ts
@@ -51,7 +51,7 @@ updateHunt.define({
     Meteor.defer(async () => {
       // Sync discord roles
       const userIds = (await MeteorUsers.find({ hunts: huntId }).fetchAsync()).map((u) => u._id);
-      await addUsersToDiscordRole(userIds, huntId);
+      await addUsersToDiscordRole(userIds, huntId, { force: false });
 
       if (oldHunt?.name !== value.name) {
         const folderId = await ensureHuntFolder({ _id: huntId, name: value.name });

--- a/imports/server/migrations/47-discord-role-grant-indexes.ts
+++ b/imports/server/migrations/47-discord-role-grant-indexes.ts
@@ -1,0 +1,15 @@
+import DiscordRoleGrants from '../../lib/models/DiscordRoleGrants';
+import Migrations from './Migrations';
+
+Migrations.add({
+  version: 47,
+  name: 'Add unique indexes to DiscordRoleGrants',
+  async up() {
+    await DiscordRoleGrants.createIndexAsync({
+      guild: 1,
+      role: 1,
+      user: 1,
+      discordAccountId: 1,
+    }, { unique: true });
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -45,3 +45,4 @@ import './43-puzzle-activity';
 import './44-better-puzzle-activity';
 import './45-folder-permission-level';
 import './46-per-user-document-activity';
+import './47-discord-role-grant-indexes';


### PR DESCRIPTION
Discord has a fairly low rate limit, so blindly attempting to add anyone
in the hunt to a role is a quick road to aggressive rate limiting.
Instead, keep track of who we've previously granted a role to (similar
to what we do for Google Drive permissions) and avoid trying to re-grant
them their role.

However, while we populate the cache any time we add a user to a role,
we only check the cache for the syncHuntDiscordRole method (and for the
updateHunt method). In any other case, we're acting on behalf of a
specific user, and we should take action for them even if we might have
done it already (to ensure they don't get stuck in a bad state
accidentally).

And while it's not my preferred solution, arguably this does fix #1296.

(There's also a fix for the logger configuration on the server-side that was inadvertently causing us to drop any `userId` field that was provided at the logging callsite)