### PR TITLE
Fix findOne{,Allowing}DeletedAsync methods

### DIFF
--- a/imports/lib/models/Base.ts
+++ b/imports/lib/models/Base.ts
@@ -186,10 +186,7 @@ class Base<T extends BaseType> extends Mongo.Collection<T> {
     selector?: Selector,
     options: FindOneOptions = {},
   ) {
-    return super.findOneAsync(
-      { ...this[formatQuery](selector ?? {}), deleted: true as any },
-      this[formatOptions](options)
-    ) as Promise<SelectorToResultType<T, Selector> | undefined>;
+    return Promise.resolve(this.findOneDeleted(selector, options));
   }
 
   findAllowingDeleted<Selector extends FindSelector<T>>(
@@ -203,14 +200,14 @@ class Base<T extends BaseType> extends Mongo.Collection<T> {
     selector?: Selector,
     options: FindOneOptions = {},
   ) {
-    return super.findOne(selector, options);
+    return super.findOne(selector, options) as SelectorToResultType<T, Selector> | undefined;
   }
 
   findOneAllowingDeletedAsync<Selector extends FindSelector<T>>(
     selector?: Selector,
     options: FindOneOptions = {},
   ) {
-    return super.findOneAsync(selector, options) as
+    return Promise.resolve(this.findOneAllowingDeleted(selector, options)) as
       Promise<SelectorToResultType<T, Selector> | undefined>;
   }
 

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -8,6 +8,7 @@ import './unit/imports/lib/ValidateShape';
 
 if (Meteor.isServer) {
   require('./unit/imports/server/MigrationRegistry');
+  require('./unit/imports/server/Base');
 }
 
 import './acceptance/authentication';

--- a/tests/unit/imports/server/Base.ts
+++ b/tests/unit/imports/server/Base.ts
@@ -1,0 +1,103 @@
+/* eslint-disable jolly-roger/no-sync-mongo-methods */
+import { Random } from 'meteor/random';
+import { assert } from 'chai';
+import Base from '../../../../imports/lib/models/Base';
+import BaseSchema from '../../../../imports/lib/schemas/Base';
+
+interface TestModelType {
+  _id: string;
+  deleted: boolean;
+  createdAt: Date;
+  createdBy: string;
+  updatedAt: Date | undefined;
+  updatedBy: string | undefined;
+}
+
+const TestModel = new Base<TestModelType>('test_model');
+TestModel.attachSchema(BaseSchema);
+
+// Note: these tests seem fairly straightforward, but they mostly exist to
+// detect if internal Meteor implementation changes cause our custom wrapper
+// functions to break, like they did with #1370.
+describe('Base', function () {
+  let deletedModelId: string;
+  let undeletedModelId: string;
+
+  before(async function () {
+    await TestModel.removeAsync({});
+
+    const fakeUserId = Random.id();
+
+    deletedModelId = await TestModel.insertAsync({
+      createdBy: fakeUserId,
+      deleted: true,
+    });
+
+    undeletedModelId = await TestModel.insertAsync({
+      createdBy: fakeUserId,
+    });
+  });
+
+  describe('find', function () {
+    it('finds only undeleted models', async function () {
+      const models = await TestModel.find({}).fetchAsync();
+      assert.sameMembers(models.map((m) => m._id), [undeletedModelId]);
+    });
+  });
+
+  describe('findOne', function () {
+    it('finds only undeleted models', function () {
+      assert.isUndefined(TestModel.findOne(deletedModelId));
+      assert.isObject(TestModel.findOne(undeletedModelId));
+    });
+  });
+
+  describe('findOneAsync', function () {
+    it('finds only undeleted models', async function () {
+      assert.isUndefined(await TestModel.findOneAsync(deletedModelId));
+      assert.isObject(await TestModel.findOneAsync(undeletedModelId));
+    });
+  });
+
+  describe('findDeleted', function () {
+    it('finds only deleted models', async function () {
+      const models = await TestModel.findDeleted({}).fetchAsync();
+      assert.sameMembers(models.map((m) => m._id), [deletedModelId]);
+    });
+  });
+
+  describe('findOneDeleted', function () {
+    it('finds only deleted models', function () {
+      assert.isUndefined(TestModel.findOneDeleted(undeletedModelId));
+      assert.isObject(TestModel.findOneDeleted(deletedModelId));
+    });
+  });
+
+  describe('findOneDeletedAsync', function () {
+    it('finds only deleted models', async function () {
+      assert.isUndefined(await TestModel.findOneDeletedAsync(undeletedModelId));
+      assert.isObject(await TestModel.findOneDeletedAsync(deletedModelId));
+    });
+  });
+
+  describe('findAllowingDeleted', function () {
+    it('finds both deleted and undeleted models', async function () {
+      const models = await TestModel.findAllowingDeleted({}).fetchAsync();
+      assert.sameMembers(models.map((m) => m._id), [deletedModelId, undeletedModelId]);
+    });
+  });
+
+  describe('findOneAllowingDeleted', function () {
+    it('finds both deleted and undeleted models', function () {
+      assert.isObject(TestModel.findOneAllowingDeleted(deletedModelId));
+      assert.isObject(TestModel.findOneAllowingDeleted(undeletedModelId));
+    });
+  });
+
+  describe('findOneAllowingDeletedAsync', function () {
+    it('finds both deleted and undeleted models', async function () {
+      assert.isObject(await TestModel.findOneAllowingDeletedAsync(deletedModelId));
+      assert.isObject(await TestModel.findOneAllowingDeletedAsync(undeletedModelId));
+    });
+  });
+});


### PR DESCRIPTION
Because of how Meteor currently implements their async methods, they call into our implementation of `findOneAsync`, which injects the deleted=false term to all queries, including those where we explicitly want deleted (or both deleted and non-deleted) objects.

The easiest way to work around that right now is to implement our own versions of the async methods in the same style as Meteor's - simply wrapping the synchronous versions.

This will eventually break as Meteor continues to migrate towards async implementations by default, so add a test that will fail if and when that happens.

I did verify in local testing that the tests failed when I didn't apply the patch to `Base.ts`:

```
I20230117-13:11:23.737(-5)?   1) Base
I20230117-13:11:23.737(-5)?        findOneDeletedAsync
I20230117-13:11:23.737(-5)?          finds only deleted models:
I20230117-13:11:23.737(-5)?      AssertionError: expected { _id: 'vKKb3g7GEszpYBy7o', …(3) } to equal undefined
I20230117-13:11:23.737(-5)?       at tests/unit/imports/server/Base.ts:78:14
I20230117-13:11:23.739(-5)?       at /Users/evan/.meteor/packages/promise/.0.12.2.1pk4jae.hyv5j++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40
I20230117-13:11:23.739(-5)?
I20230117-13:11:23.739(-5)?   2) Base
I20230117-13:11:23.740(-5)?        findOneAllowingDeletedAsync
I20230117-13:11:23.740(-5)?          finds both deleted and undeleted models:
I20230117-13:11:23.740(-5)?      AssertionError: expected undefined to be an object
I20230117-13:11:23.740(-5)?       at tests/unit/imports/server/Base.ts:99:14
I20230117-13:11:23.740(-5)?       at /Users/evan/.meteor/packages/promise/.0.12.2.1pk4jae.hyv5j++os+web.browser+web.browser.legacy+web.cordova/npm/node_modules/meteor-promise/fiber_pool.js:43:40
```

Fixes #1370.