### PR TITLE
Rewrite AnnouncementPage to preview and reuse Toast

### DIFF
--- a/client/stylesheets/_theme.scss
+++ b/client/stylesheets/_theme.scss
@@ -15,4 +15,5 @@ $toast-max-width: 380px;
   @each $name, $value in $grid-breakpoints {
     --bs-breakpoint-#{$name}: #{$value};
   }
+  --bs-toast-max-width: #{$toast-max-width};
 }

--- a/imports/client/components/AnnouncementToast.tsx
+++ b/imports/client/components/AnnouncementToast.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import Toast from 'react-bootstrap/Toast';
+import styled from 'styled-components';
+import { calendarTimeFormat } from '../../lib/calendarTimeFormat';
+import Markdown from './Markdown';
+
+const StyledNotificationTimestamp = styled.small`
+  text-align: end;
+`;
+
+const AnnouncementToast = ({
+  displayName, message, createdAt, onClose, className,
+}: {
+  displayName: string;
+  message: string;
+  createdAt: Date;
+  onClose?: () => void;
+  className?: string;
+}) => {
+  return (
+    <Toast className={className} onClose={onClose}>
+      <Toast.Header closeButton={!!onClose}>
+        <strong className="me-auto">
+          Announcement from
+          {' '}
+          {displayName}
+        </strong>
+        <StyledNotificationTimestamp>
+          {calendarTimeFormat(createdAt)}
+        </StyledNotificationTimestamp>
+      </Toast.Header>
+      <Toast.Body>
+        <Markdown text={message} />
+      </Toast.Body>
+    </Toast>
+  );
+};
+
+export default AnnouncementToast;

--- a/imports/client/components/AnnouncementsPage.tsx
+++ b/imports/client/components/AnnouncementsPage.tsx
@@ -1,14 +1,13 @@
-/* eslint-disable max-len */
 import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
 import React, { useCallback, useState } from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
 import { useParams } from 'react-router-dom';
+import ReactTextareaAutosize from 'react-textarea-autosize';
 import styled from 'styled-components';
-import { calendarTimeFormat } from '../../lib/calendarTimeFormat';
 import Announcements from '../../lib/models/Announcements';
-import type { AnnouncementType } from '../../lib/models/Announcements';
 import Hunts from '../../lib/models/Hunts';
 import { indexedDisplayNames } from '../../lib/models/MeteorUsers';
 import { userMayAddAnnouncementToHunt } from '../../lib/permission_stubs';
@@ -16,7 +15,8 @@ import announcementsForAnnouncementsPage from '../../lib/publications/announceme
 import postAnnouncement from '../../methods/postAnnouncement';
 import { useBreadcrumb } from '../hooks/breadcrumb';
 import useTypedSubscribe from '../hooks/useTypedSubscribe';
