### PR TITLE
Make heartbeats less reliable and hopefully more robust

### DIFF
--- a/imports/server/garbage-collection.ts
+++ b/imports/server/garbage-collection.ts
@@ -5,6 +5,7 @@
 import os from 'os';
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
+import Logger from '../Logger';
 import Servers from '../lib/models/Servers';
 
 const serverId = Random.id();
@@ -57,6 +58,9 @@ function periodic() {
 }
 
 // Defer the first run to give other startup hooks a chance to run
-Meteor.startup(() => Meteor.defer(() => periodic()));
+Meteor.startup(() => Meteor.defer(() => {
+  Logger.info('New server starting', { serverId });
+  periodic();
+}));
 
 export { serverId, registerPeriodicCleanupHook };


### PR DESCRIPTION
Mediasoup's default configuration attempts to make SCTP delivery ordered and reliable. However, for our heartbeat system, which sends a new message every 100ms, that's not actually what we want - if one heartbeat gets dropped, we don't want to wait for retransmission of that heartbeat before delivering subsequent ones to the receiving application.

Setting ordered: false will allow packets to be delivered out of order, and setting maxRetransmits: 1 should allow the sending side to be more aggressive about dropping missed packets, instead of trying to retransmit them.