### PR TITLE
Fixup issues discovered by schema validation

### DIFF
--- a/imports/server/discord.ts
+++ b/imports/server/discord.ts
@@ -37,7 +37,7 @@ class DiscordAPIClient {
       id: data.id,
       username: data.username,
       discriminator: data.discriminator,
-      avatar: data.avatar,
+      avatar: data.avatar ?? undefined,
     };
   };
 }

--- a/imports/server/discordClientRefresher.ts
+++ b/imports/server/discordClientRefresher.ts
@@ -130,8 +130,9 @@ class DiscordClientRefresher {
                 $set: {
                   'discordAccount.username': u.username,
                   'discordAccount.discriminator': u.discriminator,
-                  'discordAccount.avatar': u.avatar,
+                  ...u.avatar ? { 'discordAccount.avatar': u.avatar } : {},
                 },
+                ...u.avatar ? {} : { $unset: { 'discordAccount.avatar': 1 } },
               }, {
                 multi: true,
               });

--- a/imports/server/migrations/49-schema-fixups.ts
+++ b/imports/server/migrations/49-schema-fixups.ts
@@ -1,0 +1,26 @@
+import MeteorUsers from '../../lib/models/MeteorUsers';
+import Puzzles from '../../lib/models/Puzzles';
+import Migrations from './Migrations';
+
+Migrations.add({
+  version: 49,
+  name: 'Fix up database errors discovered by schema validation',
+  async up() {
+    // In 20-puzzle-multiple-answers.ts, we added the answers field but never
+    // unset the old "answer" field
+    for (const puzzle of Puzzles.find({ answer: { $exists: true } })) {
+      await Puzzles.updateAsync(puzzle._id, { $unset: { answer: 1 } });
+    }
+
+    // Prior to this revision, we would receive and store a "null" value for
+    // Discord avatar, when our schema wants that value to be absent
+    const users = MeteorUsers.find({
+      'discordAccount.avatar': { $eq: null, $exists: true },
+    });
+    for (const user of users) {
+      await MeteorUsers.updateAsync(user._id, {
+        $unset: { 'discordAccount.avatar': 1 },
+      });
+    }
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -47,3 +47,4 @@ import './45-folder-permission-level';
 import './46-per-user-document-activity';
 import './47-discord-role-grant-indexes';
 import './48-make-puzzle-tags-unique';
+import './49-schema-fixups';


### PR DESCRIPTION
When we migrated the database to support multiple answers, we never actually removed the old (singular) answer property. Additionally, the Discord API returns "null" for avatar when the user has no avatar, but we marked the field as optional (meaning it can be absent, but if present, must be a string).

Add a migration to fix both of those (and logic to handle the avatar properly going forward).