### PR TITLE
Open puzzle links from FirehosePage in new tab

### DIFF
--- a/imports/client/components/FirehosePage.tsx
+++ b/imports/client/components/FirehosePage.tsx
@@ -8,7 +8,7 @@ import Button from 'react-bootstrap/Button';
 import FormControl, { FormControlProps } from 'react-bootstrap/FormControl';
 import FormGroup from 'react-bootstrap/FormGroup';
 import InputGroup from 'react-bootstrap/InputGroup';
-import { Link, useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { shortCalendarTimeFormat } from '../../lib/calendarTimeFormat';
 import { indexedById } from '../../lib/listUtils';
@@ -77,7 +77,13 @@ const Message = React.memo(({ msg, displayNames, puzzle }: MessageProps) => {
         {puzzle !== undefined ? (
           <>
             <span>{`${puzzle.deleted ? 'deleted: ' : ''}`}</span>
-            <Link to={`/hunts/${msg.hunt}/puzzles/${msg.puzzle}`}>{puzzle.title}</Link>
+            <a
+              href={`/hunts/${msg.hunt}/puzzles/${msg.puzzle}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {puzzle.title}
+            </a>
           </>
         ) : (
           <span>deleted: no data</span>


### PR DESCRIPTION
FirehosePage is particularly expensive to reload, so if you're following the links on it, you probably don't actually want to navigate away. Open them in separate tabs instead.

Fixes #1357.