### PR TITLE
Fix find with no arguments

### DIFF
--- a/imports/lib/models/Model.ts
+++ b/imports/lib/models/Model.ts
@@ -492,7 +492,7 @@ class Model<Schema extends MongoRecordZodType, IdSchema extends z.ZodTypeAny = t
     selector?: S,
     options?: O,
   ) {
-    return this.collection.find(selector, options) as
+    return this.collection.find(selector ?? {}, options) as
       Mongo.Cursor<SelectorToResultType<z.output<this['schema']>, S>>;
   }
 
@@ -500,7 +500,7 @@ class Model<Schema extends MongoRecordZodType, IdSchema extends z.ZodTypeAny = t
     selector?: S,
     options?: O,
   ) {
-    return this.collection.findOne(selector, options) as
+    return this.collection.findOne(selector ?? {}, options) as
       SelectorToResultType<z.output<this['schema']>, S> | undefined;
   }
 
@@ -508,7 +508,7 @@ class Model<Schema extends MongoRecordZodType, IdSchema extends z.ZodTypeAny = t
     selector?: S,
     options?: O,
   ) {
-    return this.collection.findOneAsync(selector, options) as
+    return this.collection.findOneAsync(selector ?? {}, options) as
       Promise<SelectorToResultType<z.output<this['schema']>, S> | undefined>;
   }
 


### PR DESCRIPTION
Meteor's find method has the slightly confusing property that passing an `undefined` query explicitly behaves differently than passing no query (since the query is an optional parameter). Passing `undefined` explicitly returns an empty result set.

We want to allow the query to be optional, as with Meteor, but that resulted in us explicitly passing undefined to Meteor, which caused the empty result set behavior. So instead make sure we pass an empty query. (This means that we can no longer access the explicit-undefined behavior from Model, but I don't think we've ever wanted that anyway.)