### PR TITLE
Hide `Guess`es that reference deleted `Puzzle`s

### DIFF
--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -369,16 +369,17 @@ const GuessQueuePage = () => {
     };
   }, [puzzles, displayNames]);
 
-  const filteredGuesses = useCallback((allGuesses: GuessType[]) => {
+  const filteredGuesses = useCallback((allGuesses: GuessType[], puzzleMap: Map<string, PuzzleType>) => {
     const searchKeys = searchString.split(' ');
+    const guessesForKnownPuzzles = allGuesses.filter((guess) => puzzleMap.has(guess.puzzle));
     let interestingGuesses;
 
     if (searchKeys.length === 1 && searchKeys[0] === '') {
-      interestingGuesses = allGuesses;
+      interestingGuesses = guessesForKnownPuzzles;
     } else {
       const searchKeysWithEmptyKeysRemoved = searchKeys.filter((key) => { return key.length > 0; });
       const isInteresting = compileMatcher(searchKeysWithEmptyKeysRemoved);
-      interestingGuesses = allGuesses.filter(isInteresting);
+      interestingGuesses = guessesForKnownPuzzles.filter(isInteresting);
     }
 
     return interestingGuesses;
@@ -441,7 +442,7 @@ const GuessQueuePage = () => {
           <StyledHeader>Status</StyledHeader>
           <StyledHeader>&nbsp;</StyledHeader>
         </StyledHeaderRow>
-        {filteredGuesses(guesses).map((guess) => {
+        {filteredGuesses(guesses, puzzles).map((guess) => {
           return (
             <GuessBlock
               key={guess._id}

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -643,25 +643,28 @@ const NotificationCenter = () => {
   const guesses = useTracker(() => (
     loading || !fetchPendingGuesses ?
       [] :
-      Guesses.find({
-        $and: [
-          {
-            // Only display pending guesses for hunts in which we are an operator.
-            // It's possible that e.g. on a puzzle page, we'll be subscribed to
-            // all guesses for that puzzle, so we should avoid showing guess
-            // queue UI if we're an operator for a different hunt but not the
-            // one the guess is for.
-            hunt: { $in: operatorHunts },
-          },
-          {
-            $or: [
-              { state: 'pending' },
-              { updatedAt: { $gt: new Date(recentGuessEpoch) } },
-            ],
-          },
-        ],
-      }, { sort: { createdAt: 1 } }).fetch()
-  ), [loading, fetchPendingGuesses, operatorHunts, recentGuessEpoch]);
+      Guesses
+        .find({
+          $and: [
+            {
+              // Only display pending guesses for hunts in which we are an operator.
+              // It's possible that e.g. on a puzzle page, we'll be subscribed to
+              // all guesses for that puzzle, so we should avoid showing guess
+              // queue UI if we're an operator for a different hunt but not the
+              // one the guess is for.
+              hunt: { $in: operatorHunts },
+            },
+            {
+              $or: [
+                { state: 'pending' },
+                { updatedAt: { $gt: new Date(recentGuessEpoch) } },
+              ],
+            },
+          ],
+        }, { sort: { createdAt: 1 } })
+        .fetch()
+        .filter((g) => puzzles.has(g.puzzle))
+  ), [loading, fetchPendingGuesses, operatorHunts, recentGuessEpoch, puzzles]);
   const pendingAnnouncements = useTracker(() => (
     loading ?
       [] :

--- a/imports/server/methods/removePuzzleAnswer.ts
+++ b/imports/server/methods/removePuzzleAnswer.ts
@@ -1,4 +1,5 @@
 import { check } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
 import Guesses from '../../lib/models/Guesses';
 import Hunts from '../../lib/models/Hunts';
 import Puzzles from '../../lib/models/Puzzles';
@@ -25,10 +26,15 @@ defineMethod(removePuzzleAnswer, {
         hunt: 1,
       },
     });
-    const huntId = puzzle?.hunt;
+
+    if (!puzzle) {
+      throw new Meteor.Error(404, `Puzzle ${puzzleId} not found`);
+    }
+
+    const huntId = puzzle.hunt;
     const hunt = await Hunts.findOneAsync({ _id: huntId });
-    if (!huntId || !hunt || hunt.hasGuessQueue) {
-      throw new Error(`Hunt ${huntId} does not support self-service answers`);
+    if (!hunt || hunt.hasGuessQueue) {
+      throw new Meteor.Error(400, `Hunt ${huntId} does not support self-service answers`);
     }
 
     const guess = await Guesses.findOneAsync({ puzzle: puzzleId, _id: guessId });

--- a/imports/server/methods/setGuessState.ts
+++ b/imports/server/methods/setGuessState.ts
@@ -4,6 +4,7 @@ import Logger from '../../Logger';
 import Guesses from '../../lib/models/Guesses';
 import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import Puzzles from '../../lib/models/Puzzles';
 import { userMayUpdateGuessesForHunt } from '../../lib/permission_stubs';
 import { GuessCodec } from '../../lib/schemas/Guess';
 import setGuessState from '../../methods/setGuessState';
@@ -26,6 +27,11 @@ defineMethod(setGuessState, {
     const guess = await Guesses.findOneAsync(guessId);
     if (!guess) {
       throw new Meteor.Error(404, 'No such guess');
+    }
+
+    const puzzle = await Puzzles.findOneAsync(guess.puzzle);
+    if (!puzzle) {
+      throw new Meteor.Error(404, 'Puzzle is deleted');
     }
 
     if (!userMayUpdateGuessesForHunt(


### PR DESCRIPTION
We will simply pretend that they do not exist, and avoid showing them in the UI.

We also prevent taking actions on such Guesses -- we don't want to wind up running solved/unsolved hooks, and it's somewhat nonsensical to try to transition the guess state of a Guess that isn't displayed anywhere anyway.

Fixes #1371.