### PR TITLE
Don't show guesses in guess queue for hunts you don't operate

### DIFF
--- a/imports/client/bugsnag.ts
+++ b/imports/client/bugsnag.ts
@@ -2,7 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import Bugsnag from '@bugsnag/js';
 import BugsnagPluginReact from '@bugsnag/plugin-react';
 import isAdmin from '../lib/isAdmin';
-import { userIsOperatorForAnyHunt } from '../lib/permission_stubs';
+import { huntsUserIsOperatorFor } from '../lib/permission_stubs';
 
 if (__meteor_runtime_config__.bugsnagApiKey) {
   Bugsnag.start({
@@ -16,7 +16,7 @@ if (__meteor_runtime_config__.bugsnagApiKey) {
         event.setUser(user._id, user.emails?.[0]?.address, user.displayName);
         event.addMetadata('user', {
           admin: isAdmin(user),
-          operator: userIsOperatorForAnyHunt(user),
+          operator: huntsUserIsOperatorFor(user),
         });
       }
     },

--- a/imports/lib/permission_stubs.ts
+++ b/imports/lib/permission_stubs.ts
@@ -32,16 +32,14 @@ export function userIsOperatorForHunt(
   return isOperatorForHunt(user, hunt);
 }
 
-export function userIsOperatorForAnyHunt(user: Meteor.User | null | undefined): boolean {
+export function huntsUserIsOperatorFor(user: Meteor.User | null | undefined): string[] {
   if (!user) {
-    return false;
+    return [];
   }
 
-  if (isAdmin(user)) {
-    return true;
-  }
-
-  return Object.entries(user.roles ?? {}).some(([huntId, roles]) => huntId !== GLOBAL_SCOPE && roles.includes('operator'));
+  return Object.entries(user.roles ?? {})
+    .filter(([huntId, roles]) => huntId !== GLOBAL_SCOPE && roles.includes('operator'))
+    .map(([huntId]) => huntId);
 }
 
 // admins and operators are always allowed to join someone to a hunt

--- a/imports/server/bugsnag.ts
+++ b/imports/server/bugsnag.ts
@@ -11,7 +11,7 @@ import glob from 'glob';
 import Logger from '../Logger';
 import isAdmin from '../lib/isAdmin';
 import MeteorUsers from '../lib/models/MeteorUsers';
-import { userIsOperatorForAnyHunt } from '../lib/permission_stubs';
+import { huntsUserIsOperatorFor } from '../lib/permission_stubs';
 import addRuntimeConfig from './addRuntimeConfig';
 import onExit from './onExit';
 
@@ -181,7 +181,7 @@ if (apiKey) {
         event.setUser(user._id, user.emails?.[0]?.address, user.displayName);
         event.addMetadata('user', {
           admin: isAdmin(user),
-          operator: userIsOperatorForAnyHunt(user),
+          operator: huntsUserIsOperatorFor(user),
         });
       }
     },

--- a/tests/acceptance/profiles.tsx
+++ b/tests/acceptance/profiles.tsx
@@ -5,7 +5,7 @@ import { Meteor } from 'meteor/meteor';
 import { assert } from 'chai';
 import Hunts from '../../imports/lib/models/Hunts';
 import MeteorUsers from '../../imports/lib/models/MeteorUsers';
-import { addUserToRole as serverAddUserToRole, userIsOperatorForAnyHunt } from '../../imports/lib/permission_stubs';
+import { addUserToRole as serverAddUserToRole, huntsUserIsOperatorFor } from '../../imports/lib/permission_stubs';
 import TypedMethod from '../../imports/methods/TypedMethod';
 import { resetDatabase, stabilize, subscribeAsync } from './lib';
 
@@ -211,6 +211,7 @@ if (Meteor.isClient) {
         await subscribeAsync('huntRoles', huntId);
         await subscribeAsync('huntRoles', otherHuntId);
 
+        const userIsOperatorForAnyHunt = (u: Meteor.User) => huntsUserIsOperatorFor(u).length > 0;
         let operators = MeteorUsers.find().fetch().filter(userIsOperatorForAnyHunt);
         assert.sameMembers(operators.map((u) => u._id), [userId, sameHuntUserId], 'Should only show operators in hunt where you are an operator');
 


### PR DESCRIPTION
The previous behavior was that NotificationCenter would show any pending guess that was visible to the client.  This is slightly too broad: when viewing a puzzle, all guesses for that puzzle are fetched, regardless of state, so if you were an operator in hunt A you'd see the guesses for a puzzle you had open in hunt B, even though you can't action them.

Instead, we should have NotificationCenter filter guesses down to those that the user can action, which is the set of those from hunts the user is an operator for.

Fixes #1353.