### PR TITLE
Change return type for getOrCreateTagByName

### DIFF
--- a/imports/server/getOrCreateTagByName.ts
+++ b/imports/server/getOrCreateTagByName.ts
@@ -1,14 +1,10 @@
 import Logger from '../Logger';
 import Tags from '../lib/models/Tags';
 
-export default async function getOrCreateTagByName(huntId: string, name: string): Promise<{
-  _id: string,
-  hunt: string,
-  name: string,
-}> {
+export default async function getOrCreateTagByName(huntId: string, name: string): Promise<string> {
   const existingTag = await Tags.findOneAsync({ hunt: huntId, name });
   if (existingTag) {
-    return existingTag;
+    return existingTag._id;
   }
 
   Logger.info('Creating a new tag', { hunt: huntId, name });
@@ -21,9 +17,5 @@ export default async function getOrCreateTagByName(huntId: string, name: string)
     await getOrCreateTagByName(huntId, metaTagName);
   }
 
-  return {
-    _id: newTagId,
-    hunt: huntId,
-    name,
-  };
+  return newTagId;
 }

--- a/imports/server/methods/addPuzzleTag.ts
+++ b/imports/server/methods/addPuzzleTag.ts
@@ -32,7 +32,7 @@ defineMethod(addPuzzleTag, {
     }
 
     const huntId = puzzle.hunt;
-    const tagId = (await getOrCreateTagByName(huntId, tagName))._id;
+    const tagId = await getOrCreateTagByName(huntId, tagName);
 
     Logger.info('Tagging puzzle', { puzzle: puzzleId, tag: tagName });
     await Puzzles.updateAsync({

--- a/imports/server/methods/createPuzzle.ts
+++ b/imports/server/methods/createPuzzle.ts
@@ -48,7 +48,7 @@ defineMethod(createPuzzle, {
 
     // Look up each tag by name and map them to tag IDs.
     const tagIds = await Promise.all(tags.map(async (tagName) => {
-      return (await getOrCreateTagByName(huntId, tagName))._id;
+      return getOrCreateTagByName(huntId, tagName);
     }));
 
     Logger.info('Creating a new puzzle', {

--- a/imports/server/methods/updatePuzzle.ts
+++ b/imports/server/methods/updatePuzzle.ts
@@ -45,7 +45,7 @@ defineMethod(updatePuzzle, {
 
     // Look up each tag by name and map them to tag IDs.
     const tagIds = await Promise.all(tags.map(async (tagName) => {
-      return (await getOrCreateTagByName(oldPuzzle.hunt, tagName))._id;
+      return getOrCreateTagByName(oldPuzzle.hunt, tagName);
     }));
 
     Logger.info('Updating a puzzle', {


### PR DESCRIPTION
It looks like we used to return a pseudo-Tag-object, but none of the callers actually care about that anymore.

(Noticed this while playing with the branded types branch)