### PR TITLE
Switch Mongo indexes to be declarative

### DIFF
--- a/imports/lib/models/Announcements.ts
+++ b/imports/lib/models/Announcements.ts
@@ -12,6 +12,7 @@ const Announcement = withCommon(z.object({
 }));
 
 const Announcements = new SoftDeletedModel('jr_announcements', Announcement);
+Announcements.addIndex({ deleted: 1, hunt: 1, createdAt: -1 });
 export type AnnouncementType = ModelType<typeof Announcements>;
 
 export default Announcements;

--- a/imports/lib/models/ChatMessages.ts
+++ b/imports/lib/models/ChatMessages.ts
@@ -47,6 +47,8 @@ const ChatMessage = withCommon(z.object({
   timestamp: z.date(),
 }));
 const ChatMessages = new SoftDeletedModel('jr_chatmessages', ChatMessage);
+ChatMessages.addIndex({ deleted: 1, puzzle: 1 });
+ChatMessages.addIndex({ hunt: 1, createdAt: 1 });
 export type ChatMessageType = ModelType<typeof ChatMessages>;
 
 export default ChatMessages;

--- a/imports/lib/models/ChatNotifications.ts
+++ b/imports/lib/models/ChatNotifications.ts
@@ -27,6 +27,7 @@ const ChatNotification = withCommon(z.object({
 }));
 
 const ChatNotifications = new SoftDeletedModel('jr_chatnotifications', ChatNotification);
+ChatNotifications.addIndex({ deleted: 1, user: 1 });
 export type ChatNotificationType = ModelType<typeof ChatNotifications>;
 
 export default ChatNotifications;

--- a/imports/lib/models/DiscordCache.ts
+++ b/imports/lib/models/DiscordCache.ts
@@ -11,6 +11,7 @@ export const DiscordCacheSchema = withTimestamps(z.object({
 }));
 
 const DiscordCache = new Model('discord_cache', DiscordCacheSchema);
+DiscordCache.addIndex({ type: 1, snowflake: 1 }, { unique: true });
 export type DiscordCacheType = ModelType<typeof DiscordCache>;
 
 export default DiscordCache;

--- a/imports/lib/models/DiscordRoleGrants.ts
+++ b/imports/lib/models/DiscordRoleGrants.ts
@@ -12,6 +12,13 @@ const DiscordRoleGrant = withCommon(z.object({
 }));
 
 const DiscordRoleGrants = new SoftDeletedModel('jr_discord_role_grants', DiscordRoleGrant);
+DiscordRoleGrants.addIndex({
+  guild: 1,
+  role: 1,
+  user: 1,
+  discordAccountId: 1,
+}, { unique: true });
+
 export type DiscordRoleGrantType = ModelType<typeof DiscordRoleGrants>;
 
 export default DiscordRoleGrants;

--- a/imports/lib/models/DocumentActivities.ts
+++ b/imports/lib/models/DocumentActivities.ts
@@ -16,6 +16,12 @@ export const DocumentActivity = z.object({
 });
 
 const DocumentActivities = new Model('jr_document_activities', DocumentActivity);
+DocumentActivities.addIndex({ hunt: 1 });
+DocumentActivities.addIndex({
+  document: 1,
+  ts: 1,
+  user: 1,
+}, { unique: true });
 export type DocumentActivityType = ModelType<typeof DocumentActivities>;
 
 export default DocumentActivities;

--- a/imports/lib/models/Documents.ts
+++ b/imports/lib/models/Documents.ts
@@ -19,6 +19,8 @@ const DocumentSchema = withCommon(z.object({
 ])));
 
 const Documents = new SoftDeletedModel('jr_documents', DocumentSchema);
+Documents.addIndex({ deleted: 1, puzzle: 1 });
+Documents.addIndex({ 'value.id': 1 });
 export type DocumentType = ModelType<typeof Documents>;
 
 export default Documents;

--- a/imports/lib/models/FeatureFlags.ts
+++ b/imports/lib/models/FeatureFlags.ts
@@ -13,7 +13,7 @@ const FeatureFlag = withCommon(z.object({
 }));
 
 const FeatureFlags = new SoftDeletedModel('jr_featureflags', FeatureFlag);
-
+FeatureFlags.addIndex({ name: 1 }, { unique: true });
 export type FeatureFlagType = ModelType<typeof FeatureFlags>;
 
 export default FeatureFlags;

--- a/imports/lib/models/FolderPermissions.ts
+++ b/imports/lib/models/FolderPermissions.ts
@@ -13,6 +13,12 @@ const FolderPermission = withCommon(z.object({
 }));
 
 const FolderPermissions = new SoftDeletedModel('jr_folder_perms', FolderPermission);
+FolderPermissions.addIndex({
+  folder: 1,
+  user: 1,
+  googleAccount: 1,
+  permissionLevel: 1,
+}, { unique: true });
 export type FolderPermissionType = ModelType<typeof FolderPermissions>;
 
 export default FolderPermissions;

--- a/imports/lib/models/Guesses.ts
+++ b/imports/lib/models/Guesses.ts
@@ -43,6 +43,8 @@ const Guess = withCommon(z.object({
 }));
 
 const Guesses = new SoftDeletedModel('jr_guesses', Guess);