-import Markdown from './Markdown';
+import ActionButtonRow from './ActionButtonRow';
+import AnnouncementToast from './AnnouncementToast';
 
 enum AnnouncementFormSubmitState {
   IDLE = 'idle',
@@ -24,29 +24,19 @@ enum AnnouncementFormSubmitState {
   FAILED = 'failed',
 }
 
-const AnnouncementFormContainer = styled.div`
-  background-color: #f0f0f0;
-  padding: 16px;
-
-  h3 {
-    margin-top: 0;
-  }
-
-  textarea {
-    width: 100%;
-  }
-
-  .button-row {
-    display: flex;
-    flex-direction: row-reverse;
-    align-items: flex-start;
-    justify-content: flex-start;
-  }
+// Toasts are bounded in width, so the announcement log will only be about this wide.
+// Rather than have the input box be much wider than the rest of the page
+// content, set the input form width to match.
+const BoundedForm = styled(Form)`
+  width: ${window.getComputedStyle(document.body).getPropertyValue('--bs-toast-max-width')};
 `;
 
-const AnnouncementForm = ({ huntId }: { huntId: string }) => {
+const AnnouncementFormInput = ({ huntId, selfDisplayName }: {
+  huntId: string; selfDisplayName: string;
+}) => {
   const [message, setMessage] = useState<string>('');
-  const [submitState, setSubmitState] = useState<AnnouncementFormSubmitState>(AnnouncementFormSubmitState.IDLE);
+  const [submitState, setSubmitState] =
+    useState<AnnouncementFormSubmitState>(AnnouncementFormSubmitState.IDLE);
   const [errorMessage, setErrorMessage] = useState<string>('');
 
   const onMessageChanged = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -62,65 +52,43 @@ const AnnouncementForm = ({ huntId }: { huntId: string }) => {
           setSubmitState(AnnouncementFormSubmitState.FAILED);
         } else {
           setErrorMessage('');
+          setMessage('');
           setSubmitState(AnnouncementFormSubmitState.IDLE);
         }
       });
     }
   }, [message, huntId]);
 
+  const disabled = submitState === 'submitting';
   return (
-    <AnnouncementFormContainer>
-      <h3>Write an announcement:</h3>
+    <BoundedForm>
       {submitState === 'failed' ? <Alert variant="danger">{errorMessage}</Alert> : null}
-      <textarea
-        value={message}
-        onChange={onMessageChanged}
-        disabled={submitState === 'submitting'}
-      />
-      <div>Try to keep it brief and on-point.</div>
-      <div className="button-row">
-        <Button
-          variant="primary"
-          onClick={postAnnouncementCb}
-          disabled={submitState === 'submitting'}
-        >
-          Send
-        </Button>
-      </div>
-    </AnnouncementFormContainer>
-  );
-};
-
-const AnnouncementContainer = styled.div`
-  margin-top: 8px;
-  margin-bottom: 8px;
-  padding: 8px;
-  background-color: #eee;
-`;
-
-const AnnouncementOrigin = styled.div`
-  text-align: right;
-`;
-
-const AnnouncementTimestamp = styled.div`
-  text-align: right;
-`;
-
-const Announcement = ({ announcement, displayName }: {
-  announcement: AnnouncementType, displayName: string,
-}) => {
-  const ann = announcement;
-
-  // TODO: All the styles here could stand to be improved, but this gets it on the screen in a
-  // minimally-offensive manner, and preserves the intent of newlines.
-  return (
-    <AnnouncementContainer>
-      <AnnouncementOrigin>
-        <AnnouncementTimestamp>{calendarTimeFormat(ann.createdAt)}</AnnouncementTimestamp>
-        <div>{displayName}</div>
-      </AnnouncementOrigin>
-      <Markdown text={ann.message} />
-    </AnnouncementContainer>
+      {message && (
+        <AnnouncementToast
+          className="mb-2"
+          displayName={`${selfDisplayName} (preview)`}
+          message={message}
+          createdAt={new Date()}
+        />
+      )}
+      <Form.Group className="mb-2" controlId="announcement-input">
+        <Form.Label>
+          Write an announcement: (try to keep it brief and on-point)
+        </Form.Label>
+        <ReactTextareaAutosize
+          id="announcement-input"
+          minRows={4}
+          className="form-control"
+          autoFocus
+          disabled={disabled}
+          value={message}
+          onChange={onMessageChanged}
+        />
+      </Form.Group>
+      <ActionButtonRow>
+        <Button variant="primary" size="sm" disabled={disabled} onClick={postAnnouncementCb}>Send</Button>
+      </ActionButtonRow>
+    </BoundedForm>
   );
 };
 
@@ -132,10 +100,15 @@ const AnnouncementsPage = () => {
   const loading = announcementsLoading();
 
   const announcements = useTracker(() => (
-    loading ? [] : Announcements.find({ hunt: huntId }, { sort: { createdAt: 1 } }).fetch()
+    loading ? [] : Announcements.find({ hunt: huntId }, { sort: { createdAt: -1 } }).fetch()
   ), [loading, huntId]);
-  const displayNames = useTracker(() => (loading ? new Map<string, string>() : indexedDisplayNames()), [loading]);
-  const canCreateAnnouncements = useTracker(() => userMayAddAnnouncementToHunt(Meteor.user(), Hunts.findOne(huntId)), [huntId]);
+  const displayNames = useTracker(() => (
+    loading ? new Map<string, string>() : indexedDisplayNames()
+  ), [loading]);
+  const canCreateAnnouncements = useTracker(() => {
+    return userMayAddAnnouncementToHunt(Meteor.user(), Hunts.findOne(huntId));
+  }, [huntId]);
+  const selfDisplayName = useTracker(() => Meteor.user()?.displayName ?? '???', []);
 
   if (loading) {
     return <div>loading...</div>;
@@ -144,16 +117,20 @@ const AnnouncementsPage = () => {
   return (
     <div>
       <h1>Announcements</h1>
-      {canCreateAnnouncements && <AnnouncementForm huntId={huntId} />}
+      {canCreateAnnouncements && (
+        <AnnouncementFormInput huntId={huntId} selfDisplayName={selfDisplayName} />
+      )}
       {/* ostensibly these should be ul and li, but then I have to deal with overriding
           block/inline and default margins and list style type and meh */}
       <div>
         {announcements.map((announcement) => {
           return (
-            <Announcement
+            <AnnouncementToast
+              className="mb-2"
               key={announcement._id}
-              announcement={announcement}
+              createdAt={announcement.createdAt}
               displayName={displayNames.get(announcement.createdBy) ?? '???'}
+              message={announcement.message}
             />
           );
         })}

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -48,6 +48,7 @@ import { requestDiscordCredential } from '../discord';
 import { useOperatorActionsHidden } from '../hooks/persisted-state';
 import { useBlockReasons } from '../hooks/useBlockUpdate';
 import useTypedSubscribe from '../hooks/useTypedSubscribe';
+import AnnouncementToast from './AnnouncementToast';
 import ChatMessage from './ChatMessage';
 import Markdown from './Markdown';
 import PuzzleAnswer from './PuzzleAnswer';
@@ -385,23 +386,12 @@ const AnnouncementMessage = React.memo(({
   }
 
   return (
-    <Toast onClose={onDismiss}>
-      <Toast.Header>
-        <strong className="me-auto">
-          Announcement
-        </strong>
-        <StyledNotificationTimestamp>
-          {calendarTimeFormat(announcement.createdAt)}
-        </StyledNotificationTimestamp>
-      </Toast.Header>
-      <Toast.Body>
-        <Markdown text={announcement.message} />
-        <div>
-          {'- '}
-          {createdByDisplayName}
-        </div>
-      </Toast.Body>
-    </Toast>
+    <AnnouncementToast
+      message={announcement.message}
+      createdAt={announcement.createdAt}
+      displayName={createdByDisplayName}
+      onClose={onDismiss}
+    />
   );
 });
 


### PR DESCRIPTION
`AnnouncementPage` was hastily constructed in a different age.  Let's bring it a bit more up-to-date by:

* Extracting a Toast-based component to use for announcements in both the NotificationCenter and on the AnnoucementPage
* Showing a rendered preview of the announcement, which will probably help people with getting the markdown link test/url order correct more often when posting links
* Sorting messages from most recent to oldest, since more recent messages are likely more important for users to read than older ones.

Fixes #1358.

Before:

https://user-images.githubusercontent.com/307325/216796301-3aabbde9-e58e-4fa1-9fc5-a8d1d23de79b.mov

After:

https://user-images.githubusercontent.com/307325/216796307-27fb36f6-c7ea-4217-a977-a745ef9ea2a6.mov

