### PR TITLE
Only ding on matches at start-of-word

### DIFF
--- a/imports/lib/dingwordLogic.ts
+++ b/imports/lib/dingwordLogic.ts
@@ -20,8 +20,10 @@ export function normalizedMessageDingsUserByDingword(
   normalizedMessage: string,
   user: Meteor.User
 ): boolean {
+  const words = normalizedMessage.split(/\s+/);
   return (user.dingwords ?? []).some((dingword) => {
-    return normalizedMessage.includes(dingword);
+    const dingwordLower = dingword.toLowerCase();
+    return words.some((word) => word.startsWith(dingwordLower));
   });
 }
 


### PR DESCRIPTION
Hopefully this reduces spurious dinging for things like "description" triggering on "script", as described in #597.

Also ensure that the dingwords themselves are lowercase before attempting to match.  We do this client-side on OwnProfilePage when setting dingwords, but it's probably good to ensure serverside too.