+Guesses.addIndex({ deleted: 1, hunt: 1, puzzle: 1 });
+Guesses.addIndex({ deleted: 1, state: 1 });
 export type GuessType = ModelType<typeof Guesses>;
 
 export default Guesses;

--- a/imports/lib/models/PendingAnnouncements.ts
+++ b/imports/lib/models/PendingAnnouncements.ts
@@ -13,6 +13,7 @@ const PendingAnnouncement = withCommon(z.object({
 }));
 
 const PendingAnnouncements = new SoftDeletedModel('jr_pending_announcements', PendingAnnouncement);
+PendingAnnouncements.addIndex({ user: 1 });
 export type PendingAnnouncementType = ModelType<typeof PendingAnnouncements>;
 
 export default PendingAnnouncements;

--- a/imports/lib/models/Puzzles.ts
+++ b/imports/lib/models/Puzzles.ts
@@ -23,6 +23,7 @@ const Puzzle = withCommon(z.object({
 }));
 
 const Puzzles = new SoftDeletedModel('jr_puzzles', Puzzle);
+Puzzles.addIndex({ deleted: 1, hunt: 1 });
 export type PuzzleType = ModelType<typeof Puzzles>;
 
 export default Puzzles;

--- a/imports/lib/models/Servers.ts
+++ b/imports/lib/models/Servers.ts
@@ -10,6 +10,7 @@ const Server = z.object({
 });
 
 const Servers = new Model('jr_servers', Server);
+Servers.addIndex({ updatedAt: 1 });
 export type ServerType = ModelType<typeof Servers>;
 
 export default Servers;

