### PR TITLE
Fix initial firing on Flags.observeChanges

### DIFF
--- a/imports/Flags.ts
+++ b/imports/Flags.ts
@@ -37,7 +37,7 @@ const Flags = {
     check(cb, Function);
 
     let state: FeatureFlagType | undefined;
-    const checkUpdate = (_id?: string, flag?: Partial<FeatureFlagType>) => {
+    const checkUpdate = (_id: string, flag?: Partial<FeatureFlagType>) => {
       let newState;
       if (flag) {
         newState = { ...state ?? {}, ...flag } as FeatureFlagType;
@@ -59,7 +59,7 @@ const Flags = {
     // If state is still undefined, then the record does not exist yet and we
     // should explicitly initialize it to false.
     if (state === undefined) {
-      checkUpdate();
+      cb(false);
     }
 
     return handle;

--- a/tests/main.ts
+++ b/tests/main.ts
@@ -19,10 +19,11 @@ if (Meteor.isServer) {
 
   Accounts.removeDefaultRateLimit();
 
-  require('./unit/imports/server/MigrationRegistry');
-  require('./unit/imports/server/publishJoinedQuery');
+  require('./unit/imports/server/Flags');
   require('./unit/imports/server/generateJsonSchema');
+  require('./unit/imports/server/MigrationRegistry');
   require('./unit/imports/server/Model');
+  require('./unit/imports/server/publishJoinedQuery');
   require('./unit/imports/server/validateSchema');
 }
 

--- a/tests/unit/imports/server/Flags.ts
+++ b/tests/unit/imports/server/Flags.ts
@@ -1,0 +1,104 @@
+import { Accounts } from 'meteor/accounts-base';
+import { Meteor } from 'meteor/meteor';
+import { assert } from 'chai';
+import Flags from '../../../../imports/Flags';
+import FeatureFlags from '../../../../imports/lib/models/FeatureFlags';
+import { ModelType, Selector } from '../../../../imports/lib/models/Model';
+import { USER_EMAIL, USER_PASSWORD } from '../../../acceptance/lib';
+
+async function propagationPromise(query: Selector<ModelType<typeof FeatureFlags>>) {
+  return new Promise<void>((r) => {
+    let initializing = true;
+    let handle: Meteor.LiveQueryHandle | undefined;
+    const cb = () => {
+      if (!initializing) {
+        handle?.stop();
+        r();
+      }
+    };
+    handle = FeatureFlags.find(query).observeChanges({
+      added: cb,
+      changed: cb,
+      removed: cb,
+    });
+    initializing = false;
+  });
+}
+
+describe('Flags', function () {
+  describe('observeChanges', function () {
+    let userId: string;
+    this.beforeAll(async function () {
+      // Since FeatureFlags uses `withUsers`, we need at least one user to use for createdBy
+      userId = await Accounts.createUserAsync({ email: USER_EMAIL, password: USER_PASSWORD });
+    });
+
+    it('fires once if the flag does not exist', function () {
+      let callCount = 0;
+      const cb = () => { callCount += 1; };
+      const observer = Flags.observeChanges('test', cb);
+      observer.stop();
+
+      assert.equal(callCount, 1);
+    });
+
+    it('fires once if the flag is inserted but does not change state', async function () {
+      let callCount = 0;
+      const cb = () => { callCount += 1; };
+      const observer = Flags.observeChanges('test', cb);
+      const updatePropagated = propagationPromise({ name: 'test' });
+
+      await FeatureFlags.upsertAsync({ name: 'test' }, {
+        $set: {
+          type: 'off',
+          createdBy: userId,
+        },
+      });
+      await updatePropagated;
+      observer.stop();
+
+      assert.equal(callCount, 1);
+    });
+
+    it('fires twice if the insertion does change state', async function () {
+      let callCount = 0;
+      const cb = () => { callCount += 1; };
+      const observer = Flags.observeChanges('test', cb);
+      const updatePropagated = propagationPromise({ name: 'test' });
+
+      await FeatureFlags.upsertAsync({ name: 'test' }, {
+        $set: {
+          type: 'on',
+          createdBy: userId,
+        },
+      });
+      await updatePropagated;
+      observer.stop();
+
+      assert.equal(callCount, 2);
+    });
+
+    it('fires if flag changes state', async function () {
+      await FeatureFlags.upsertAsync({ name: 'test' }, {
+        $set: {
+          type: 'off',
+          createdBy: userId,
+        },
+      });
+
+      let callCount = 0;
+      const cb = () => { callCount += 1; };
+      const observer = Flags.observeChanges('test', cb);
+      const updatePropagated = propagationPromise({ name: 'test' });
+
+      // reset call count
+      callCount = 0;
+
+      await FeatureFlags.upsertAsync({ name: 'test' }, { $set: { type: 'on' } });
+      await updatePropagated;
+      observer.stop();
+
+      assert.equal(callCount, 1);
+    });
+  });
+});


### PR DESCRIPTION
Bug fix from #1448.

If the flag record does not exist by the time we initialize our observer, then that means that state is undefined, but the new state implied by calling checkUpdate would also be undefined, so we'd never call the callback. We don't actually want to checkUpdate; we want to call the callback manually.

(For the record, this currently breaks the startup of any of our server-side stuff that's using `observeChanges`, including at minimum calls and probably some other stuff like Discord and Drive activity)