### PR TITLE
Add additional client-side Bugsnag reporting

### DIFF
--- a/imports/client/components/HuntListPage.tsx
+++ b/imports/client/components/HuntListPage.tsx
@@ -13,7 +13,6 @@ import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Modal from 'react-bootstrap/Modal';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Link } from 'react-router-dom';
-import Logger from '../../Logger';
 import Hunts from '../../lib/models/Hunts';
 import { userMayCreateHunt, userMayUpdateHunt } from '../../lib/permission_stubs';
 import type { HuntType } from '../../lib/schemas/Hunt';
@@ -38,12 +37,7 @@ const Hunt = React.memo(({ hunt }: { hunt: HuntType }) => {
   const deleteModalRef = useRef<ModalFormHandle>(null);
 
   const onDelete = useCallback((callback: () => void) => {
-    destroyHunt.call({ huntId }, (error) => {
-      if (error) {
-        Logger.error('Failed to destroy hunt', { error, hunt: huntId });
-      }
-      callback();
-    });
+    destroyHunt.call({ huntId }, callback);
   }, [huntId]);
 
   const showDeleteModal = useCallback(() => {

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -51,7 +51,6 @@ import TextareaAutosize from 'react-textarea-autosize';
 import type { Descendant } from 'slate';
 import styled, { css } from 'styled-components';
 import Flags from '../../Flags';
-import Logger from '../../Logger';
 import { calendarTimeFormat, shortCalendarTimeFormat } from '../../lib/calendarTimeFormat';
 import { messageDingsUser } from '../../lib/dingwordLogic';
 import { indexedById, sortedBy } from '../../lib/listUtils';
@@ -1103,30 +1102,15 @@ const PuzzlePageMetadata = ({
   const guessModalRef = useRef<React.ElementRef<typeof PuzzleGuessModal>>(null);
   const answerModalRef = useRef<React.ElementRef<typeof PuzzleAnswerModal>>(null);
   const onCreateTag = useCallback((tagName: string) => {
-    addPuzzleTag.call({ puzzleId, tagName }, (error) => {
-      // Not really much we can do in the case of a failure other than log it
-      if (error) {
-        Logger.error('Failed to create tag', { error, puzzleId, tagName });
-      }
-    });
+    addPuzzleTag.call({ puzzleId, tagName });
   }, [puzzleId]);
 
   const onRemoveTag = useCallback((tagId: string) => {
-    removePuzzleTag.call({ puzzleId, tagId }, (error) => {
-      // Not really much we can do in the case of a failure, other than (again) logging it
-      if (error) {
-        Logger.error('Failed to remove tag', { error, puzzleId, tagId });
-      }
-    });
+    removePuzzleTag.call({ puzzleId, tagId });
   }, [puzzleId]);
 
   const onRemoveAnswer = useCallback((guessId: string) => {
-    removePuzzleAnswer.call({ puzzleId, guessId }, (error) => {
-      // Not really much we can do in the case of a failure, other than (again) logging it
-      if (error) {
-        Logger.error('Failed to remove answer', { error, puzzleId, guessId });
-      }
-    });
+    removePuzzleAnswer.call({ puzzleId, guessId });
   }, [puzzleId]);
 
   const onEdit = useCallback((
@@ -1475,13 +1459,6 @@ const PuzzleGuessModal = React.forwardRef(({
         if (error) {
           setSubmitError(error.message);
           setSubmitState(PuzzleGuessSubmitState.FAILED);
-          Logger.error('Error submitting guess', {
-            error,
-            puzzleId: puzzle._id,
-            guess: guessInput,
-            direction: directionInput,
-            confidence: confidenceInput,
-          });
         } else {
           // Clear the input box.  Don't dismiss the dialog.
           setGuessInput('');

--- a/imports/client/hooks/useCallState.ts
+++ b/imports/client/hooks/useCallState.ts
@@ -334,10 +334,6 @@ const useTransport = (
         mediasoupConnectTransport.call({
           transportId: _id,
           dtlsParameters: JSON.stringify(clientDtlsParameters),
-        }, (error) => {
-          if (error) {
-            logger.error('Failed to connect transport', { direction, error });
-          }
         });
       });
       logger.debug('setting transport', { direction, newTransport });
@@ -793,11 +789,7 @@ const useCallState = ({ huntId, puzzleId, tabId }: {
     // If we've been remote-muted, acknowledge to the server and translate into local mute.
     if (selfPeer?.remoteMutedBy) {
       dispatch({ type: 'set-remote-muted', remoteMutedBy: selfPeer.remoteMutedBy });
-      mediasoupAckPeerRemoteMute.call({ peerId: selfPeer._id }, (error) => {
-        if (error) {
-          logger.error('Error calling mediasoupAckPeerRemoteMute method', { error });
-        }
-      });
+      mediasoupAckPeerRemoteMute.call({ peerId: selfPeer._id });
     }
   }, [selfPeer?._id, selfPeer?.remoteMutedBy]);
   // otherwise we update peer state so that mute/deafen are visible to others.
@@ -810,10 +802,6 @@ const useCallState = ({ huntId, puzzleId, tabId }: {
         mediasoupSetPeerState.call({
           peerId: selfPeer._id,
           state: localEffectiveState,
-        }, (error) => {
-          if (error) {
-            logger.error('Error calling mediasoupSetPeerState method', { error, peerId: selfPeer._id, state: localEffectiveState });
-          }
         });
       }
     }
@@ -895,11 +883,7 @@ const useCallState = ({ huntId, puzzleId, tabId }: {
                   entry.consumer = newConsumer;
                   // Push the track into state.
                   dispatch({ type: 'add-peer-track', peerId: peer._id, track: newConsumer.track });
-                  mediasoupAckConsumer.call({ consumerId: meteorConsumerId }, (error) => {
-                    if (error) {
-                      logger.error('Error calling mediasoupAckConsumer', { error, consumerId: meteorConsumerId });
-                    }
-                  });
+                  mediasoupAckConsumer.call({ consumerId: meteorConsumerId });
                 } else {
                   logger.error('Created Mediasoup consumer for consumer not in consumerMapRef', { consumer: consumer._id });
                 }

--- a/imports/methods/TypedMethod.ts
+++ b/imports/methods/TypedMethod.ts
@@ -1,6 +1,9 @@
 import { check } from 'meteor/check';
 import type { EJSONable, EJSONableProperty } from 'meteor/ejson';
+import { EJSON } from 'meteor/ejson';
 import { Meteor } from 'meteor/meteor';
+import Bugsnag from '@bugsnag/js';
+import Logger from '../Logger';
 import type ValidateShape from '../lib/ValidateShape';
 
 export type TypedMethodParam = EJSONable | EJSONableProperty;
@@ -15,7 +18,7 @@ type TypedMethodCallback<Return extends TypedMethodParam | void> =
 type TypedMethodCallArgs<T, Arg extends TypedMethodArgs, Return extends TypedMethodParam | void> =
   Arg extends void ?
     ([TypedMethodCallback<Return>] | []) :
-    ([ValidateShape<T, Arg>, TypedMethodCallback<Return>] | [Arg]);
+    ([ValidateShape<T, Arg>, TypedMethodCallback<Return>] | [ValidateShape<T, Arg>]);
 type TypedMethodCallPromiseArgs<T, Arg extends TypedMethodArgs> =
   Arg extends void ?
     [] :
@@ -34,10 +37,60 @@ export default class TypedMethod<
   }
 
   call<T>(...args: TypedMethodCallArgs<T, Args, Return>): void {
-    return Meteor.call(this.name, ...args);
+    let callback: TypedMethodCallback<Return> | undefined;
+    if (typeof args[args.length - 1] === 'function') {
+      callback = args.pop() as TypedMethodCallback<Return>;
+    }
+
+    if (Bugsnag.isStarted()) {
+      Bugsnag.leaveBreadcrumb('Meteor method call', {
+        method: this.name,
+        arguments: typeof args[0] === 'object' ? EJSON.stringify(args[0]) : undefined,
+      }, 'request');
+    }
+
+    return Meteor.call(this.name, ...args, (error: Meteor.Error, result: Return) => {
+      if (error) {
+        const severity =
+          error instanceof Meteor.Error &&
+            error.error >= 400 &&
+            error.error < 500 ?
+            'info' :
+            'error';
+        Logger[severity](`Meteor method call failed: ${this.name}`, {
+          error,
+          method: this.name,
+          arguments: typeof args[0] === 'object' ? EJSON.stringify(args[0]) : undefined,
+        });
+      }
+      callback?.(error, result as any);
+    });
   }
 
-  callPromise<T>(...args: TypedMethodCallPromiseArgs<T, Args>): Promise<Return> {
-    return Meteor.callAsync(this.name, ...args);
+  async callPromise<T>(...args: TypedMethodCallPromiseArgs<T, Args>): Promise<Return> {
+    try {
+      if (Bugsnag.isStarted()) {
+        Bugsnag.leaveBreadcrumb('Meteor method call', {
+          method: this.name,
+          arguments: typeof args[0] === 'object' ? EJSON.stringify(args[0]) : undefined,
+        }, 'request');
+      }
+      return await Meteor.callAsync(this.name, ...args);
+    } catch (error) {
+      if (error) {
+        const severity =
+          error instanceof Meteor.Error &&
+            error.error >= 400 &&
+            error.error < 500 ?
+            'info' :
+            'error';
+        Logger[severity](`Meteor method call failed: ${this.name}`, {
+          error,
+          method: this.name,
+          arguments: typeof args[0] === 'object' ? EJSON.stringify(args[0]) : undefined,
+        });
+      }
+      throw error;
+    }
   }
 }


### PR DESCRIPTION
This catches any Meteor method exception and reports it to Bugsnag. This will be duplicative with our server-side reporting, but we generally have significantly better contextual information on the client, which should make debugging easier.

Additionally, add breadcrumbs on method calls so we can better tell what was happening immediately prior to an error.

(I also dropped the places where we were only catching a method error so that we could report it to Bugsnag, since this will catch all of those now)