--- a/imports/lib/models/Settings.ts
+++ b/imports/lib/models/Settings.ts
@@ -67,7 +67,7 @@ export const SettingNames = SettingDiscriminatedUnion.options.map((option) => {
 export type SettingNameType = typeof SettingNames[number];
 
 const Settings = new SoftDeletedModel('jr_settings', Setting);
-
+Settings.addIndex({ name: 1 }, { unique: true });
 export type SettingType = ModelType<typeof Settings>;
 
 export default Settings;

--- a/imports/lib/models/Tags.ts
+++ b/imports/lib/models/Tags.ts
@@ -10,6 +10,7 @@ const Tag = withCommon(z.object({
 }));
 
 const Tags = new SoftDeletedModel('jr_tags', Tag);
+Tags.addIndex({ deleted: 1, hunt: 1, name: 1 });
 export type TagType = ModelType<typeof Tags>;
 
 export default Tags;

--- a/imports/lib/models/mediasoup/CallHistories.ts
+++ b/imports/lib/models/mediasoup/CallHistories.ts
@@ -12,6 +12,8 @@ const CallHistory = z.object({
 });
 
 const CallHistories = new Model('jr_mediasoup_call_histories', CallHistory);
+CallHistories.addIndex({ call: 1 }, { unique: true });
+CallHistories.addIndex({ hunt: 1 });
 export type CallHistoryType = ModelType<typeof CallHistories>;
 
 export default CallHistories;

--- a/imports/lib/models/mediasoup/ConnectAcks.ts
+++ b/imports/lib/models/mediasoup/ConnectAcks.ts
@@ -14,6 +14,9 @@ const ConnectAck = withCommon(z.object({
 }));
 
 const ConnectAcks = new SoftDeletedModel('jr_mediasoup_connect_acks', ConnectAck);
+ConnectAcks.addIndex({ transport: 1 }, { unique: true });
+ConnectAcks.addIndex({ peer: 1 });
+ConnectAcks.addIndex({ createdServer: 1 });
 export type ConnectAckType = ModelType<typeof ConnectAcks>;
 
 export default ConnectAcks;

--- a/imports/lib/models/mediasoup/ConnectRequests.ts
+++ b/imports/lib/models/mediasoup/ConnectRequests.ts
@@ -16,6 +16,10 @@ const ConnectRequest = withCommon(z.object({
 }));
 
 const ConnectRequests = new SoftDeletedModel('jr_mediasoup_connect_requests', ConnectRequest);
+ConnectRequests.addIndex({ transport: 1 }, { unique: true });
+ConnectRequests.addIndex({ createdServer: 1 });
+ConnectRequests.addIndex({ routedServer: 1 });
+ConnectRequests.addIndex({ peer: 1 });
 export type ConnectRequestType = ModelType<typeof ConnectRequests>;
 
 export default ConnectRequests;

--- a/imports/lib/models/mediasoup/ConsumerAcks.ts
+++ b/imports/lib/models/mediasoup/ConsumerAcks.ts
@@ -15,6 +15,9 @@ const ConsumerAck = withCommon(z.object({
 }));
 
 const ConsumerAcks = new SoftDeletedModel('jr_mediasoup_consumer_acks', ConsumerAck);
+ConsumerAcks.addIndex({ consumer: 1 }, { unique: true });
+ConsumerAcks.addIndex({ peer: 1 });
+ConsumerAcks.addIndex({ createdServer: 1 });
 export type ConsumerAckType = ModelType<typeof ConsumerAcks>;
 
 export default ConsumerAcks;

--- a/imports/lib/models/mediasoup/Consumers.ts
+++ b/imports/lib/models/mediasoup/Consumers.ts
@@ -19,6 +19,9 @@ const Consumer = withCommon(z.object({
 }));
 
 const Consumers = new SoftDeletedModel('jr_mediasoup_consumers', Consumer);
+Consumers.addIndex({ peer: 1 });
+Consumers.addIndex({ consumerId: 1 });
+Consumers.addIndex({ createdServer: 1 });
 export type ConsumerType = ModelType<typeof Consumers>;
 
 export default Consumers;

--- a/imports/lib/models/mediasoup/Peers.ts
+++ b/imports/lib/models/mediasoup/Peers.ts
@@ -20,6 +20,9 @@ const Peer = withCommon(z.object({
 }));
 
 const Peers = new SoftDeletedModel('jr_mediasoup_peers', Peer);
+Peers.addIndex({ hunt: 1, call: 1, tab: 1 }, { unique: true });
+Peers.addIndex({ call: 1, createdAt: 1 });
+Peers.addIndex({ createdServer: 1 });
 export type PeerType = ModelType<typeof Peers>;
 
 export default Peers;

--- a/imports/lib/models/mediasoup/ProducerClients.ts
+++ b/imports/lib/models/mediasoup/ProducerClients.ts
@@ -19,6 +19,9 @@ const ProducerClient = withCommon(z.object({
 }));
 
 const ProducerClients = new SoftDeletedModel('jr_mediasoup_producer_clients', ProducerClient);
+ProducerClients.addIndex({ transport: 1 });
+ProducerClients.addIndex({ createdServer: 1 });
+ProducerClients.addIndex({ routedServer: 1 });
 export type ProducerClientType = ModelType<typeof ProducerClients>;
 
 export default ProducerClients;

--- a/imports/lib/models/mediasoup/ProducerServers.ts
+++ b/imports/lib/models/mediasoup/ProducerServers.ts
@@ -15,6 +15,10 @@ const ProducerServer = withCommon(z.object({
 }));
 
 const ProducerServers = new SoftDeletedModel('jr_mediasoup_producer_servers', ProducerServer);
+ProducerServers.addIndex({ producerClient: 1 }, { unique: true });
+ProducerServers.addIndex({ transport: 1 });
+ProducerServers.addIndex({ createdServer: 1 });
+ProducerServers.addIndex({ producerId: 1 });
 export type ProducerServerType = ModelType<typeof ProducerServers>;
 
 export default ProducerServers;

--- a/imports/lib/models/mediasoup/Rooms.ts
+++ b/imports/lib/models/mediasoup/Rooms.ts
@@ -14,6 +14,8 @@ const Room = withCommon(z.object({
 }));
 
 const Rooms = new SoftDeletedModel('jr_mediasoup_rooms', Room);
+Rooms.addIndex({ call: 1 }, { unique: true });
+Rooms.addIndex({ routedServer: 1 });
 export type RoomType = ModelType<typeof Rooms>;
 
 export default Rooms;

--- a/imports/lib/models/mediasoup/Routers.ts
+++ b/imports/lib/models/mediasoup/Routers.ts
@@ -13,6 +13,9 @@ const Router = withCommon(z.object({
 }));
 
 const Routers = new SoftDeletedModel('jr_mediasoup_routers', Router);
+Routers.addIndex({ call: 1 }, { unique: true });
+Routers.addIndex({ routerId: 1 });
+Routers.addIndex({ createdServer: 1 });
 export type RouterType = ModelType<typeof Routers>;
 
 export default Routers;

--- a/imports/lib/models/mediasoup/TransportRequests.ts
+++ b/imports/lib/models/mediasoup/TransportRequests.ts
@@ -13,6 +13,8 @@ const TransportRequest = withCommon(z.object({
 }));
 
 const TransportRequests = new SoftDeletedModel('jr_mediasoup_transport_requests', TransportRequest);
+TransportRequests.addIndex({ createdServer: 1 });
+TransportRequests.addIndex({ routedServer: 1 });
 export type TransportRequestType = ModelType<typeof TransportRequests>;
 
 export default TransportRequests;

--- a/imports/lib/models/mediasoup/TransportStates.ts
+++ b/imports/lib/models/mediasoup/TransportStates.ts
@@ -20,6 +20,8 @@ const TransportState = withCommon(z.object({
 }));
 
 const TransportStates = new SoftDeletedModel('jr_mediasoup_transport_states', TransportState);
+TransportStates.addIndex({ transportId: 1, createdServer: 1 }, { unique: true });
+TransportStates.addIndex({ transportId: 1 });
 export type TransportStateType = ModelType<typeof TransportStates>;
 
 export default TransportStates;

--- a/imports/lib/models/mediasoup/Transports.ts
+++ b/imports/lib/models/mediasoup/Transports.ts
@@ -20,6 +20,9 @@ const Transport = withCommon(z.object({
 }));
 
 const Transports = new SoftDeletedModel('jr_mediasoup_transports', Transport);
+Transports.addIndex({ transportRequest: 1, direction: 1 }, { unique: true });
+Transports.addIndex({ transportId: 1 });
+Transports.addIndex({ createdServer: 1 });
 export type TransportType = ModelType<typeof Transports>;
 
 export default Transports;

--- a/imports/server/indexes.ts
+++ b/imports/server/indexes.ts
@@ -1,0 +1,86 @@
+import util from 'util';
+import { MongoInternals } from 'meteor/mongo';
+import type { IndexSpecification, CreateIndexesOptions, CommandOperationOptions } from 'mongodb';
+import Logger from '../Logger';
+import type { ModelIndexSpecification } from '../lib/models/Model';
+import { AllModels, normalizeIndexOptions, normalizeIndexSpecification } from '../lib/models/Model';
+import startupIfLatestBuild from './startupIfLatestBuild';
+
+const { MongoError } = MongoInternals.NpmModules.mongodb.module;
+
+type ListIndexResult = {
+  v: number;
+  key: IndexSpecification;
+} & Omit<CreateIndexesOptions, keyof CommandOperationOptions>;
+
+type ExistingIndexSpecification = ModelIndexSpecification & {
+  name: string | undefined;
+}
+
+startupIfLatestBuild(async () => {
+  for (const model of AllModels) {
+    const { indexes: expectedIndexes } = model;
+    const collection = model.collection.rawCollection();
+    let existingIndexesRaw: ListIndexResult[];
+    try {
+      existingIndexesRaw = await collection.listIndexes().toArray();
+    } catch (error) {
+      if (!(error instanceof MongoError) || error.code !== 26 /* NamespaceNotFound */) {
+        throw error;
+      }
+      existingIndexesRaw = [];
+    }
+    const existingIndexes: ExistingIndexSpecification[] = existingIndexesRaw.map(({
+      v: _v, key, name, ...options
+    }) => {
+      const normalizedIndex = normalizeIndexSpecification(key);
+      const normalizedOptions = normalizeIndexOptions(options);
+      const stringified = JSON.stringify([normalizedIndex, normalizedOptions]);
+      return {
+        name,
+        index: normalizedIndex,
+        options: normalizedOptions,
+        stringified,
+      };
+    });
+
+    const existingIndexSet = new Set(existingIndexes.map(({ stringified }) => stringified));
+    const expectedIndexSet = new Set(expectedIndexes.map(({ stringified }) => stringified));
+
+    const missingIndexes = expectedIndexes
+      .filter(({ stringified }) => !existingIndexSet.has(stringified));
+    const extraIndexes = existingIndexes
+      .filter(({ index, stringified }) => {
+        // Don't (try to) delete the default _id index
+        return !util.isDeepStrictEqual(index, [['_id', 1]]) &&
+          !expectedIndexSet.has(stringified);
+      });
+
+    for (const { index, options } of missingIndexes) {
+      Logger.info('Creating new index', {
+        model: model.name,
+        index,
+        options,
+      });
+      await collection.createIndex(index, Object.fromEntries(options));
+    }
+    for (const { name, index, options } of extraIndexes) {
+      if (!name) {
+        Logger.warn('Unable to drop index with no name', {
+          model: model.name,
+          index,
+          options,
+          error: new Error('Unable to drop index with no name'),
+        });
+        continue;
+      }
+
+      Logger.info('Dropping unexpected index', {
+        model: model.name,
+        index,
+        options,
+      });
+      await collection.dropIndex(name);
+    }
+  }
+});

--- a/imports/server/migrations/1-basic-indexes.ts
+++ b/imports/server/migrations/1-basic-indexes.ts
@@ -1,18 +1,10 @@
-import Announcements from '../../lib/models/Announcements';
-import ChatMessages from '../../lib/models/ChatMessages';
-import Guesses from '../../lib/models/Guesses';
-import Puzzles from '../../lib/models/Puzzles';
-import Tags from '../../lib/models/Tags';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 1,
   name: 'Add basic indexes to collections',
   async up() {
-    await Announcements.createIndexAsync({ deleted: 1, hunt: 1, createdAt: -1 });
-    await ChatMessages.createIndexAsync({ puzzleId: 1, timestamp: -1 });
-    await Guesses.createIndexAsync({ deleted: 1, hunt: 1, puzzle: 1 });
-    await Puzzles.createIndexAsync({ deleted: 1, hunt: 1 });
-    await Tags.createIndexAsync({ deleted: 1, hunt: 1 });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/11-api-keys-indexes.ts
+++ b/imports/server/migrations/11-api-keys-indexes.ts
@@ -1,10 +1,10 @@
-import APIKeys from '../models/APIKeys';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 11,
   name: 'Add indexes for API keys',
   async up() {
-    await APIKeys.createIndexAsync({ key: 1 });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/15-backfill-chat-base-props.ts
+++ b/imports/server/migrations/15-backfill-chat-base-props.ts
@@ -35,8 +35,5 @@ Migrations.add({
         bypassSchema: true,
       });
     }
-
-    await ChatMessages.dropIndexAsync('puzzleId_1_timestamp_-1');
-    await ChatMessages.createIndexAsync({ deleted: 1, puzzle: 1 });
   },
 });

