### PR TITLE
Experiment with using branded types for hunt IDs

### DIFF
--- a/imports/FixtureHunt.ts
+++ b/imports/FixtureHunt.ts
@@ -1,5 +1,7 @@
 import type { GuessType } from './lib/models/Guesses';
 import type { HuntType } from './lib/models/Hunts';
+import type Hunts from './lib/models/Hunts';
+import { makeForeignKey } from './lib/models/Model';
 import type { PuzzleType } from './lib/models/Puzzles';
 import type { TagType } from './lib/models/Tags';
 
@@ -11,7 +13,7 @@ type FixtureHuntType = Pick<HuntType, '_id' | 'name'> & {
 };
 
 const FixtureHunt: FixtureHuntType = {
-  _id: 'S5BBzdFRnKSDktDwd',
+  _id: makeForeignKey<typeof Hunts>('S5BBzdFRnKSDktDwd'),
   name: 'Mystery Hunt 2018',
   tags: [
     { _id: 'QeJLufdCqv7rMSSbS', name: 'group:anger' },

--- a/imports/client/components/AnnouncementsPage.tsx
+++ b/imports/client/components/AnnouncementsPage.tsx
@@ -9,6 +9,7 @@ import styled from 'styled-components';
 import { calendarTimeFormat } from '../../lib/calendarTimeFormat';
 import Announcements from '../../lib/models/Announcements';
 import type { AnnouncementType } from '../../lib/models/Announcements';
+import type { HuntId } from '../../lib/models/Hunts';
 import Hunts from '../../lib/models/Hunts';
 import { indexedDisplayNames } from '../../lib/models/MeteorUsers';
 import { userMayAddAnnouncementToHunt } from '../../lib/permission_stubs';
@@ -44,7 +45,7 @@ const AnnouncementFormContainer = styled.div`
   }
 `;
 
-const AnnouncementForm = ({ huntId }: { huntId: string }) => {
+const AnnouncementForm = ({ huntId }: { huntId: HuntId }) => {
   const [message, setMessage] = useState<string>('');
   const [submitState, setSubmitState] = useState<AnnouncementFormSubmitState>(AnnouncementFormSubmitState.IDLE);
   const [errorMessage, setErrorMessage] = useState<string>('');
@@ -125,7 +126,7 @@ const Announcement = ({ announcement, displayName }: {
 };
 
 const AnnouncementsPage = () => {
-  const huntId = useParams<'huntId'>().huntId!;
+  const huntId = useParams<{ huntId: HuntId }>().huntId!;
   useBreadcrumb({ title: 'Announcements', path: `/hunts/${huntId}/announcements` });
 
   const announcementsLoading = useTypedSubscribe(announcementsForAnnouncementsPage, { huntId });

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -13,6 +13,7 @@ import styled from 'styled-components';
 import Flags from '../../Flags';
 import { RECENT_ACTIVITY_TIME_WINDOW_MS } from '../../lib/config/webrtc';
 import type { DiscordAccountType } from '../../lib/models/DiscordAccount';
+import type { HuntId } from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import CallHistories from '../../lib/models/mediasoup/CallHistories';
 import Peers from '../../lib/models/mediasoup/Peers';
@@ -94,7 +95,7 @@ const ChatterSection = styled.section`
 const ChatPeople = ({
   huntId, puzzleId, disabled, onHeightChange, callState, callDispatch,
 }: {
-  huntId: string;
+  huntId: HuntId;
   puzzleId: string;
   disabled: boolean;
   onHeightChange: () => void;

--- a/imports/client/components/FirehosePage.tsx
+++ b/imports/client/components/FirehosePage.tsx
@@ -15,6 +15,7 @@ import { shortCalendarTimeFormat } from '../../lib/calendarTimeFormat';
 import { indexedById } from '../../lib/listUtils';
 import type { ChatMessageType } from '../../lib/models/ChatMessages';
 import ChatMessages from '../../lib/models/ChatMessages';
+import type { HuntId } from '../../lib/models/Hunts';
 import { indexedDisplayNames } from '../../lib/models/MeteorUsers';
 import Puzzles from '../../lib/models/Puzzles';
 import type { PuzzleType } from '../../lib/models/Puzzles';
@@ -108,7 +109,7 @@ const MessagesPane = styled.div`
 `;
 
 const FirehosePage = () => {
-  const huntId = useParams<'huntId'>().huntId!;
+  const huntId = (useParams<{ huntId: HuntId }>().huntId)!;
   const [searchParams, setSearchParams] = useSearchParams();
   const searchString = searchParams.get('q') ?? '';
 

--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -22,7 +22,7 @@ import { indexedById } from '../../lib/listUtils';
 import Guesses from '../../lib/models/Guesses';
 import type { GuessType } from '../../lib/models/Guesses';
 import Hunts from '../../lib/models/Hunts';
-import type { HuntType } from '../../lib/models/Hunts';
+import type { HuntType, HuntId } from '../../lib/models/Hunts';
 import { indexedDisplayNames } from '../../lib/models/MeteorUsers';
 import Puzzles from '../../lib/models/Puzzles';
 import type { PuzzleType } from '../../lib/models/Puzzles';
@@ -290,7 +290,7 @@ const GuessBlock = React.memo(({
 });
 
 const GuessQueuePage = () => {
-  const huntId = useParams<'huntId'>().huntId!;
+  const huntId = useParams<{ huntId: HuntId }>().huntId!;
   const [searchParams, setSearchParams] = useSearchParams();
   const searchString = searchParams.get('q') ?? '';
 

--- a/imports/client/components/HuntApp.tsx
+++ b/imports/client/components/HuntApp.tsx
@@ -8,7 +8,7 @@ import {
   Outlet, useNavigate, useParams,
 } from 'react-router-dom';
 import Hunts from '../../lib/models/Hunts';
-import type { HuntType } from '../../lib/models/Hunts';
+import type { HuntType, HuntId } from '../../lib/models/Hunts';
 import { userMayAddUsersToHunt, userMayUpdateHunt } from '../../lib/permission_stubs';
 import huntForHuntApp from '../../lib/publications/huntForHuntApp';
 import addHuntUser from '../../methods/addHuntUser';
@@ -107,7 +107,7 @@ const HuntMemberError = React.memo(({ hunt, canJoin }: {
 });
 
 const HuntApp = React.memo(() => {
-  const huntId = useParams<'huntId'>().huntId!;
+  const huntId = useParams<{ huntId: HuntId }>().huntId!;
 
   const huntLoading = useTypedSubscribe(huntForHuntApp, { huntId });
   const loading = huntLoading();

--- a/imports/client/components/HuntEditPage.tsx
+++ b/imports/client/components/HuntEditPage.tsx
@@ -18,7 +18,7 @@ import Row from 'react-bootstrap/Row';
 import { useNavigate, useParams } from 'react-router-dom';
 import DiscordCache from '../../lib/models/DiscordCache';
 import Hunts from '../../lib/models/Hunts';
-import type { EditableHuntType, SavedDiscordObjectType } from '../../lib/models/Hunts';
+import type { EditableHuntType, SavedDiscordObjectType, HuntId } from '../../lib/models/Hunts';
 import Settings from '../../lib/models/Settings';
 import discordChannelsForConfiguredGuild from '../../lib/publications/discordChannelsForConfiguredGuild';
 import discordRolesForConfiguredGuild from '../../lib/publications/discordRolesForConfiguredGuild';
@@ -176,7 +176,7 @@ const DiscordRoleSelector = ({ guildId, ...rest }: DiscordSelectorParams & { gui
 };
 
 const HuntEditPage = () => {
-  const huntId = useParams<{ huntId: string }>().huntId;
+  const huntId = useParams<{ huntId: HuntId }>().huntId;
   const hunt = useTracker(() => (huntId ? Hunts.findOne(huntId) : null), [huntId]);
 
   useBreadcrumb({ title: huntId ? 'Edit Hunt' : 'Create Hunt', path: `/hunts/${huntId ? `${huntId}/edit` : 'new'}` });

--- a/imports/client/components/HuntProfileListPage.tsx
+++ b/imports/client/components/HuntProfileListPage.tsx
@@ -2,6 +2,7 @@ import { Meteor } from 'meteor/meteor';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 import React from 'react';
 import { useParams } from 'react-router-dom';
+import type { HuntId } from '../../lib/models/Hunts';
 import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import {
@@ -11,7 +12,7 @@ import { useBreadcrumb } from '../hooks/breadcrumb';
 import ProfileList from './ProfileList';
 
 const HuntProfileListPage = () => {
-  const huntId = useParams<'huntId'>().huntId!;
+  const huntId = useParams<{ huntId: HuntId }>().huntId!;
   useBreadcrumb({ title: 'Hunters', path: `/hunts/${huntId}/hunters` });
 
   const profilesLoading = useSubscribe('huntProfiles', huntId);

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -22,7 +22,7 @@ import Modal from 'react-bootstrap/Modal';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import isAdmin from '../../lib/isAdmin';
-import type { HuntType } from '../../lib/models/Hunts';
+import type { HuntId, HuntType } from '../../lib/models/Hunts';
 import { userIsOperatorForHunt } from '../../lib/permission_stubs';
 import demoteOperator from '../../methods/demoteOperator';
 import promoteOperator from '../../methods/promoteOperator';
@@ -66,7 +66,10 @@ type OperatorModalHandle = {
 };
 
 const PromoteOperatorModal = React.forwardRef((
-  { user, huntId }: { user: Meteor.User, huntId: string },
+  { user, huntId }: {
+    user: Meteor.User,
+    huntId: HuntId,
+  },
   forwardedRef: React.Ref<OperatorModalHandle>,
 ) => {
   const [visible, setVisible] = useState(true);
@@ -122,7 +125,10 @@ const PromoteOperatorModal = React.forwardRef((
 });
 
 const DemoteOperatorModal = React.forwardRef((
-  { user, huntId }: { user: Meteor.User, huntId: string },
+  { user, huntId }: {
+    user: Meteor.User,
+    huntId: HuntId,
+  },
   forwardedRef: React.Ref<OperatorModalHandle>,
 ) => {
   const [visible, setVisible] = useState(true);

--- a/imports/client/components/PuzzleActivity.tsx
+++ b/imports/client/components/PuzzleActivity.tsx
@@ -13,6 +13,7 @@ import { Sparklines, SparklinesLine, SparklinesSpots } from 'react-sparklines';
 import styled, { css } from 'styled-components';
 import { calendarTimeFormat } from '../../lib/calendarTimeFormat';
 import { ACTIVITY_GRANULARITY, ACTIVITY_SEGMENTS } from '../../lib/config/activityTracking';
+import type { HuntId } from '../../lib/models/Hunts';
 import relativeTimeFormat from '../../lib/relativeTimeFormat';
 import roundedTime from '../../lib/roundedTime';
 import ActivityBuckets from '../ActivityBuckets';
@@ -76,7 +77,7 @@ const PuzzleActivityDetailTimeRange = styled.div`
 `;
 
 interface PuzzleActivityProps {
-  huntId: string;
+  huntId: HuntId;
   puzzleId: string;
   unlockTime: Date;
 }

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -25,9 +25,10 @@ import ToggleButtonGroup from 'react-bootstrap/ToggleButtonGroup';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import { sortedBy } from '../../lib/listUtils';
+import type { HuntId } from '../../lib/models/Hunts';
 import Hunts from '../../lib/models/Hunts';
-import Puzzles from '../../lib/models/Puzzles';
 import type { PuzzleType } from '../../lib/models/Puzzles';
+import Puzzles from '../../lib/models/Puzzles';
 import Tags from '../../lib/models/Tags';
 import { userMayWritePuzzlesForHunt } from '../../lib/permission_stubs';
 import puzzleActivityForHunt from '../../lib/publications/puzzleActivityForHunt';
@@ -124,7 +125,7 @@ const PuzzleListToolbar = styled.div`
 const PuzzleListView = ({
   huntId, canAdd, canUpdate, loading,
 }: {
-  huntId: string
+  huntId: HuntId;
   canAdd: boolean;
   canUpdate: boolean;
   loading: boolean;
@@ -509,7 +510,7 @@ const StyledPuzzleListLinkLabel = styled.span`
 `;
 
 const PuzzleListPage = () => {
-  const huntId = useParams<'huntId'>().huntId!;
+  const huntId = useParams<{ huntId: HuntId }>().huntId!;
 
   // Assertion is safe because hunt is already subscribed and checked by HuntApp
   const hunt = useTracker(() => Hunts.findOne(huntId)!, [huntId]);

--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -12,6 +12,7 @@ import FormLabel from 'react-bootstrap/FormLabel';
 import Row from 'react-bootstrap/Row';
 import type { ActionMeta } from 'react-select';
 import type { GdriveMimeTypesType } from '../../lib/GdriveMimeTypes';
+import type { HuntId } from '../../lib/models/Hunts';
 import type { PuzzleType } from '../../lib/models/Puzzles';
 import type { TagType } from '../../lib/models/Tags';
 import LabelledRadioGroup from './LabelledRadioGroup';
@@ -26,7 +27,7 @@ const Creatable = React.lazy(() => import('react-select/creatable')) as typeof i
 type TagSelectOption = { value: string, label: string };
 
 export interface PuzzleModalFormSubmitPayload {
-  huntId: string;
+  huntId: HuntId;
   title: string;
   url: string | undefined;
   tags: string[];
@@ -47,7 +48,7 @@ export type PuzzleModalFormHandle = {
 const PuzzleModalForm = React.forwardRef(({
   huntId, puzzle, tags: propsTags, onSubmit, showOnMount,
 }: {
-  huntId: string;
+  huntId: HuntId;
   puzzle?: PuzzleType;
   // All known tags for this hunt
   tags: TagType[];

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -54,16 +54,17 @@ import { messageDingsUser } from '../../lib/dingwordLogic';
 import { indexedById, sortedBy } from '../../lib/listUtils';
 import type { ChatMessageType } from '../../lib/models/ChatMessages';
 import ChatMessages from '../../lib/models/ChatMessages';
-import Documents from '../../lib/models/Documents';
 import type { DocumentType } from '../../lib/models/Documents';
-import Guesses from '../../lib/models/Guesses';
+import Documents from '../../lib/models/Documents';
 import type { GuessType } from '../../lib/models/Guesses';
+import Guesses from '../../lib/models/Guesses';
+import type { HuntId } from '../../lib/models/Hunts';
 import Hunts from '../../lib/models/Hunts';
 import MeteorUsers, { indexedDisplayNames } from '../../lib/models/MeteorUsers';
-import Puzzles from '../../lib/models/Puzzles';
 import type { PuzzleType } from '../../lib/models/Puzzles';
-import Tags from '../../lib/models/Tags';
+import Puzzles from '../../lib/models/Puzzles';
 import type { TagType } from '../../lib/models/Tags';
+import Tags from '../../lib/models/Tags';
 import nodeIsMention from '../../lib/nodeIsMention';
 import nodeIsText from '../../lib/nodeIsText';
 import { userMayWritePuzzlesForHunt } from '../../lib/permission_stubs';
@@ -107,10 +108,8 @@ import PuzzleModalForm from './PuzzleModalForm';
 import SplitPanePlus from './SplitPanePlus';
 import TagList from './TagList';
 import {
-  GuessConfidence,
+  formatConfidence, formatGuessDirection, GuessConfidence,
   GuessDirection,
-  formatGuessDirection,
-  formatConfidence,
 } from './guessDetails';
 import Breakable from './styling/Breakable';
 import FixedLayout from './styling/FixedLayout';
@@ -537,7 +536,7 @@ const ChatInput = React.memo(({
 }: {
   onHeightChange: () => void;
   onMessageSent: () => void;
-  huntId: string;
+  huntId: HuntId;
   puzzleId: string;
   disabled: boolean;
 }) => {
@@ -648,7 +647,7 @@ const ChatSection = React.forwardRef(({
   disabled: boolean;
   displayNames: Map<string, string>;
   puzzleId: string;
-  huntId: string;
+  huntId: HuntId;
   callState: CallState;
   callDispatch: React.Dispatch<Action>;
   selfUser: Meteor.User;
@@ -1709,7 +1708,11 @@ const PuzzlePageMultiplayerDocument = React.memo(({ document }: {
 
 const PuzzleDeletedModal = ({
   puzzleId, huntId, replacedBy,
-}: { puzzleId: string, huntId: string, replacedBy?: string }) => {
+}: {
+  puzzleId: string,
+  huntId: HuntId,
+  replacedBy?: string,
+}) => {
   const canUpdate = useTracker(() => userMayWritePuzzlesForHunt(Meteor.user(), Hunts.findOne(huntId)), [huntId]);
 
   const replacement = useTracker(() => Puzzles.findOneAllowingDeleted(replacedBy), [replacedBy]);
@@ -1775,7 +1778,7 @@ const PuzzlePage = React.memo(() => {
   const [sidebarWidth, setSidebarWidth] = useState<number>(DefaultSidebarWidth);
   const [isDesktop, setIsDesktop] = useState<boolean>(window.innerWidth >= MinimumDesktopWidth);
 
-  const huntId = useParams<'huntId'>().huntId!;
+  const huntId = (useParams<{ huntId: HuntId }>().huntId)!;
   const puzzleId = useParams<'puzzleId'>().puzzleId!;
 
   // Add the current user to the collection of people viewing this puzzle.

--- a/imports/client/components/RelatedPuzzleGroup.tsx
+++ b/imports/client/components/RelatedPuzzleGroup.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback, useEffect, useRef, useState,
 } from 'react';
 import styled from 'styled-components';
+import type { HuntId } from '../../lib/models/Hunts';
 import type { TagType } from '../../lib/models/Tags';
 import type { PuzzleGroup } from '../../lib/puzzle-sort-and-group';
 import { useHuntPuzzleListCollapseGroup } from '../hooks/persisted-state';
@@ -45,7 +46,7 @@ const NoSharedTagLabel = styled.div`
 const RelatedPuzzleGroup = ({
   huntId, group, noSharedTagLabel = '(no tag)', allTags, includeCount, canUpdate, suppressedTagIds, trackPersistentExpand,
 }: {
-  huntId: string;
+  huntId: HuntId;
   group: PuzzleGroup;
   // noSharedTagLabel is used to label the group only if sharedTag is undefined.
   noSharedTagLabel?: string;

--- a/imports/client/components/UserInvitePage.tsx
+++ b/imports/client/components/UserInvitePage.tsx
@@ -11,6 +11,7 @@ import FormLabel from 'react-bootstrap/FormLabel';
 import Row from 'react-bootstrap/Row';
 import { useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import type { HuntId } from '../../lib/models/Hunts';
 import Hunts from '../../lib/models/Hunts';
 import { userMayBulkAddToHunt } from '../../lib/permission_stubs';
 import addHuntUser from '../../methods/addHuntUser';
@@ -22,7 +23,7 @@ const BulkError = styled.p`
 `;
 
 const UserInvitePage = () => {
-  const huntId = useParams<'huntId'>().huntId!;
+  const huntId = (useParams<{ huntId: HuntId }>().huntId)!;
   const navigate = useNavigate();
   useBreadcrumb({ title: 'Invite', path: `/hunts/${huntId}/hunters/invite` });
   const [submitting, setSubmitting] = useState<boolean>(false);

--- a/imports/client/hooks/persisted-state.ts
+++ b/imports/client/hooks/persisted-state.ts
@@ -1,12 +1,13 @@
 import type { SetStateAction } from 'react';
 import { useCallback } from 'react';
 import createPersistedState from 'use-persisted-state';
+import type { HuntId } from '../../lib/models/Hunts';
 
 export type OperatorActionsHiddenState = Record<string /* huntId */, boolean>;
 export const useOperatorActionsHidden =
   createPersistedState<OperatorActionsHiddenState>('operatorActionsHidden');
 
-export const useOperatorActionsHiddenForHunt = (huntId: string) => {
+export const useOperatorActionsHiddenForHunt = (huntId: HuntId) => {
   const [operatorActionsHidden, setOperatorActionsHidden] = useOperatorActionsHidden();
   return [
     operatorActionsHidden?.[huntId] ?? false,
@@ -32,7 +33,7 @@ export const usePuzzleListState = createPersistedState<Record<string /* huntId *
 const defaultPuzzleListState = () => {
   return { displayMode: 'group', showSolved: true, collapseGroups: {} } as PuzzleListState;
 };
-export const useHuntPuzzleListState = (huntId: string) => {
+export const useHuntPuzzleListState = (huntId: HuntId) => {
   const [puzzleListView, setPuzzleListView] = usePuzzleListState();
   return [
     puzzleListView?.[huntId] ?? defaultPuzzleListState(),
@@ -48,7 +49,7 @@ export const useHuntPuzzleListState = (huntId: string) => {
   ] as const;
 };
 
-export const useHuntPuzzleListDisplayMode = (huntId: string) => {
+export const useHuntPuzzleListDisplayMode = (huntId: HuntId) => {
   const [huntPuzzleListView, setHuntPuzzleListView] = useHuntPuzzleListState(huntId);
   return [
     huntPuzzleListView.displayMode,
@@ -64,7 +65,7 @@ export const useHuntPuzzleListDisplayMode = (huntId: string) => {
   ] as const;
 };
 
-export const useHuntPuzzleListShowSolved = (huntId: string) => {
+export const useHuntPuzzleListShowSolved = (huntId: HuntId) => {
   const [huntPuzzleListView, setHuntPuzzleListView] = useHuntPuzzleListState(huntId);
   return [
     huntPuzzleListView.showSolved,
@@ -80,7 +81,7 @@ export const useHuntPuzzleListShowSolved = (huntId: string) => {
   ] as const;
 };
 
-export const useHuntPuzzleListCollapseGroups = (huntId: string) => {
+export const useHuntPuzzleListCollapseGroups = (huntId: HuntId) => {
   const [huntPuzzleListView, setHuntPuzzleListView] = useHuntPuzzleListState(huntId);
   return [
     huntPuzzleListView.collapseGroups,
@@ -96,7 +97,10 @@ export const useHuntPuzzleListCollapseGroups = (huntId: string) => {
   ] as const;
 };
 
-export const useHuntPuzzleListCollapseGroup = (huntId: string, tagId: string) => {
+export const useHuntPuzzleListCollapseGroup = (
+  huntId: HuntId,
+  tagId: string
+) => {
   const [huntPuzzleListCollapseGroups, setHuntPuzzleListCollapseGroups] =
     useHuntPuzzleListCollapseGroups(huntId);
   return [

--- a/imports/client/hooks/useCallState.ts
+++ b/imports/client/hooks/useCallState.ts
@@ -3,19 +3,20 @@ import { useFind, useTracker } from 'meteor/react-meteor-data';
 import type { types } from 'mediasoup-client';
 import type React from 'react';
 import {
-  useEffect, useMemo, useReducer, useRef, useState, useCallback,
+  useCallback, useEffect, useMemo, useReducer, useRef, useState,
 } from 'react';
 import { logger as defaultLogger } from '../../Logger';
 import { groupedBy } from '../../lib/listUtils';
+import type { HuntId } from '../../lib/models/Hunts';
 import ConnectAcks from '../../lib/models/mediasoup/ConnectAcks';
 import Consumers from '../../lib/models/mediasoup/Consumers';
-import Peers from '../../lib/models/mediasoup/Peers';
 import type { PeerType } from '../../lib/models/mediasoup/Peers';
+import Peers from '../../lib/models/mediasoup/Peers';
 import ProducerServers from '../../lib/models/mediasoup/ProducerServers';
-import Routers from '../../lib/models/mediasoup/Routers';
 import type { RouterType } from '../../lib/models/mediasoup/Routers';
-import Transports from '../../lib/models/mediasoup/Transports';
+import Routers from '../../lib/models/mediasoup/Routers';
 import type { TransportType } from '../../lib/models/mediasoup/Transports';
+import Transports from '../../lib/models/mediasoup/Transports';
 import mediasoupAckConsumer from '../../methods/mediasoupAckConsumer';
 import mediasoupAckPeerRemoteMute from '../../methods/mediasoupAckPeerRemoteMute';
 import mediasoupConnectTransport from '../../methods/mediasoupConnectTransport';
@@ -400,7 +401,7 @@ type ConsumerState = {
 }
 
 const useCallState = ({ huntId, puzzleId, tabId }: {
-  huntId: string,
+  huntId: HuntId,
   puzzleId: string,
   tabId: string,
 }): [CallState, React.Dispatch<Action>] => {

--- a/imports/client/hooks/useSubscribeAvatars.ts
+++ b/imports/client/hooks/useSubscribeAvatars.ts
@@ -1,5 +1,6 @@
 import { useSubscribe } from 'meteor/react-meteor-data';
+import type { HuntId } from '../../lib/models/Hunts';
 
-export default function useSubscribeAvatars(huntId: string) {
+export default function useSubscribeAvatars(huntId: HuntId) {
   return useSubscribe('avatars', huntId);
 }

--- a/imports/client/hooks/useSubscribeDisplayNames.ts
+++ b/imports/client/hooks/useSubscribeDisplayNames.ts
@@ -1,5 +1,6 @@
 import { useSubscribe } from 'meteor/react-meteor-data';
+import type { HuntId } from '../../lib/models/Hunts';
 
-export default function useSubscribeDisplayNames(huntId: string) {
+export default function useSubscribeDisplayNames(huntId: HuntId) {
   return useSubscribe('displayNames', huntId);
 }

--- a/imports/lib/config/activityTracking.ts
+++ b/imports/lib/config/activityTracking.ts
@@ -1,4 +1,5 @@
 import { Meteor } from 'meteor/meteor';
+import type { HuntId } from '../models/Hunts';
 
 export const ACTIVITY_GRANULARITY = Meteor.isDevelopment ?
   // Set granularity to be quite low in development. Note that this will not
@@ -12,7 +13,7 @@ export const ACTIVITY_SEGMENTS = 36;
 
 export type PublishedBucket = {
   _id: string;
-  hunt: string;
+  hunt: HuntId;
   puzzle: string;
   ts: Date;
 

--- a/imports/lib/models/Announcements.ts
+++ b/imports/lib/models/Announcements.ts
@@ -7,7 +7,7 @@ import withCommon from './withCommon';
 // A broadcast message from a hunt operator to be displayed
 // to all participants in the specified hunt.
 const Announcement = withCommon(z.object({
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
   message: nonEmptyString,
 }));
 

--- a/imports/lib/models/ChatMessages.ts
+++ b/imports/lib/models/ChatMessages.ts
@@ -34,7 +34,7 @@ export function contentFromMessage(msg: string): ChatMessageContentType {
 }
 
 const ChatMessage = withCommon(z.object({
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
   // The puzzle to which this chat was sent.
   puzzle: foreignKey,
   // The message contents.

--- a/imports/lib/models/ChatNotifications.ts
+++ b/imports/lib/models/ChatNotifications.ts
@@ -17,7 +17,7 @@ const ChatNotification = withCommon(z.object({
   // The puzzle to which this chat was sent.
   puzzle: foreignKey,
   // The hunt in which the puzzle resides.
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
   // The message content, if chat message v2.
   content: ChatMessageContent,
   // The date this message was sent.  Used for ordering chats in the log.

--- a/imports/lib/models/DocumentActivities.ts
+++ b/imports/lib/models/DocumentActivities.ts
@@ -7,7 +7,7 @@ import { foreignKey } from './customTypes';
    server, not by users */
 export const DocumentActivity = z.object({
   ts: z.date(), /* rounded to ACTIVITY_GRANULARITY */
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
   puzzle: foreignKey,
   document: foreignKey,
   // user can be undefined if we aren't able to match an activity record back to

--- a/imports/lib/models/Documents.ts
+++ b/imports/lib/models/Documents.ts
@@ -5,7 +5,7 @@ import { foreignKey, nonEmptyString } from './customTypes';
 import withCommon from './withCommon';
 
 const DocumentSchema = withCommon(z.object({
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
   puzzle: foreignKey,
 }).and(z.discriminatedUnion('provider', [
   z.object({

--- a/imports/lib/models/Guesses.ts
+++ b/imports/lib/models/Guesses.ts
@@ -16,7 +16,7 @@ export const GuessStates = z.enum(['pending', 'intermediate', 'correct', 'incorr
 
 const Guess = withCommon(z.object({
   // Denormalized in so subscriptions can filter on hunt without having to join on Puzzles
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
   // The puzzle this guess is for.
   puzzle: foreignKey,
   // The text of this guess.

--- a/imports/lib/models/Hunts.ts
+++ b/imports/lib/models/Hunts.ts
@@ -1,8 +1,8 @@
 import { Match } from 'meteor/check';
 import { z } from 'zod';
-import type { ModelType } from './Model';
+import type { ForeignKeyType, ModelType } from './Model';
 import SoftDeletedModel from './SoftDeletedModel';
-import { nonEmptyString, snowflake } from './customTypes';
+import { nonEmptyString, snowflake, stringId } from './customTypes';
 import withCommon from './withCommon';
 
 export const SavedDiscordObjectFields = z.object({
@@ -66,7 +66,8 @@ export const HuntPattern = {
   memberDiscordRole: Match.Optional(SavedDiscordObjectPattern),
 };
 
-const Hunts = new SoftDeletedModel('jr_hunts', Hunt);
+const Hunts = new SoftDeletedModel('jr_hunts', Hunt, stringId.brand('jr_hunts'));
 export type HuntType = ModelType<typeof Hunts>;
+export type HuntId = ForeignKeyType<typeof Hunts>;
 
 export default Hunts;

--- a/imports/lib/models/PendingAnnouncements.ts
+++ b/imports/lib/models/PendingAnnouncements.ts
@@ -7,7 +7,7 @@ import withCommon from './withCommon';
 // Broadcast announcements that have not yet been viewed by a given
 // user
 const PendingAnnouncement = withCommon(z.object({
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
   announcement: foreignKey,
   user: foreignKey,
 }));

--- a/imports/lib/models/Puzzles.ts
+++ b/imports/lib/models/Puzzles.ts
@@ -13,7 +13,7 @@ attachCustomJsonSchema(tagList, {
 });
 
 const Puzzle = withCommon(z.object({
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
   tags: tagList,
   title: nonEmptyString,
   url: z.string().url().optional(),

--- a/imports/lib/models/SoftDeletedModel.ts
+++ b/imports/lib/models/SoftDeletedModel.ts
@@ -57,14 +57,16 @@ const injectOptions = <Opts extends Mongo.Options<any>>(
 
 class SoftDeletedModel<
   Schema extends MongoRecordZodType,
+  Name extends string,
   IdSchema extends z.ZodTypeAny = typeof stringId
 > extends Model<
     Schema extends z.ZodObject<infer Shape, infer UnknownKeys, infer Catchall> ?
       z.ZodObject<z.extendShape<Shape, { deleted: typeof deleted }>, UnknownKeys, Catchall> :
       z.ZodIntersection<Schema, z.ZodObject<{ deleted: typeof deleted }>>,
+    Name,
     IdSchema
   > {
-  constructor(name: string, schema: Schema, idSchema?: IdSchema) {
+  constructor(name: Name, schema: Schema, idSchema?: IdSchema) {
     super(
       name,
       schema instanceof z.ZodObject ?
@@ -98,7 +100,7 @@ class SoftDeletedModel<
     options?: O,
   ): Mongo.Cursor<SelectorToResultType<ModelType<this>, S>> {
     return super.find(
-      injectQuery(selector, { deleted: false }) as any,
+      injectQuery(selector, { deleted: false } as S) as any,
       injectOptions(options)
     ) as any;
   }
@@ -108,7 +110,7 @@ class SoftDeletedModel<
     options?: O,
   ): SelectorToResultType<ModelType<this>, S> | undefined {
     return super.findOne(
-      injectQuery(selector, { deleted: false }) as any,
+      injectQuery(selector, { deleted: false } as S) as any,
       injectOptions(options)
     ) as any;
   }
@@ -118,7 +120,7 @@ class SoftDeletedModel<
     options?: O,
   ): Promise<SelectorToResultType<ModelType<this>, S> | undefined> {
     return super.findOneAsync(
-      injectQuery(selector, { deleted: false }) as any,
+      injectQuery(selector, { deleted: false } as S) as any,
       injectOptions(options)
     ) as any;
   }
@@ -170,7 +172,7 @@ class SoftDeletedModel<
     options?: O,
   ): Mongo.Cursor<SelectorToResultType<ModelType<this>, S>> {
     return super.find(
-      injectQuery(selector, { deleted: true }) as any,
+      injectQuery(selector, { deleted: true } as S) as any,
       injectOptions(options)
     ) as any;
   }
@@ -183,7 +185,7 @@ class SoftDeletedModel<
     options?: O,
   ): SelectorToResultType<ModelType<this>, S> | undefined {
     return super.findOne(
-      injectQuery(selector, { deleted: true }) as any,
+      injectQuery(selector, { deleted: true } as S) as any,
       injectOptions(options)
     ) as any;
   }
@@ -196,7 +198,7 @@ class SoftDeletedModel<
     options?: O,
   ): Promise<SelectorToResultType<ModelType<this>, S> | undefined> {
     return super.findOneAsync(
-      injectQuery(selector, { deleted: true }) as any,
+      injectQuery(selector, { deleted: true } as S) as any,
       injectOptions(options)
     ) as any;
   }

--- a/imports/lib/models/Tags.ts
+++ b/imports/lib/models/Tags.ts
@@ -6,7 +6,7 @@ import withCommon from './withCommon';
 
 const Tag = withCommon(z.object({
   name: nonEmptyString,
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
 }));
 
 const Tags = new SoftDeletedModel('jr_tags', Tag);

--- a/imports/lib/models/mediasoup/CallHistories.ts
+++ b/imports/lib/models/mediasoup/CallHistories.ts
@@ -6,7 +6,7 @@ import { foreignKey } from '../customTypes';
 // Don't use the BaseCodec here - unlike most database objects, this isn't
 // manipulated by users, so many of the fields don't make sense
 const CallHistory = z.object({
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
   call: foreignKey,
   lastActivity: z.date(),
 });

--- a/imports/lib/models/mediasoup/Peers.ts
+++ b/imports/lib/models/mediasoup/Peers.ts
@@ -9,7 +9,7 @@ import withCommon from '../withCommon';
 // create a corresponding Room on the same server.
 const Peer = withCommon(z.object({
   createdServer: foreignKey,
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
   call: foreignKey,
   // Tab ID doesn't refer to a database record, so it's technically not a foreign key
   tab: z.string().regex(Id),

--- a/imports/lib/models/mediasoup/Rooms.ts
+++ b/imports/lib/models/mediasoup/Rooms.ts
@@ -8,7 +8,7 @@ import withCommon from '../withCommon';
 // mediasoup integration to create a router.
 
 const Room = withCommon(z.object({
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
   call: foreignKey,
   routedServer: foreignKey,
 }));

--- a/imports/lib/models/mediasoup/Routers.ts
+++ b/imports/lib/models/mediasoup/Routers.ts
@@ -5,7 +5,7 @@ import { foreignKey, nonEmptyString } from '../customTypes';
 import withCommon from '../withCommon';
 
 const Router = withCommon(z.object({
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
   call: foreignKey,
   createdServer: foreignKey,
   routerId: z.string().uuid(), // mediasoup identifier

--- a/imports/lib/permission_stubs.ts
+++ b/imports/lib/permission_stubs.ts
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import isAdmin, { GLOBAL_SCOPE } from './isAdmin';
-import type { HuntType } from './models/Hunts';
+import type { HuntId, HuntType } from './models/Hunts';
 import MeteorUsers from './models/MeteorUsers';
 
 function isOperatorForHunt(user: Pick<Meteor.User, 'roles'>, hunt: Pick<HuntType, '_id'>): boolean {
@@ -34,7 +34,7 @@ export function userIsOperatorForHunt(
 
 export function huntsUserIsOperatorFor(
   user: Pick<Meteor.User, 'roles'> | null | undefined
-): Set<string> {
+): Set<HuntId> {
   if (!user?.roles) {
     return new Set();
   }
@@ -42,9 +42,9 @@ export function huntsUserIsOperatorFor(
   return Object.entries(user.roles)
     .filter(([huntId, roles]) => huntId !== GLOBAL_SCOPE && roles?.includes('operator'))
     .reduce((acc, [huntId]) => {
-      acc.add(huntId);
+      acc.add(huntId as HuntId);
       return acc;
-    }, new Set<string>());
+    }, new Set<HuntId>());
 }
 
 // admins and operators are always allowed to join someone to a hunt

--- a/imports/lib/publications/announcementsForAnnouncementsPage.ts
+++ b/imports/lib/publications/announcementsForAnnouncementsPage.ts
@@ -1,5 +1,6 @@
+import type { HuntId } from '../models/Hunts';
 import TypedPublication from './TypedPublication';
 
-export default new TypedPublication<{ huntId: string }>(
+export default new TypedPublication<{ huntId: HuntId }>(
   'Announcements.publications.forAnnouncementsPage'
 );

--- a/imports/lib/publications/chatMessagesForFirehose.ts
+++ b/imports/lib/publications/chatMessagesForFirehose.ts
@@ -1,5 +1,6 @@
+import type { HuntId } from '../models/Hunts';
 import TypedPublication from './TypedPublication';
 
-export default new TypedPublication<{ huntId: string }>(
+export default new TypedPublication<{ huntId: HuntId }>(
   'ChatMessages.publications.forFirehose'
 );

--- a/imports/lib/publications/chatMessagesForPuzzle.ts
+++ b/imports/lib/publications/chatMessagesForPuzzle.ts
@@ -1,5 +1,6 @@
+import type { HuntId } from '../models/Hunts';
 import TypedPublication from './TypedPublication';
 
-export default new TypedPublication<{ puzzleId: string, huntId: string }>(
+export default new TypedPublication<{ puzzleId: string, huntId: HuntId }>(
   'ChatMessages.publications.forPuzzle'
 );

--- a/imports/lib/publications/guessesForGuessQueue.ts
+++ b/imports/lib/publications/guessesForGuessQueue.ts
@@ -1,5 +1,6 @@
+import type { HuntId } from '../models/Hunts';
 import TypedPublication from './TypedPublication';
 
-export default new TypedPublication<{ huntId: string }>(
+export default new TypedPublication<{ huntId: HuntId }>(
   'Guesses.publications.forGuessQueue'
 );

--- a/imports/lib/publications/huntForHuntApp.ts
+++ b/imports/lib/publications/huntForHuntApp.ts
@@ -1,5 +1,6 @@
+import type { HuntId } from '../models/Hunts';
 import TypedPublication from './TypedPublication';
 
-export default new TypedPublication<{ huntId: string }>(
+export default new TypedPublication<{ huntId: HuntId }>(
   'Hunts.publications.forHuntApp'
 );

--- a/imports/lib/publications/puzzleActivityForHunt.ts
+++ b/imports/lib/publications/puzzleActivityForHunt.ts
@@ -1,5 +1,6 @@
+import type { HuntId } from '../models/Hunts';
 import TypedPublication from './TypedPublication';
 
-export default new TypedPublication<{ huntId: string }>(
+export default new TypedPublication<{ huntId: HuntId }>(
   'PuzzleActivity.publications.forHunt'
 );

--- a/imports/lib/publications/puzzleForPuzzlePage.ts
+++ b/imports/lib/publications/puzzleForPuzzlePage.ts
@@ -1,5 +1,6 @@
+import type { HuntId } from '../models/Hunts';
 import TypedPublication from './TypedPublication';
 
-export default new TypedPublication<{ puzzleId: string, huntId: string }>(
+export default new TypedPublication<{ puzzleId: string, huntId: HuntId }>(
   'Puzzles.publications.forPuzzlePage'
 );

--- a/imports/lib/publications/puzzlesForHunt.ts
+++ b/imports/lib/publications/puzzlesForHunt.ts
@@ -1,5 +1,9 @@
+import type { HuntId } from '../models/Hunts';
 import TypedPublication from './TypedPublication';
 
-export default new TypedPublication<{ huntId: string, includeDeleted?: boolean }>(
+export default new TypedPublication<{
+  huntId: HuntId,
+  includeDeleted?: boolean,
+}>(
   'Puzzles.publications.forHunt'
 );

--- a/imports/lib/publications/puzzlesForPuzzleList.ts
+++ b/imports/lib/publications/puzzlesForPuzzleList.ts
@@ -1,5 +1,9 @@
+import type { HuntId } from '../models/Hunts';
 import TypedPublication from './TypedPublication';
 
-export default new TypedPublication<{ huntId: string, includeDeleted?: boolean }>(
+export default new TypedPublication<{
+  huntId: HuntId,
+  includeDeleted?: boolean
+}>(
   'Puzzles.publications.forPuzzleList'
 );

--- a/imports/methods/addHuntUser.ts
+++ b/imports/methods/addHuntUser.ts
@@ -1,5 +1,6 @@
+import type { HuntId } from '../lib/models/Hunts';
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<{ huntId: string, email: string }, void>(
+export default new TypedMethod<{ huntId: HuntId, email: string }, void>(
   'Hunts.methods.addUser'
 );

--- a/imports/methods/bulkAddHuntUsers.ts
+++ b/imports/methods/bulkAddHuntUsers.ts
@@ -1,5 +1,6 @@
+import type { HuntId } from '../lib/models/Hunts';
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<{ huntId: string, emails: string[] }, void>(
+export default new TypedMethod<{ huntId: HuntId, emails: string[] }, void>(
   'Hunts.methods.bulkAddUsers'
 );

--- a/imports/methods/createHunt.ts
+++ b/imports/methods/createHunt.ts
@@ -1,6 +1,6 @@
-import type { EditableHuntType } from '../lib/models/Hunts';
+import type { EditableHuntType, HuntId } from '../lib/models/Hunts';
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<EditableHuntType, string>(
+export default new TypedMethod<EditableHuntType, HuntId>(
   'Hunts.methods.create'
 );

--- a/imports/methods/createPuzzle.ts
+++ b/imports/methods/createPuzzle.ts
@@ -1,8 +1,9 @@
 import type { GdriveMimeTypesType } from '../lib/GdriveMimeTypes';
+import type { HuntId } from '../lib/models/Hunts';
 import TypedMethod from './TypedMethod';
 
 export default new TypedMethod<{
-  huntId: string,
+  huntId: HuntId,
   title: string,
   url?: string,
   tags: string[],

--- a/imports/methods/demoteOperator.ts
+++ b/imports/methods/demoteOperator.ts
@@ -1,5 +1,9 @@
+import type { HuntId } from '../lib/models/Hunts';
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<{ targetUserId: string, huntId: string }, void>(
+export default new TypedMethod<{
+  targetUserId: string,
+  huntId: HuntId,
+}, void>(
   'Users.method.demoteOperator'
 );

--- a/imports/methods/destroyHunt.ts
+++ b/imports/methods/destroyHunt.ts
@@ -1,5 +1,6 @@
+import type { HuntId } from '../lib/models/Hunts';
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<{ huntId: string }, void>(
+export default new TypedMethod<{ huntId: HuntId }, void>(
   'Hunts.methods.destroy'
 );

--- a/imports/methods/postAnnouncement.ts
+++ b/imports/methods/postAnnouncement.ts
@@ -1,5 +1,6 @@
+import type { HuntId } from '../lib/models/Hunts';
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<{ huntId: string, message: string }, void>(
+export default new TypedMethod<{ huntId: HuntId, message: string }, void>(
   'Announcements.methods.post'
 );

--- a/imports/methods/promoteOperator.ts
+++ b/imports/methods/promoteOperator.ts
@@ -1,5 +1,9 @@
+import type { HuntId } from '../lib/models/Hunts';
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<{ targetUserId: string, huntId: string }, void>(
+export default new TypedMethod<{
+  targetUserId: string,
+  huntId: HuntId
+}, void>(
   'Users.method.promoteOperator'
 );

--- a/imports/methods/syncHuntDiscordRole.ts
+++ b/imports/methods/syncHuntDiscordRole.ts
@@ -1,5 +1,6 @@
+import type { HuntId } from '../lib/models/Hunts';
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<{ huntId: string }, void>(
+export default new TypedMethod<{ huntId: HuntId }, void>(
   'Hunts.methods.syncDiscordRole'
 );

--- a/imports/methods/undestroyHunt.ts
+++ b/imports/methods/undestroyHunt.ts
@@ -1,5 +1,6 @@
+import type { HuntId } from '../lib/models/Hunts';
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<{ huntId: string }, void>(
+export default new TypedMethod<{ huntId: HuntId }, void>(
   'Hunts.methods.undestroy'
 );

--- a/imports/methods/updateHunt.ts
+++ b/imports/methods/updateHunt.ts
@@ -1,6 +1,9 @@
-import type { EditableHuntType } from '../lib/models/Hunts';
+import type { EditableHuntType, HuntId } from '../lib/models/Hunts';
 import TypedMethod from './TypedMethod';
 
-export default new TypedMethod<{ huntId: string, value: EditableHuntType }, void>(
+export default new TypedMethod<{
+  huntId: HuntId,
+  value: EditableHuntType,
+}, void>(
   'Hunts.methods.update'
 );

--- a/imports/server/addUsersToDiscordRole.ts
+++ b/imports/server/addUsersToDiscordRole.ts
@@ -1,6 +1,7 @@
 import Flags from '../Flags';
 import Logger from '../Logger';
 import DiscordRoleGrants from '../lib/models/DiscordRoleGrants';
+import type { HuntId } from '../lib/models/Hunts';
 import Hunts from '../lib/models/Hunts';
 import MeteorUsers from '../lib/models/MeteorUsers';
 import Settings from '../lib/models/Settings';
@@ -8,7 +9,7 @@ import { DiscordBot } from './discord';
 
 export default async (
   userIds: string[],
-  huntId: string,
+  huntId: HuntId,
   { force = true }: { force?: boolean } = {}
 ) => {
   if (Flags.active('disable.discord')) {

--- a/imports/server/gdrive.ts
+++ b/imports/server/gdrive.ts
@@ -6,6 +6,7 @@ import type { GdriveMimeTypesType } from '../lib/GdriveMimeTypes';
 import GdriveMimeTypes from '../lib/GdriveMimeTypes';
 import Documents from '../lib/models/Documents';
 import FolderPermissions from '../lib/models/FolderPermissions';
+import type { HuntId } from '../lib/models/Hunts';
 import Hunts from '../lib/models/Hunts';
 import type { SettingType } from '../lib/models/Settings';
 import Settings from '../lib/models/Settings';
@@ -203,7 +204,7 @@ export async function ensureHuntFolder(hunt: { _id: string, name: string }) {
 }
 
 export async function ensureHuntFolderPermission(
-  huntId: string,
+  huntId: HuntId,
   userId: string,
   googleAccount: string,
 ) {
@@ -232,7 +233,7 @@ export async function ensureHuntFolderPermission(
 export async function ensureDocument(puzzle: {
   _id: string,
   title: string,
-  hunt: string,
+  hunt: HuntId,
 }, type: GdriveMimeTypesType = 'spreadsheet') {
   const hunt = await Hunts.findOneAllowingDeletedAsync(puzzle.hunt);
   const folderId = hunt ? await ensureHuntFolder(hunt) : undefined;

--- a/imports/server/getOrCreateTagByName.ts
+++ b/imports/server/getOrCreateTagByName.ts
@@ -1,9 +1,13 @@
 import Logger from '../Logger';
+import type { HuntId } from '../lib/models/Hunts';
 import Tags from '../lib/models/Tags';
 
-export default async function getOrCreateTagByName(huntId: string, name: string): Promise<{
+export default async function getOrCreateTagByName(
+  huntId: HuntId,
+  name: string
+): Promise<{
   _id: string,
-  hunt: string,
+  hunt: HuntId,
   name: string,
 }> {
   const existingTag = await Tags.findOneAsync({ hunt: huntId, name });

--- a/imports/server/mediasoup-api.ts
+++ b/imports/server/mediasoup-api.ts
@@ -4,6 +4,7 @@ import Flags from '../Flags';
 import Logger from '../Logger';
 import Hunts from '../lib/models/Hunts';
 import MeteorUsers from '../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../lib/models/Model';
 import Puzzles from '../lib/models/Puzzles';
 import Servers from '../lib/models/Servers';
 import CallHistories from '../lib/models/mediasoup/CallHistories';
@@ -83,7 +84,7 @@ Meteor.publish('mediasoup:debug', async function () {
 });
 
 Meteor.publish('mediasoup:metadata', async function (hunt, call) {
-  check(hunt, String);
+  check(hunt, makeForeignKeyMatcher<typeof Hunts>());
   check(call, String);
 
   if (!this.userId) {
@@ -104,7 +105,7 @@ Meteor.publish('mediasoup:metadata', async function (hunt, call) {
 });
 
 Meteor.publish('mediasoup:join', async function (hunt, call, tab) {
-  check(hunt, String);
+  check(hunt, makeForeignKeyMatcher<typeof Hunts>());
   check(call, String);
   check(tab, String);
 

--- a/imports/server/mediasoup.ts
+++ b/imports/server/mediasoup.ts
@@ -9,28 +9,29 @@ import Flags from '../Flags';
 import Logger from '../Logger';
 import { ACTIVITY_GRANULARITY } from '../lib/config/activityTracking';
 import { RECENT_ACTIVITY_TIME_WINDOW_MS } from '../lib/config/webrtc';
+import type { HuntId } from '../lib/models/Hunts';
 import type { ServerType } from '../lib/models/Servers';
 import Servers from '../lib/models/Servers';
 import CallHistories from '../lib/models/mediasoup/CallHistories';
 import ConnectAcks from '../lib/models/mediasoup/ConnectAcks';
-import ConnectRequests from '../lib/models/mediasoup/ConnectRequests';
 import type { ConnectRequestType } from '../lib/models/mediasoup/ConnectRequests';
-import ConsumerAcks from '../lib/models/mediasoup/ConsumerAcks';
+import ConnectRequests from '../lib/models/mediasoup/ConnectRequests';
 import type { ConsumerAckType } from '../lib/models/mediasoup/ConsumerAcks';
+import ConsumerAcks from '../lib/models/mediasoup/ConsumerAcks';
 import Consumers from '../lib/models/mediasoup/Consumers';
-import MonitorConnectAcks from '../lib/models/mediasoup/MonitorConnectAcks';
 import type { MonitorConnectAckType } from '../lib/models/mediasoup/MonitorConnectAcks';
-import MonitorConnectRequests from '../lib/models/mediasoup/MonitorConnectRequests';
+import MonitorConnectAcks from '../lib/models/mediasoup/MonitorConnectAcks';
 import type { MonitorConnectRequestType } from '../lib/models/mediasoup/MonitorConnectRequests';
+import MonitorConnectRequests from '../lib/models/mediasoup/MonitorConnectRequests';
 import Peers from '../lib/models/mediasoup/Peers';
-import ProducerClients from '../lib/models/mediasoup/ProducerClients';
 import type { ProducerClientType } from '../lib/models/mediasoup/ProducerClients';
+import ProducerClients from '../lib/models/mediasoup/ProducerClients';
 import ProducerServers from '../lib/models/mediasoup/ProducerServers';
-import Rooms from '../lib/models/mediasoup/Rooms';
 import type { RoomType } from '../lib/models/mediasoup/Rooms';
+import Rooms from '../lib/models/mediasoup/Rooms';
 import Routers from '../lib/models/mediasoup/Routers';
-import TransportRequests from '../lib/models/mediasoup/TransportRequests';
 import type { TransportRequestType } from '../lib/models/mediasoup/TransportRequests';
+import TransportRequests from '../lib/models/mediasoup/TransportRequests';
 import TransportStates from '../lib/models/mediasoup/TransportStates';
 import Transports from '../lib/models/mediasoup/Transports';
 import roundedTime from '../lib/roundedTime';
@@ -94,12 +95,12 @@ type TransportAppData = {
 };
 
 type AudioLevelObserverAppData = {
-  hunt: string;
+  hunt: HuntId;
   call: string;
 };
 
 type RouterAppData = {
-  hunt: string;
+  hunt: HuntId;
   call: string;
   createdBy: string;
 };

--- a/imports/server/methods/addHuntUser.ts
+++ b/imports/server/methods/addHuntUser.ts
@@ -2,6 +2,7 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import { userMayAddUsersToHunt } from '../../lib/permission_stubs';
 import addHuntUser from '../../methods/addHuntUser';
 import addUserToHunt from '../addUserToHunt';
@@ -10,7 +11,7 @@ import defineMethod from './defineMethod';
 defineMethod(addHuntUser, {
   validate(arg) {
     check(arg, {
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
       email: String,
     });
     return arg;

--- a/imports/server/methods/bulkAddHuntUsers.ts
+++ b/imports/server/methods/bulkAddHuntUsers.ts
@@ -2,6 +2,7 @@ import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import { userMayBulkAddToHunt } from '../../lib/permission_stubs';
 import bulkAddHuntUsers from '../../methods/bulkAddHuntUsers';
 import addUserToHunt from '../addUserToHunt';
@@ -10,7 +11,7 @@ import defineMethod from './defineMethod';
 defineMethod(bulkAddHuntUsers, {
   validate(arg) {
     check(arg, {
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
       emails: [String],
     });
     return arg;

--- a/imports/server/methods/createPuzzle.ts
+++ b/imports/server/methods/createPuzzle.ts
@@ -7,6 +7,7 @@ import type { GdriveMimeTypesType } from '../../lib/GdriveMimeTypes';
 import GdriveMimeTypes from '../../lib/GdriveMimeTypes';
 import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import Puzzles from '../../lib/models/Puzzles';
 import { userMayWritePuzzlesForHunt } from '../../lib/permission_stubs';
 import createPuzzle from '../../methods/createPuzzle';
@@ -19,7 +20,7 @@ import defineMethod from './defineMethod';
 defineMethod(createPuzzle, {
   validate(arg) {
     check(arg, {
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
       title: String,
       url: Match.Optional(String),
       tags: [String],

--- a/imports/server/methods/demoteOperator.ts
+++ b/imports/server/methods/demoteOperator.ts
@@ -3,6 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import Logger from '../../Logger';
 import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import { removeUserFromRole, userMayMakeOperatorForHunt } from '../../lib/permission_stubs';
 import demoteOperator from '../../methods/demoteOperator';
 import defineMethod from './defineMethod';
@@ -11,7 +12,7 @@ defineMethod(demoteOperator, {
   validate(arg) {
     check(arg, {
       targetUserId: String,
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
     });
     return arg;
   },

--- a/imports/server/methods/destroyHunt.ts
+++ b/imports/server/methods/destroyHunt.ts
@@ -1,13 +1,14 @@
 import { check } from 'meteor/check';
 import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import { checkAdmin } from '../../lib/permission_stubs';
 import destroyHunt from '../../methods/destroyHunt';
 import defineMethod from './defineMethod';
 
 defineMethod(destroyHunt, {
   validate(arg) {
-    check(arg, { huntId: String });
+    check(arg, { huntId: makeForeignKeyMatcher<typeof Hunts>() });
     return arg;
   },
 

--- a/imports/server/methods/postAnnouncement.ts
+++ b/imports/server/methods/postAnnouncement.ts
@@ -4,6 +4,7 @@ import Logger from '../../Logger';
 import Announcements from '../../lib/models/Announcements';
 import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import PendingAnnouncements from '../../lib/models/PendingAnnouncements';
 import { userMayAddAnnouncementToHunt } from '../../lib/permission_stubs';
 import postAnnouncement from '../../methods/postAnnouncement';
@@ -12,7 +13,7 @@ import defineMethod from './defineMethod';
 defineMethod(postAnnouncement, {
   validate(arg) {
     check(arg, {
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
       message: String,
     });
 

--- a/imports/server/methods/promoteOperator.ts
+++ b/imports/server/methods/promoteOperator.ts
@@ -3,6 +3,7 @@ import { Meteor } from 'meteor/meteor';
 import Logger from '../../Logger';
 import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import { addUserToRole, userMayMakeOperatorForHunt } from '../../lib/permission_stubs';
 import promoteOperator from '../../methods/promoteOperator';
 import defineMethod from './defineMethod';
@@ -11,7 +12,7 @@ defineMethod(promoteOperator, {
   validate(arg) {
     check(arg, {
       targetUserId: String,
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
     });
     return arg;
   },

--- a/imports/server/methods/syncHuntDiscordRole.ts
+++ b/imports/server/methods/syncHuntDiscordRole.ts
@@ -1,6 +1,8 @@
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
+import type Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import { userMayUseDiscordBotAPIs } from '../../lib/permission_stubs';
 import syncHuntDiscordRole from '../../methods/syncHuntDiscordRole';
 import addUsersToDiscordRole from '../addUsersToDiscordRole';
@@ -8,7 +10,9 @@ import defineMethod from './defineMethod';
 
 defineMethod(syncHuntDiscordRole, {
   validate(arg) {
-    check(arg, { huntId: String });
+    check(arg, {
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
+    });
     return arg;
   },
 

--- a/imports/server/methods/undestroyHunt.ts
+++ b/imports/server/methods/undestroyHunt.ts
@@ -1,6 +1,7 @@
 import { check } from 'meteor/check';
 import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import { checkAdmin } from '../../lib/permission_stubs';
 import undestroyHunt from '../../methods/undestroyHunt';
 import defineMethod from './defineMethod';
@@ -8,7 +9,7 @@ import defineMethod from './defineMethod';
 defineMethod(undestroyHunt, {
   validate(arg) {
     check(arg, {
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
     });
     return arg;
   },

--- a/imports/server/methods/updateHunt.ts
+++ b/imports/server/methods/updateHunt.ts
@@ -4,6 +4,7 @@ import Logger from '../../Logger';
 import type { HuntType } from '../../lib/models/Hunts';
 import Hunts, { HuntPattern } from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import { checkAdmin } from '../../lib/permission_stubs';
 import updateHunt from '../../methods/updateHunt';
 import addUsersToDiscordRole from '../addUsersToDiscordRole';
@@ -12,7 +13,7 @@ import defineMethod from './defineMethod';
 
 defineMethod(updateHunt, {
   validate(arg) {
-    check(arg, { huntId: String, value: HuntPattern });
+    check(arg, { huntId: makeForeignKeyMatcher<typeof Hunts>(), value: HuntPattern });
     return arg;
   },
 

--- a/imports/server/models/CallActivities.ts
+++ b/imports/server/models/CallActivities.ts
@@ -5,7 +5,7 @@ import { foreignKey } from '../../lib/models/customTypes';
 
 const CallActivity = z.object({
   ts: z.date(),
-  hunt: foreignKey,
+  hunt: foreignKey.brand('jr_hunts'),
   call: foreignKey,
   user: foreignKey,
 });

--- a/imports/server/publications/announcementsForAnnouncementsPage.ts
+++ b/imports/server/publications/announcementsForAnnouncementsPage.ts
@@ -1,6 +1,8 @@
 import { check } from 'meteor/check';
 import Announcements from '../../lib/models/Announcements';
+import type Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import announcementsForAnnouncementsPage from '../../lib/publications/announcementsForAnnouncementsPage';
 import publishJoinedQuery from '../publishJoinedQuery';
 import definePublication from './definePublication';
@@ -8,7 +10,7 @@ import definePublication from './definePublication';
 definePublication(announcementsForAnnouncementsPage, {
   validate(arg) {
     check(arg, {
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
     });
     return arg;
   },

--- a/imports/server/publications/chatMessagesForFirehose.ts
+++ b/imports/server/publications/chatMessagesForFirehose.ts
@@ -1,6 +1,8 @@
 import { check } from 'meteor/check';
 import ChatMessages from '../../lib/models/ChatMessages';
+import type Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import Puzzles from '../../lib/models/Puzzles';
 import chatMessagesForFirehose from '../../lib/publications/chatMessagesForFirehose';
 import publishJoinedQuery from '../publishJoinedQuery';
@@ -9,7 +11,7 @@ import definePublication from './definePublication';
 definePublication(chatMessagesForFirehose, {
   validate(arg) {
     check(arg, {
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
     });
     return arg;
   },

--- a/imports/server/publications/chatMessagesForPuzzle.ts
+++ b/imports/server/publications/chatMessagesForPuzzle.ts
@@ -1,6 +1,8 @@
 import { check } from 'meteor/check';
 import ChatMessages from '../../lib/models/ChatMessages';
+import type Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import chatMessagesForPuzzle from '../../lib/publications/chatMessagesForPuzzle';
 import definePublication from './definePublication';
 
@@ -8,7 +10,7 @@ definePublication(chatMessagesForPuzzle, {
   validate(arg) {
     check(arg, {
       puzzleId: String,
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
     });
     return arg;
   },

--- a/imports/server/publications/guessesForGuessQueue.ts
+++ b/imports/server/publications/guessesForGuessQueue.ts
@@ -2,6 +2,7 @@ import { check } from 'meteor/check';
 import Guesses from '../../lib/models/Guesses';
 import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import Puzzles from '../../lib/models/Puzzles';
 import guessesForGuessQueue from '../../lib/publications/guessesForGuessQueue';
 import publishJoinedQuery from '../publishJoinedQuery';
@@ -10,7 +11,7 @@ import definePublication from './definePublication';
 definePublication(guessesForGuessQueue, {
   validate(arg) {
     check(arg, {
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
     });
     return arg;
   },

--- a/imports/server/publications/huntForHuntApp.ts
+++ b/imports/server/publications/huntForHuntApp.ts
@@ -1,12 +1,13 @@
 import { check } from 'meteor/check';
 import Hunts from '../../lib/models/Hunts';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import huntForHuntApp from '../../lib/publications/huntForHuntApp';
 import definePublication from './definePublication';
 
 definePublication(huntForHuntApp, {
   validate(arg) {
     check(arg, {
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
     });
     return arg;
   },

--- a/imports/server/publications/pendingGuessesForSelf.ts
+++ b/imports/server/publications/pendingGuessesForSelf.ts
@@ -1,5 +1,6 @@
-import Guesses from '../../lib/models/Guesses';
 import type { GuessType } from '../../lib/models/Guesses';
+import Guesses from '../../lib/models/Guesses';
+import type { HuntId } from '../../lib/models/Hunts';
 import Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Puzzles from '../../lib/models/Puzzles';
@@ -19,7 +20,7 @@ definePublication(pendingGuessesForSelf, {
       return [];
     }
 
-    const huntGuessWatchers: Map<string, SubSubscription> = new Map();
+    const huntGuessWatchers: Map<HuntId, SubSubscription> = new Map();
 
     const merger = new PublicationMerger(this);
 

--- a/imports/server/publications/puzzleActivityForHunt.ts
+++ b/imports/server/publications/puzzleActivityForHunt.ts
@@ -7,6 +7,9 @@ import {
 } from '../../lib/config/activityTracking';
 import ChatMessages from '../../lib/models/ChatMessages';
 import DocumentActivities from '../../lib/models/DocumentActivities';
+import type Hunts from '../../lib/models/Hunts';
+import type { HuntId } from '../../lib/models/Hunts';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import puzzleActivityForHunt from '../../lib/publications/puzzleActivityForHunt';
 import roundedTime from '../../lib/roundedTime';
 import CallActivities from '../models/CallActivities';
@@ -27,7 +30,7 @@ type ActivityBuckets = Map<number, ActivityBucket>;
 class HuntActivityAggregator {
   static aggregators = new Map<string, HuntActivityAggregator>();
 
-  hunt: string;
+  hunt: HuntId;
 
   activitiesByPuzzle: Map<string, ActivityBuckets> = new Map();
 
@@ -41,7 +44,7 @@ class HuntActivityAggregator {
 
   subscriptions: Set<Subscription> = new Set();
 
-  private constructor(hunt: string) {
+  private constructor(hunt: HuntId) {
     this.hunt = hunt;
 
     // Note that this won't update reactively, but sets a bound for the initial
@@ -193,7 +196,7 @@ class HuntActivityAggregator {
     this.timeouts.delete(this.bucketId(puzzle, time));
   }
 
-  static get(hunt: string) {
+  static get(hunt: HuntId) {
     let aggregator = HuntActivityAggregator.aggregators.get(hunt);
     if (!aggregator) {
       aggregator = new HuntActivityAggregator(hunt);
@@ -225,7 +228,7 @@ class HuntActivityAggregator {
 
 definePublication(puzzleActivityForHunt, {
   validate(arg) {
-    check(arg, { huntId: String });
+    check(arg, { huntId: makeForeignKeyMatcher<typeof Hunts>() });
     return arg;
   },
 

--- a/imports/server/publications/puzzleForPuzzlePage.ts
+++ b/imports/server/publications/puzzleForPuzzlePage.ts
@@ -1,7 +1,9 @@
 import { check } from 'meteor/check';
 import Documents from '../../lib/models/Documents';
 import Guesses from '../../lib/models/Guesses';
+import type Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import Puzzles from '../../lib/models/Puzzles';
 import Tags from '../../lib/models/Tags';
 import puzzleForPuzzlePage from '../../lib/publications/puzzleForPuzzlePage';
@@ -14,7 +16,7 @@ definePublication(puzzleForPuzzlePage, {
   validate(arg) {
     check(arg, {
       puzzleId: String,
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
     });
     return arg;
   },

--- a/imports/server/publications/puzzlesForHunt.ts
+++ b/imports/server/publications/puzzlesForHunt.ts
@@ -1,5 +1,7 @@
 import { check, Match } from 'meteor/check';
+import type Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import Puzzles from '../../lib/models/Puzzles';
 import puzzlesForHunt from '../../lib/publications/puzzlesForHunt';
 import definePublication from './definePublication';
@@ -7,7 +9,7 @@ import definePublication from './definePublication';
 definePublication(puzzlesForHunt, {
   validate(arg) {
     check(arg, {
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
       includeDeleted: Match.Optional(Boolean),
     });
     return arg;

--- a/imports/server/publications/puzzlesForPuzzleList.ts
+++ b/imports/server/publications/puzzlesForPuzzleList.ts
@@ -1,5 +1,7 @@
 import { check, Match } from 'meteor/check';
+import type Hunts from '../../lib/models/Hunts';
 import MeteorUsers from '../../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../lib/models/Model';
 import Puzzles from '../../lib/models/Puzzles';
 import Tags from '../../lib/models/Tags';
 import puzzlesForPuzzleList from '../../lib/publications/puzzlesForPuzzleList';
@@ -8,7 +10,7 @@ import definePublication from './definePublication';
 definePublication(puzzlesForPuzzleList, {
   validate(arg) {
     check(arg, {
-      huntId: String,
+      huntId: makeForeignKeyMatcher<typeof Hunts>(),
       includeDeleted: Match.Optional(Boolean),
     });
     return arg;

--- a/imports/server/publishJoinedQuery.ts
+++ b/imports/server/publishJoinedQuery.ts
@@ -17,7 +17,7 @@ type Projection<T> = Partial<Record<keyof T, 0 | 1>>;
 // effectively building the tree in the generic parameters. I'm not entirely
 // sure how to actually do that.
 export type PublishSpec<T extends { _id: string }> = {
-  model: Mongo.Collection<T> | Model<z.ZodType<T, any, any> & MongoRecordZodType>,
+  model: Mongo.Collection<T> | Model<z.ZodType<T, any, any> & MongoRecordZodType, any, any>,
   allowDeleted?: boolean,
   projection?: Projection<T>,
   foreignKeys?: {
@@ -27,7 +27,7 @@ export type PublishSpec<T extends { _id: string }> = {
   lingerTime?: number;
 }
 
-function modelName(model: Mongo.Collection<any> | Model<any>) {
+function modelName(model: Mongo.Collection<any> | Model<any, any, any>) {
   return model instanceof Mongo.Collection ? model._name : model.name;
 }
 
@@ -79,7 +79,10 @@ class RefCountedJoinedObjectObserverMap<T extends { _id: string }> {
   }
 }
 
-const finder = (model: Mongo.Collection<any> | Model<any>, allowDeleted: boolean | undefined) => {
+const finder = (
+  model: Mongo.Collection<any> | Model<any, any, any>,
+  allowDeleted: boolean | undefined
+) => {
   return allowDeleted && 'findAllowingDeleted' in model && typeof model.findAllowingDeleted === 'function' ?
     model.findAllowingDeleted.bind(model) as typeof model.find :
     model.find.bind(model);

--- a/imports/server/users.ts
+++ b/imports/server/users.ts
@@ -6,6 +6,7 @@ import type { Mongo } from 'meteor/mongo';
 import { GLOBAL_SCOPE } from '../lib/isAdmin';
 import Hunts from '../lib/models/Hunts';
 import MeteorUsers from '../lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../lib/models/Model';
 import type { ProfileFields } from '../lib/models/User';
 import { userMaySeeUserInfoForHunt } from '../lib/permission_stubs';
 import type { SubSubscription } from './PublicationMerger';
@@ -79,7 +80,7 @@ const makeHuntFilterTransform = (hunts: string[] = []):
 };
 
 Meteor.publish('displayNames', async function (huntId: unknown) {
-  check(huntId, String);
+  check(huntId, makeForeignKeyMatcher<typeof Hunts>());
 
   if (!this.userId) {
     return [];
@@ -97,7 +98,7 @@ Meteor.publish('displayNames', async function (huntId: unknown) {
 });
 
 Meteor.publish('avatars', async function (huntId: unknown) {
-  check(huntId, String);
+  check(huntId, makeForeignKeyMatcher<typeof Hunts>());
 
   if (!this.userId) {
     return [];
@@ -133,7 +134,7 @@ Meteor.publish('allProfiles', async function () {
 });
 
 Meteor.publish('huntProfiles', async function (huntId: unknown) {
-  check(huntId, String);
+  check(huntId, makeForeignKeyMatcher<typeof Hunts>());
 
   if (!this.userId) {
     return [];
@@ -178,7 +179,7 @@ Meteor.publish('profile', async function (userId: unknown) {
 });
 
 Meteor.publish('huntRoles', async function (huntId: unknown) {
-  check(huntId, String);
+  check(huntId, makeForeignKeyMatcher<typeof Hunts>());
 
   await republishOnUserChange(this, { hunts: 1, roles: 1 }, async (u) => {
     // Only publish other users' roles to admins and other operators.

--- a/tests/acceptance/chatHooks.ts
+++ b/tests/acceptance/chatHooks.ts
@@ -2,6 +2,8 @@ import { promisify } from 'util';
 import { Meteor } from 'meteor/meteor';
 import { assert } from 'chai';
 import ChatMessages from '../../imports/lib/models/ChatMessages';
+import Hunts from '../../imports/lib/models/Hunts';
+import { makeForeignKey } from '../../imports/lib/models/Model';
 import chatMessagesForFirehose from '../../imports/lib/publications/chatMessagesForFirehose';
 import createFixtureHunt from '../../imports/methods/createFixtureHunt';
 import provisionFirstUser from '../../imports/methods/provisionFirstUser';
@@ -24,7 +26,7 @@ if (Meteor.isClient) {
         await promisify(Meteor.loginWithPassword)(USER_EMAIL, USER_PASSWORD);
         await createFixtureHunt.callPromise();
 
-        const huntId = 'S5BBzdFRnKSDktDwd';
+        const huntId = makeForeignKey<typeof Hunts>('S5BBzdFRnKSDktDwd');
         const guessId = '5bYkNpXBC2mAdZBDC';
         const puzzleId = 'hiMpJHfWjotCGb9NT';
         const metaPuzzleIds = ['NeMxJZKPGqN7CcmcN', '3zTi6pDY9mHJSbLoS'];

--- a/tests/acceptance/profiles.tsx
+++ b/tests/acceptance/profiles.tsx
@@ -3,8 +3,9 @@ import { Accounts } from 'meteor/accounts-base';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { assert } from 'chai';
-import Hunts from '../../imports/lib/models/Hunts';
+import Hunts, { HuntId } from '../../imports/lib/models/Hunts';
 import MeteorUsers from '../../imports/lib/models/MeteorUsers';
+import { makeForeignKeyMatcher } from '../../imports/lib/models/Model';
 import { addUserToRole as serverAddUserToRole, huntsUserIsOperatorFor } from '../../imports/lib/permission_stubs';
 import TypedMethod from '../../imports/methods/TypedMethod';
 import resetDatabase from '../lib/resetDatabase';
@@ -14,8 +15,8 @@ import { stabilize, subscribeAsync } from './lib';
 // of our normal permissions. They don't even require that you be logged in.
 const createUser = new TypedMethod<{ email: string, password: string, displayName: string }, string>('test.methods.profiles.createUser');
 const addUserToRole = new TypedMethod<{ userId: string, scope: string, role: string }, void>('test.methods.profiles.addUserToRole');
-const createHunt = new TypedMethod<{ name: string }, string>('test.methods.profiles.createHunt');
-const joinHunt = new TypedMethod<{ huntId: string, userId: string }, void>('test.methods.profiles.joinHunt');
+const createHunt = new TypedMethod<{ name: string }, HuntId>('test.methods.profiles.createHunt');
+const joinHunt = new TypedMethod<{ huntId: HuntId, userId: string }, void>('test.methods.profiles.joinHunt');
 
 if (Meteor.isServer) {
   const defineMethod: typeof import('../../imports/server/methods/defineMethod').default =
@@ -90,7 +91,7 @@ if (Meteor.isServer) {
   defineMethod(joinHunt, {
     validate(arg: unknown) {
       check(arg, {
-        huntId: String,
+        huntId: makeForeignKeyMatcher<typeof Hunts>(),
         userId: String,
       });
 
@@ -113,8 +114,8 @@ if (Meteor.isClient) {
         const sameHuntUserId: string = await createUser.callPromise({ email: 'jolly-roger+same-hunt@deathandmayhem.com', password: 'password', displayName: 'U2' });
         const differentHuntUserId: string = await createUser.callPromise({ email: 'jolly-roger+different-hunt@deathandmayhem.com', password: 'password', displayName: 'U3' });
 
-        const huntId: string = await createHunt.callPromise({ name: 'Test Hunt' });
-        const otherHuntId: string = await createHunt.callPromise({ name: 'Other Hunt' });
+        const huntId = await createHunt.callPromise({ name: 'Test Hunt' });
+        const otherHuntId = await createHunt.callPromise({ name: 'Other Hunt' });
 
         await joinHunt.callPromise({ huntId, userId });
         await joinHunt.callPromise({ huntId, userId: sameHuntUserId });
@@ -159,8 +160,8 @@ if (Meteor.isClient) {
         const sameHuntUserId: string = await createUser.callPromise({ email: 'jolly-roger+same-hunt@deathandmayhem.com', password: 'password', displayName: 'U2' });
         const differentHuntUserId: string = await createUser.callPromise({ email: 'jolly-roger+different-hunt@deathandmayhem.com', password: 'password', displayName: 'U3' });
 
-        const huntId: string = await createHunt.callPromise({ name: 'Test Hunt' });
-        const otherHuntId: string = await createHunt.callPromise({ name: 'Other Hunt' });
+        const huntId = await createHunt.callPromise({ name: 'Test Hunt' });
+        const otherHuntId = await createHunt.callPromise({ name: 'Other Hunt' });
 
         await joinHunt.callPromise({ huntId, userId });
         await joinHunt.callPromise({ huntId, userId: sameHuntUserId });
@@ -196,8 +197,8 @@ if (Meteor.isClient) {
         const sameHuntUserId: string = await createUser.callPromise({ email: 'jolly-roger+same-hunt@deathandmayhem.com', password: 'password', displayName: 'U2' });
         const differentHuntUserId: string = await createUser.callPromise({ email: 'jolly-roger+different-hunt@deathandmayhem.com', password: 'password', displayName: 'U3' });
 
-        const huntId: string = await createHunt.callPromise({ name: 'Test Hunt' });
-        const otherHuntId: string = await createHunt.callPromise({ name: 'Other Hunt' });
+        const huntId = await createHunt.callPromise({ name: 'Test Hunt' });
+        const otherHuntId = await createHunt.callPromise({ name: 'Other Hunt' });
 
         await joinHunt.callPromise({ huntId, userId });
         await joinHunt.callPromise({ huntId: otherHuntId, userId });

--- a/tests/unit/imports/lib/puzzle-sort-and-group.ts
+++ b/tests/unit/imports/lib/puzzle-sort-and-group.ts
@@ -1,9 +1,11 @@
 import { assert } from 'chai';
+import type Hunts from '../../../../imports/lib/models/Hunts';
+import { makeForeignKey } from '../../../../imports/lib/models/Model';
 import type { PuzzleType } from '../../../../imports/lib/models/Puzzles';
 import type { TagType } from '../../../../imports/lib/models/Tags';
 import { puzzleInterestingness, puzzleGroupsByRelevance, filteredPuzzleGroups } from '../../../../imports/lib/puzzle-sort-and-group';
 
-const hunt = 'hunt_id';
+const hunt = makeForeignKey<typeof Hunts>('hunt_id');
 const allTags: TagType[] = [];
 const allTagsById: Map<string, TagType> = new Map(); // index by _id -- wanted by implementation
 const allTagsByName: Map<string, TagType> = new Map(); // index by name, wanted for test readability

--- a/tests/unit/imports/server/Model.ts
+++ b/tests/unit/imports/server/Model.ts
@@ -16,13 +16,13 @@ import { MongoRecordZodType } from '../../../../imports/lib/models/generateJsonS
 import attachSchema from '../../../../imports/server/attachSchema';
 import AssertTypesEqual from '../../../lib/AssertTypesEqual';
 
-const testModels: Set<Model<any>> = new Set();
+const testModels: Set<Model<any, any, any>> = new Set();
 
 async function createTestModel<T extends MongoRecordZodType>(
   schema: T
-): Promise<Model<T>> {
+): Promise<Model<T, any>> {
   const collectionName = `test_schema_${Random.id()}`;
-  const model = new Model<T>(collectionName, schema);
+  const model = new Model<T, any>(collectionName, schema);
   await attachSchema(model.schema, model.collection);
   testModels.add(model);
   return model;
@@ -86,7 +86,7 @@ describe('Model', function () {
         // separate field
         string: stringId,
       });
-      let model: Model<typeof schema>;
+      let model: Model<typeof schema, any>;
       this.beforeAll(async function () {
         model = await createTestModel(schema);
       });
@@ -107,7 +107,7 @@ describe('Model', function () {
         createdAt: createdTimestamp,
         updatedAt: updatedTimestamp,
       });
-      let model: Model<typeof schema>;
+      let model: Model<typeof schema, any>;
       this.beforeAll(async function () {
         model = await createTestModel(schema);
       });
@@ -392,7 +392,7 @@ describe('Model', function () {
       string: nonEmptyString,
       number: z.number(),
     });
-    let model: Model<typeof schema>;
+    let model: Model<typeof schema, any>;
     this.beforeAll(async function () {
       model = await createTestModel(schema);
     });
@@ -401,7 +401,7 @@ describe('Model', function () {
       z.object({ name: z.literal('foo'), foo: nonEmptyString }),
       z.object({ name: z.literal('bar'), bar: z.number() }),
     ]);
-    let discriminatedUnionModel: Model<typeof discriminatedUnionSchema>;
+    let discriminatedUnionModel: Model<typeof discriminatedUnionSchema, any>;
     this.beforeAll(async function () {
       discriminatedUnionModel = await createTestModel(discriminatedUnionSchema);
     });


### PR DESCRIPTION
Types in TypeScript are structural by default, meaning that an object of one type can be assigned to another if those types have the same shape. Branded types are a form of nominal typing, meaning that an object can't be assigned to a variable of a branded type unless it is explicitly the same exact type.

This is useful for types which look the same but should be treated differently - for instance, a hunt ID and a puzzle ID. They're both strings, but they're not the same string.

This switches hunt IDs throughout the database to be branded, using Zod's built-in support for branded types. Zod's branding requires a brand name; we use the collection name.

This also introduces an assortment of helpers to deal with branded types:
* `ForeignKeyType<M extends Model>`: The branded type of a foreign key to a model. This is used in place of `string` for foreign keys. (Most of the changes in this commit are to replace `string` with `ForeignKeyType<typeof Hunts>`.)
* `makeForeignKey<M extends Model>(id: string)`: A helper to create a foreign key of the correct type. This is used to "encode" a string which we know to be a valid foreign key, and should be used very sparingly. In practice, we only need this in tests and for the hard-coded fixture hunt ID.
* `matchForeignKey<M extends Model>()`: Returns a matcher which can be passed to `check` to assert that a value is a foreign key. This is actually equivalent to just verifying that the value is any string (because we can't actually check that a string is a valid foreign key without querying the database), but it's necessary for our handling of typed methods and publications.

Note that none of this should introduce any runtime overhead; type brands exist at the type layer only, and do not have any runtime footprint (other than values passing through a few extra identity functions).