### PR TITLE
Add rule lines between guesses in grids

### DIFF
--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -51,6 +51,7 @@ const StyledTable = styled.div`
     [confidence] minmax(6em, auto)
     [status] auto
     [actions] auto;
+  border-bottom: 1px solid #ddd;
   ${mediaBreakpointDown(compactViewBreakpoint, css`
     grid-template-columns: 100%;
   `)}
@@ -74,6 +75,12 @@ const StyledRow = styled.div<{ $state: GuessType['state'] }>`
   display: contents;
   margin-bottom: 8px;
   background-color: ${(props) => guessColorLookupTable[props.$state].background};
+
+  &::before {
+    content: " ";
+    border-top: 1px solid #ddd;
+    grid-column: 1 / -1;
+  }
 
   :hover {
     background-color: ${(props) => guessColorLookupTable[props.$state].hoverBackground};
@@ -181,6 +188,10 @@ const StyledGuessDetailLabel = styled.span`
 const StyledAdditionalNotes = styled(StyledCell)`
   grid-column: 1 / -1;
   overflow: hidden;
+
+  p {
+    margin-bottom: 0;
+  }
 `;
 
 const GuessBlock = React.memo(({

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -1279,6 +1279,7 @@ const GuessTable = styled.div`
     [submitter] auto
     [direction] 4em
     [confidence] 4em;
+  border-bottom: 1px solid #ddd;
   ${mediaBreakpointDown('sm', css`
     grid-template-columns: minmax(0, auto) minmax(0, auto);
   `)}
@@ -1296,6 +1297,12 @@ const GuessTableSmallRow = styled.div`
 const GuessRow = styled.div<{ $state: GuessType['state'] }>`
   display: contents;
   background-color: ${(props) => guessColorLookupTable[props.$state].background};
+
+  &::before {
+    content: " ";
+    border-top: 1px solid #ddd;
+    grid-column: 1 / -1;
+  }
 
   :hover {
     background-color: ${(props) => guessColorLookupTable[props.$state].hoverBackground};
@@ -1326,7 +1333,6 @@ const GuessCell = styled.div`
   background-color: inherit;
   align-items: center;
   padding: 0.25rem;
-  outline: 1px solid #ddd;
   ${mediaBreakpointDown('sm', css`
     outline: 0;
   `)}


### PR DESCRIPTION
Per discussion with @ebroder add rules between guesses in grid presentations (and remove existing outline around every cell in the guess submission modal).