--- a/imports/server/migrations/16-feature-flag-indexes.ts
+++ b/imports/server/migrations/16-feature-flag-indexes.ts
@@ -1,10 +1,10 @@
-import FeatureFlags from '../../lib/models/FeatureFlags';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 16,
   name: 'Create index for feature flags',
   async up() {
-    await FeatureFlags.createIndexAsync({ name: 1 }, { unique: true });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/18-rename-gdrive-template.ts
+++ b/imports/server/migrations/18-rename-gdrive-template.ts
@@ -5,8 +5,6 @@ Migrations.add({
   version: 18,
   name: 'Update the Google Spreadsheet template setting name',
   async up() {
-    await Settings.createIndexAsync({ name: 1 }, { unique: true });
-
     await Settings.updateAsync(
       <any>{ name: 'gdrive.template' },
       { $set: { name: 'gdrive.template.spreadsheet' } }

--- a/imports/server/migrations/19-subscribers-name-index.ts
+++ b/imports/server/migrations/19-subscribers-name-index.ts
@@ -1,10 +1,10 @@
-import Subscribers from '../models/Subscribers';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 19,
   name: 'Create new index for subscribers.fetch subscription',
   async up() {
-    await Subscribers.createIndexAsync({ name: 1 });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/2-lock-unique.ts
+++ b/imports/server/migrations/2-lock-unique.ts
@@ -1,10 +1,10 @@
-import Locks from '../models/Locks';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 2,
   name: 'Add unique index to locks',
   async up() {
-    await Locks.createIndexAsync({ name: 1 }, { unique: true });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/28-discord-cache-indexes.ts
+++ b/imports/server/migrations/28-discord-cache-indexes.ts
@@ -1,10 +1,10 @@
-import DiscordCache from '../../lib/models/DiscordCache';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 28,
   name: 'Create index for discord cache',
   async up() {
-    await DiscordCache.createIndexAsync({ type: 1, snowflake: 1 }, { unique: true });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/3-subscribers-indexes.ts
+++ b/imports/server/migrations/3-subscribers-indexes.ts
@@ -1,11 +1,10 @@
-import Subscribers from '../models/Subscribers';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 3,
   name: 'Add indexes for subscriber tracking',
   async up() {
-    await Subscribers.createIndexAsync({ server: 1 });
-    await Subscribers.createIndexAsync({ name: 1 });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/32-index-chat-notifications.ts
+++ b/imports/server/migrations/32-index-chat-notifications.ts
@@ -1,11 +1,10 @@
-import ChatNotifications from '../../lib/models/ChatNotifications';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 32,
   name: 'Add indexes on ChatNotifications',
   async up() {
-    // Ensure that the query pattern in chat-notifications.ts is indexed.
-    await ChatNotifications.createIndexAsync({ deleted: 1, user: 1 });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/34-mediasoup-indexes.ts
+++ b/imports/server/migrations/34-mediasoup-indexes.ts
@@ -1,66 +1,10 @@
-import ConnectAcks from '../../lib/models/mediasoup/ConnectAcks';
-import ConnectRequests from '../../lib/models/mediasoup/ConnectRequests';
-import ConsumerAcks from '../../lib/models/mediasoup/ConsumerAcks';
-import Consumers from '../../lib/models/mediasoup/Consumers';
-import Peers from '../../lib/models/mediasoup/Peers';
-import ProducerClients from '../../lib/models/mediasoup/ProducerClients';
-import ProducerServers from '../../lib/models/mediasoup/ProducerServers';
-import Rooms from '../../lib/models/mediasoup/Rooms';
-import Routers from '../../lib/models/mediasoup/Routers';
-import TransportRequests from '../../lib/models/mediasoup/TransportRequests';
-import TransportStates from '../../lib/models/mediasoup/TransportStates';
-import Transports from '../../lib/models/mediasoup/Transports';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 34,
   name: 'Add indexes to mediasoup collections',
   async up() {
-    await Rooms.createIndexAsync({ call: 1 }, { unique: true });
-    await Rooms.createIndexAsync({ routedServer: 1 });
-
-    await Routers.createIndexAsync({ call: 1 }, { unique: true });
-    await Routers.createIndexAsync({ routerId: 1 });
-    await Routers.createIndexAsync({ createdServer: 1 });
-
-    await Peers.createIndexAsync({ hunt: 1, call: 1, tab: 1 }, { unique: true });
-    await Peers.createIndexAsync({ call: 1, createdAt: 1 });
-    await Peers.createIndexAsync({ createdServer: 1 });
-
-    await TransportRequests.createIndexAsync({ createdServer: 1 });
-    await TransportRequests.createIndexAsync({ routedServer: 1 });
-
-    await Transports.createIndexAsync({ transportRequest: 1, direction: 1 }, { unique: true });
-    await Transports.createIndexAsync({ transportId: 1 });
-    await Transports.createIndexAsync({ createdServer: 1 });
-
-    await TransportStates.createIndexAsync({ transportId: 1, createdServer: 1 }, { unique: true });
-    await TransportStates.createIndexAsync({ transportId: 1 });
-
-    await ConnectRequests.createIndexAsync({ transport: 1 }, { unique: true });
-    await ConnectRequests.createIndexAsync({ createdServer: 1 });
-    await ConnectRequests.createIndexAsync({ routedServer: 1 });
-    await ConnectRequests.createIndexAsync({ peer: 1 });
-
-    await ConnectAcks.createIndexAsync({ transport: 1 }, { unique: true });
-    await ConnectAcks.createIndexAsync({ peer: 1 });
-    await ConnectAcks.createIndexAsync({ createdServer: 1 });
-
-    await ProducerClients.createIndexAsync({ transport: 1 });
-    await ProducerClients.createIndexAsync({ createdServer: 1 });
-    await ProducerClients.createIndexAsync({ routedServer: 1 });
-
-    await ProducerServers.createIndexAsync({ producerClient: 1 }, { unique: true });
-    await ProducerServers.createIndexAsync({ transport: 1 });
-    await ProducerServers.createIndexAsync({ createdServer: 1 });
-    await ProducerServers.createIndexAsync({ producerId: 1 });
-
-    await Consumers.createIndexAsync({ peer: 1 });
-    await Consumers.createIndexAsync({ consumerId: 1 });
-    await Consumers.createIndexAsync({ createdServer: 1 });
-
-    await ConsumerAcks.createIndexAsync({ consumer: 1 }, { unique: true });
-    await ConsumerAcks.createIndexAsync({ peer: 1 });
-    await ConsumerAcks.createIndexAsync({ createdServer: 1 });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/35-folder-permissions-indexes.ts
+++ b/imports/server/migrations/35-folder-permissions-indexes.ts
@@ -1,13 +1,10 @@
-import FolderPermissions from '../../lib/models/FolderPermissions';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 35,
   name: 'Indexes for new FolderPermissions model',
   async up() {
-    await FolderPermissions.createIndexAsync(
-      { folder: 1, user: 1, googleAccount: 1 },
-      { unique: true },
-    );
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/36-call-history-indexes.ts
+++ b/imports/server/migrations/36-call-history-indexes.ts
@@ -1,11 +1,10 @@
-import CallHistories from '../../lib/models/mediasoup/CallHistories';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 36,
   name: 'Add indexes to CallHistory collection',
   async up() {
-    await CallHistories.createIndexAsync({ call: 1 }, { unique: true });
-    await CallHistories.createIndexAsync({ hunt: 1 });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/4-fix-subscribers-indexes.ts
+++ b/imports/server/migrations/4-fix-subscribers-indexes.ts
@@ -1,11 +1,10 @@
-import Subscribers from '../models/Subscribers';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 4,
   name: 'Fix indexes for subscriber tracking',
   async up() {
-    await Subscribers.dropIndexAsync('name_1');
-    await Subscribers.createIndexAsync({ 'context.hunt': 1 });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/41-document-activities.ts
+++ b/imports/server/migrations/41-document-activities.ts
@@ -1,11 +1,10 @@
-import DocumentActivities from '../../lib/models/DocumentActivities';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 41,
   name: 'Add document activities collections and indexes',
   async up() {
-    await DocumentActivities.createIndexAsync({ hunt: 1 });
-    await DocumentActivities.createIndexAsync({ document: 1, ts: 1 }, { unique: true });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/42-document-by-external-id.ts
+++ b/imports/server/migrations/42-document-by-external-id.ts
@@ -1,10 +1,10 @@
-import Documents from '../../lib/models/Documents';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 42,
   name: 'Index for finding documents by external id',
   async up() {
-    await Documents.createIndexAsync({ 'value.id': 1 });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/44-better-puzzle-activity.ts
+++ b/imports/server/migrations/44-better-puzzle-activity.ts
@@ -1,24 +1,10 @@
-import ChatMessages from '../../lib/models/ChatMessages';
-import CallActivities from '../models/CallActivities';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 44,
   name: 'Indexes for puzzle activity tracking',
   async up() {
-    await CallActivities.createIndexAsync({
-      ts: 1,
-      call: 1,
-      user: 1,
-    }, { unique: true });
-    await CallActivities.createIndexAsync({
-      hunt: 1,
-      ts: 1,
-    });
-
-    await ChatMessages.createIndexAsync({
-      hunt: 1,
-      createdAt: 1,
-    });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/45-folder-permission-level.ts
+++ b/imports/server/migrations/45-folder-permission-level.ts
@@ -1,16 +1,10 @@
-import FolderPermissions from '../../lib/models/FolderPermissions';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 45,
   name: 'Add permission level to FolderPermissions index',
   async up() {
-    await FolderPermissions.createIndexAsync({
-      folder: 1,
-      user: 1,
-      googleAccount: 1,
-      permissionLevel: 1,
-    }, { unique: true });
-    await FolderPermissions.dropIndexAsync('folder_1_user_1_googleAccount_1');
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/46-per-user-document-activity.ts
+++ b/imports/server/migrations/46-per-user-document-activity.ts
@@ -1,4 +1,3 @@
-import DocumentActivities from '../../lib/models/DocumentActivities';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Migrations from './Migrations';
 
@@ -6,13 +5,6 @@ Migrations.add({
   version: 46,
   name: 'Collect per-user document activity',
   async up() {
-    await DocumentActivities.createIndexAsync({
-      document: 1,
-      ts: 1,
-      user: 1,
-    }, { unique: true });
-    await DocumentActivities.dropIndexAsync('document_1_ts_1');
-
     await MeteorUsers.createIndexAsync({ hunt: 1, googleAccountId: 1, createdAt: 1 });
   },
 });

--- a/imports/server/migrations/47-discord-role-grant-indexes.ts
+++ b/imports/server/migrations/47-discord-role-grant-indexes.ts
@@ -1,15 +1,10 @@
-import DiscordRoleGrants from '../../lib/models/DiscordRoleGrants';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 47,
   name: 'Add unique indexes to DiscordRoleGrants',
   async up() {
-    await DiscordRoleGrants.createIndexAsync({
-      guild: 1,
-      role: 1,
-      user: 1,
-      discordAccountId: 1,
-    }, { unique: true });
+    // This migration previously created an index, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/5-pending-announcement-indexes.ts
+++ b/imports/server/migrations/5-pending-announcement-indexes.ts
@@ -1,10 +1,10 @@
-import PendingAnnouncements from '../../lib/models/PendingAnnouncements';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 5,
   name: 'Create indexes for pending announcements',
   async up() {
-    await PendingAnnouncements.createIndexAsync({ user: 1 });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/migrations/7-more-indexes.ts
+++ b/imports/server/migrations/7-more-indexes.ts
@@ -1,7 +1,4 @@
-import Documents from '../../lib/models/Documents';
-import Guesses from '../../lib/models/Guesses';
 import MeteorUsers from '../../lib/models/MeteorUsers';
-import Tags from '../../lib/models/Tags';
 import Migrations from './Migrations';
 
 Migrations.add({
@@ -9,13 +6,5 @@ Migrations.add({
   name: 'Add more missing indexes',
   async up() {
     await MeteorUsers.createIndexAsync({ hunts: 1 });
-
-    await Tags.createIndexAsync({ deleted: 1, hunt: 1, name: 1 });
-
-    await Tags.dropIndexAsync('deleted_1_hunt_1');
-
-    await Documents.createIndexAsync({ deleted: 1, puzzle: 1 });
-
-    await Guesses.createIndexAsync({ deleted: 1, state: 1 });
   },
 });

--- a/imports/server/migrations/8-subscriber-servers-index.ts
+++ b/imports/server/migrations/8-subscriber-servers-index.ts
@@ -1,10 +1,10 @@
-import Servers from '../../lib/models/Servers';
 import Migrations from './Migrations';
 
 Migrations.add({
   version: 8,
   name: 'Add index for subscriptions server tracker',
   async up() {
-    await Servers.createIndexAsync({ updatedAt: 1 });
+    // This migration previously created indexes, which is now handled
+    // declaratively
   },
 });

--- a/imports/server/models/APIKeys.ts
+++ b/imports/server/models/APIKeys.ts
@@ -10,6 +10,7 @@ const APIKey = withCommon(z.object({
 }));
 
 const APIKeys = new SoftDeletedModel('jr_api_keys', APIKey);
+APIKeys.addIndex({ key: 1 });
 export type APIKeyType = ModelType<typeof APIKeys>;
 
 export default APIKeys;

--- a/imports/server/models/CallActivities.ts
+++ b/imports/server/models/CallActivities.ts
@@ -11,6 +11,15 @@ const CallActivity = z.object({
 });
 
 const CallActivities = new Model('jr_call_activities', CallActivity);
+CallActivities.addIndex({
+  ts: 1,
+  call: 1,
+  user: 1,
+}, { unique: true });
+CallActivities.addIndex({
+  hunt: 1,
+  ts: 1,
+});
 export type CallActivityType = ModelType<typeof CallActivities>;
 
 export default CallActivities;

--- a/imports/server/models/LatestDeploymentTimestamps.ts
+++ b/imports/server/models/LatestDeploymentTimestamps.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+import type { ModelType } from '../../lib/models/Model';
+import Model from '../../lib/models/Model';
+import { nonEmptyString } from '../../lib/models/customTypes';
+import withTimestamps from '../../lib/models/withTimestamps';
+
+// LatestDeploymentTimestamp captures the most recent build timestamp that we've
+// observed, and is used to prevent older builds from accidentally warring over
+// newer changes. It is a singleton collection with _id "default"
+const LatestDeploymentTimestamp = withTimestamps(z.object({
+  buildTimestamp: z.date(),
+  gitRevision: nonEmptyString,
+}));
+
+const LatestDeploymentTimestamps = new Model('jr_latest_deployment_timestamps', LatestDeploymentTimestamp, z.literal('default'));
+export type LatestDeploymentTimestampType = ModelType<typeof LatestDeploymentTimestamps>;
+export default LatestDeploymentTimestamps;

--- a/imports/server/models/Locks.ts
+++ b/imports/server/models/Locks.ts
@@ -13,6 +13,7 @@ export const Lock = z.object({
 });
 
 const Locks = new Model('jr_locks', Lock);
+Locks.addIndex({ name: 1 }, { unique: true });
 export type LockType = ModelType<typeof Locks>;
 
 export default Locks;

--- a/imports/server/models/Subscribers.ts
+++ b/imports/server/models/Subscribers.ts
@@ -16,6 +16,9 @@ export const Subscriber = withTimestamps(z.object({
 }));
 
 const Subscribers = new Model('jr_subscribers', Subscriber);
+Subscribers.addIndex({ server: 1 });
+Subscribers.addIndex({ 'context.hunt': 1 });
+Subscribers.addIndex({ name: 1 });
 export type SubscriberType = ModelType<typeof Subscribers>;
 
 export default Subscribers;

--- a/imports/server/schemas.ts
+++ b/imports/server/schemas.ts
@@ -1,22 +1,16 @@
 import { Meteor } from 'meteor/meteor';
-import { Promise as MeteorPromise } from 'meteor/promise';
 import { AllModels } from '../lib/models/Model';
 import User from '../lib/models/User';
 import attachSchema from './attachSchema';
+import startupIfLatestBuild from './startupIfLatestBuild';
 
-Meteor.startup(() => {
-  // We want this to be synchronous, so that if it fails we crash the
-  // application (better than having no schema in place). We should be able to
-  // eliminate this if Meteor backports support for async startup functions (as
-  // requested in https://github.com/meteor/meteor/discussions/12468)
-  MeteorPromise.await((async () => {
-    for (const model of AllModels.values()) {
-      await attachSchema(model.schema, model.collection);
-    }
-    // Note: this will fail type checking if our schema for User gets out of sync
-    // with the type declaration for Meteor.User. (This could happen if we change
-    // our extensions to Meteor.User in imports/lib/models/User.ts but is more
-    // likely to happen if Meteor upstream changes their type declaration.)
-    await attachSchema(User, Meteor.users);
-  })());
+startupIfLatestBuild(async () => {
+  for (const model of AllModels.values()) {
+    await attachSchema(model.schema, model.collection);
+  }
+  // Note: this will fail type checking if our schema for User gets out of sync
+  // with the type declaration for Meteor.User. (This could happen if we change
+  // our extensions to Meteor.User in imports/lib/models/User.ts but is more
+  // likely to happen if Meteor upstream changes their type declaration.)
+  await attachSchema(User, Meteor.users);
 });

--- a/imports/server/startupIfLatestBuild.ts
+++ b/imports/server/startupIfLatestBuild.ts
@@ -1,0 +1,58 @@
+import { promises as fs } from 'fs';
+import { Meteor } from 'meteor/meteor';
+import { Promise as MeteorPromise } from 'meteor/promise';
+import Logger from '../Logger';
+import ignoringDuplicateKeyErrors from './ignoringDuplicateKeyErrors';
+import LatestDeploymentTimestamps from './models/LatestDeploymentTimestamps';
+
+const startupHooks = new Set<() => Promise<void>>();
+
+// startupIfLatestBuild registers a hook which runs on server startup, but only
+// if this is the most recent build timestamp that we've observed (otherwise the
+// hook is skipped)
+export default function startupIfLatestBuild(fn: () => Promise<void>) {
+  startupHooks.add(fn);
+}
+
+Meteor.startup(() => {
+  // We want this to be synchronous, so that if it fails we crash the
+  // application. We should be able to eliminate this if Meteor backports
+  // support for async startup functions (as requested in
+  // https://github.com/meteor/meteor/discussions/12468)
+  MeteorPromise.await((async () => {
+    const stat = await fs.stat(process.argv[1]!);
+    const buildTimestamp = stat.mtime;
+
+    const previousLatest = await LatestDeploymentTimestamps.findOneAsync('default');
+    if (previousLatest && previousLatest.buildTimestamp > buildTimestamp) {
+      Logger.warn('Skipping startup hooks because we are not the latest', {
+        previousTimestamp: previousLatest.buildTimestamp,
+        previousRevision: previousLatest.gitRevision,
+        buildTimestamp,
+      });
+      return;
+    }
+
+    for (const fn of startupHooks) {
+      await fn();
+    }
+
+    await ignoringDuplicateKeyErrors(async () => {
+      await LatestDeploymentTimestamps.insertAsync({
+        _id: 'default',
+        buildTimestamp,
+        gitRevision: Meteor.gitCommitHash,
+      });
+    });
+
+    await LatestDeploymentTimestamps.updateAsync({
+      _id: 'default',
+      buildTimestamp: { $lt: buildTimestamp },
+    }, {
+      $set: {
+        buildTimestamp,
+        gitRevision: Meteor.gitCommitHash,
+      },
+    });
+  })());
+});

--- a/server/main.ts
+++ b/server/main.ts
@@ -2,8 +2,9 @@
 import '../imports/server/bugsnag';
 import '../imports/server/configureLogger';
 
-// setup schemas on models
+// setup schemas and indexes on models
 import '../imports/server/schemas';
+import '../imports/server/indexes';
 
 // explicitly import all the stuff from lib/ since mainModule skips autoloading
 // things


### PR DESCRIPTION
Instead of creating indexes in migrations, declare them as part of the model. Then, at startup, iterate through all declared indexes and indexes actually present in the database and reconcile them.