### PR TITLE
Fix modifiers for arrays with defaults

### DIFF
--- a/imports/lib/models/Model.ts
+++ b/imports/lib/models/Model.ts
@@ -62,7 +62,7 @@ export function relaxSchema(schema: z.ZodFirstPartySchemaTypes): z.ZodTypeAny {
       return z.record(def.keyType, relaxSchema(def.valueType)).optional();
     case z.ZodFirstPartyTypeKind.ZodDefault: {
       const { defaultValue, innerType } = def;
-      return innerType.optional().transform((v: z.output<typeof innerType>) => {
+      return relaxSchema(innerType).transform((v: z.output<typeof innerType>) => {
         if (v !== undefined) return v;
         if (IsInsert.getOrNullIfOutsideFiber() || IsUpsert.getOrNullIfOutsideFiber()) {
           return defaultValue();

--- a/tests/unit/imports/server/Model.ts
+++ b/tests/unit/imports/server/Model.ts
@@ -267,6 +267,33 @@ describe('Model', function () {
       assert.isTrue(valid.success);
     });
 
+    it('accepts valid modifiers for arrays with defaults', async function () {
+      const schema = z.object({
+        array: z.array(nonEmptyString).default([]),
+      });
+      const relaxed = relaxSchema(schema);
+
+      // A $set operation (with and without a value)
+      let valid = await relaxed.safeParseAsync({
+        array: ['foo'],
+      });
+      assert.isTrue(valid.success);
+      valid = await relaxed.safeParseAsync({});
+      assert.isTrue(valid.success);
+
+      // A $push operation
+      valid = await relaxed.safeParseAsync({
+        array: 'foo',
+      });
+      assert.isTrue(valid.success);
+
+      // A $addToSet operation
+      valid = await relaxed.safeParseAsync({
+        array: { $each: ['foo'] },
+      });
+      assert.isTrue(valid.success);
+    });
+
     it('does not enforce length limits for arrays', async function () {
       const schema = z.object({
         array: z.array(nonEmptyString).max(1),


### PR DESCRIPTION
Even if a schema has a default, we still need to relax the inner type to make sure we handle arrays correctly.