### PR TITLE
Refactor async lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -150,7 +150,7 @@
     "@typescript-eslint/prefer-namespace-keyword": "off",
 
     // This is especially useful in combination with the autofixer from
-    // jolly-roger/no-sync-mongo-methods, which intentionally introduces
+    // jolly-roger/no-disallowed-sync-methods, which intentionally introduces
     // potentially spurious dependencies, but it seems useful to be
     // stylistically consistent across the codebase.
     "@typescript-eslint/no-extra-parens": ["error", "all", {
@@ -262,7 +262,7 @@
         "node": true
       },
       "rules": {
-        "jolly-roger/no-sync-mongo-methods": "error"
+        "jolly-roger/no-disallowed-sync-methods": "error"
       }
     },
     {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -241,15 +241,6 @@
       "files": "**/client/**",
       "env": {
         "browser": true
-      },
-      "rules": {
-        "@typescript-eslint/no-restricted-imports": ["error", {
-          "patterns": [{
-            "group": ["**/schemas/**"],
-            "message": "Non-type imports of schemas are restricted to limit bloat of the client bundle",
-            "allowTypeImports": true
-          }]
-        }]
       }
     },
     {

--- a/eslint/index.ts
+++ b/eslint/index.ts
@@ -1,7 +1,7 @@
-import noSyncMongoMethods from './rules/no-sync-mongo-methods';
+import noDisallowedSyncMethods from './rules/no-disallowed-sync-methods';
 
 export = {
   rules: {
-    'no-sync-mongo-methods': noSyncMongoMethods,
+    'no-disallowed-sync-methods': noDisallowedSyncMethods,
   },
 };

--- a/imports/server/accounts.ts
+++ b/imports/server/accounts.ts
@@ -114,7 +114,7 @@ const DEFAULT_ENROLL_ACCOUNT_TEMPLATE = 'Hiya!\n' +
     'This message was sent to {{email}}';
 
 function makeView(user: Meteor.User, url: string) {
-  // eslint-disable-next-line jolly-roger/no-sync-mongo-methods
+  // eslint-disable-next-line jolly-roger/no-disallowed-sync-methods
   const hunts = Hunts.find({ _id: { $in: user.hunts } }).fetch();
   const email = user?.emails?.[0]?.address;
   const huntNames = hunts.map((h) => h.name);

--- a/tests/unit/imports/server/generateJsonSchema.ts
+++ b/tests/unit/imports/server/generateJsonSchema.ts
@@ -1,4 +1,4 @@
-/* eslint-disable jolly-roger/no-sync-mongo-methods -- We're doing a lot of
+/* eslint-disable jolly-roger/no-disallowed-sync-methods -- We're doing a lot of
    testing of failures, and Meteor's async methods currently throw instead of
    rejecting, so just using the sync methods for now makes everything easier */
 import { Mongo } from 'meteor/mongo';


### PR DESCRIPTION
As Meteor continues to introduce more async alternatives to synchronous methods, we will want to be able to ban more than just Mongo-specific methods, so make the rule a bit more generic.

(As an example, there's now an `Email.sendAsync` which we should ideally be using instead of `Email.send`, although it's not currently in the TypeScript type declarations)