### PR TITLE
Use createPortal for modal popups

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -115,6 +115,11 @@
     // default prop values of `undefined`
     "react/require-default-props": "off",
 
+    // This seems to interact poorly with HOCs like forwardRef. TypeScript means
+    // that we don't really have to worry about missing types on our component
+    // props
+    "react/prop-types": "off",
+
     // We use spread props a lot for HOCs or other wrapper-type components
     "react/jsx-props-no-spreading": "off",
 

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -15,6 +15,7 @@ import Modal from 'react-bootstrap/Modal';
 import Overlay from 'react-bootstrap/Overlay';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tooltip from 'react-bootstrap/Tooltip';
+import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 import Flags from '../../Flags';
 import MeteorUsers from '../../lib/models/MeteorUsers';
@@ -214,7 +215,7 @@ const RemoteMuteConfirmModal = React.forwardRef((
     setDisabled(true);
   }, [peerId, hide]);
 
-  return (
+  const modal = (
     <Modal show={visible} onHide={hide}>
       <Modal.Header closeButton>
         <Modal.Title>
@@ -256,6 +257,8 @@ const RemoteMuteConfirmModal = React.forwardRef((
       </Modal.Footer>
     </Modal>
   );
+
+  return createPortal(modal, document.body);
 });
 
 const PeerBox = ({

--- a/imports/client/components/HuntListPage.tsx
+++ b/imports/client/components/HuntListPage.tsx
@@ -11,6 +11,7 @@ import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import Modal from 'react-bootstrap/Modal';
+import { createPortal } from 'react-dom';
 import { LinkContainer } from 'react-router-bootstrap';
 import { Link } from 'react-router-dom';
 import Hunts from '../../lib/models/Hunts';
@@ -112,7 +113,7 @@ const CreateFixtureModal = React.forwardRef((
     setDisabled(true);
   }, [hide]);
 
-  return (
+  const modal = (
     <Modal show={visible} onHide={hide}>
       <Modal.Header closeButton>
         <Modal.Title>Create sample hunt</Modal.Title>
@@ -144,6 +145,8 @@ const CreateFixtureModal = React.forwardRef((
       </Modal.Footer>
     </Modal>
   );
+
+  return createPortal(modal, document.body);
 });
 
 const HuntListPage = () => {

--- a/imports/client/components/ModalForm.tsx
+++ b/imports/client/components/ModalForm.tsx
@@ -4,6 +4,7 @@ import React, {
 import Button from 'react-bootstrap/Button';
 import type { ModalProps } from 'react-bootstrap/Modal';
 import Modal from 'react-bootstrap/Modal';
+import { createPortal } from 'react-dom';
 import styled from 'styled-components';
 
 const StyledModalTitle = styled(Modal.Title)`
@@ -69,7 +70,7 @@ const ModalForm = React.forwardRef((
   const submitLabel = props.submitLabel ?? 'Save';
   const submitStyle = props.submitStyle ?? 'primary';
 
-  return (
+  const modal = (
     <Modal show={isShown} onHide={hide} size={props.size}>
       <form className="form-horizontal" onSubmit={submit}>
         <Modal.Header closeButton>
@@ -99,6 +100,8 @@ const ModalForm = React.forwardRef((
       </form>
     </Modal>
   );
+
+  return createPortal(modal, document.body);
 });
 
 export default ModalForm;

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -19,6 +19,7 @@ import InputGroup from 'react-bootstrap/InputGroup';
 import ListGroup from 'react-bootstrap/ListGroup';
 import ListGroupItem from 'react-bootstrap/ListGroupItem';
 import Modal from 'react-bootstrap/Modal';
+import { createPortal } from 'react-dom';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import isAdmin from '../../lib/isAdmin';
@@ -90,7 +91,7 @@ const PromoteOperatorModal = React.forwardRef((
     setDisabled(true);
   }, [huntId, hide, user._id]);
 
-  return (
+  const modal = (
     <Modal show={visible} onHide={hide}>
       <Modal.Header closeButton>
         <Modal.Title>Promote Operator</Modal.Title>
@@ -119,6 +120,8 @@ const PromoteOperatorModal = React.forwardRef((
       </Modal.Footer>
     </Modal>
   );
+
+  return createPortal(modal, document.body);
 });
 
 const DemoteOperatorModal = React.forwardRef((
@@ -146,7 +149,7 @@ const DemoteOperatorModal = React.forwardRef((
     setDisabled(true);
   }, [huntId, hide, user._id]);
 
-  return (
+  const modal = (
     <Modal show={visible} onHide={hide}>
       <Modal.Header closeButton>
         <Modal.Title>Demote Operator</Modal.Title>
@@ -174,6 +177,8 @@ const DemoteOperatorModal = React.forwardRef((
       </Modal.Footer>
     </Modal>
   );
+
+  return createPortal(modal, document.body);
 });
 
 const OperatorControls = ({ user, hunt }: { user: Meteor.User, hunt: HuntType }) => {

--- a/imports/client/components/PuzzleDeleteModal.tsx
+++ b/imports/client/components/PuzzleDeleteModal.tsx
@@ -4,6 +4,7 @@ import React, {
 } from 'react';
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/esm/Modal';
+import { createPortal } from 'react-dom';
 import Puzzles from '../../lib/models/Puzzles';
 import type { PuzzleType } from '../../lib/models/Puzzles';
 import Peers from '../../lib/models/mediasoup/Peers';
@@ -82,7 +83,7 @@ const PuzzleDeleteModal = React.forwardRef((
     hide();
   }, [puzzle._id, replacementId?.value, hide]);
 
-  return (
+  const modal = (
     <Modal show={visible} onHide={hide}>
       <Modal.Header closeButton>
         <Modal.Title>Delete Puzzle</Modal.Title>
@@ -130,6 +131,8 @@ const PuzzleDeleteModal = React.forwardRef((
       </Modal.Footer>
     </Modal>
   );
+
+  return createPortal(modal, document.body);
 });
 
 export default PuzzleDeleteModal;

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -46,6 +46,7 @@ import Tabs from 'react-bootstrap/Tabs';
 import OverlayTrigger from 'react-bootstrap/esm/OverlayTrigger';
 import Tooltip from 'react-bootstrap/esm/Tooltip';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
+import { createPortal } from 'react-dom';
 import { Link, useParams } from 'react-router-dom';
 import type { Descendant } from 'slate';
 import styled, { css } from 'styled-components';
@@ -871,7 +872,7 @@ const InsertImageModal = React.forwardRef((
     imageProcessState === InsertImageProcessImageState.PROCESSING ||
     submitState === InsertImageSubmitState.SUBMITTING;
 
-  return (
+  const modal = (
     <Modal show={visible} onHide={hide}>
       <Modal.Header closeButton>
         Insert image
@@ -931,6 +932,8 @@ const InsertImageModal = React.forwardRef((
       </Form>
     </Modal>
   );
+
+  return createPortal(modal, document.body);
 });
 
 const InsertImage = ({ documentId }: { documentId: string }) => {
@@ -966,30 +969,32 @@ const InsertImage = ({ documentId }: { documentId: string }) => {
     return null;
   }
 
+  const errorModal = (
+    <Modal show onHide={clearListSheetsError}>
+      <Modal.Header closeButton>
+        Error fetching sheets in spreadsheet
+      </Modal.Header>
+      <Modal.Body>
+        <p>
+          Something went wrong while fetching the list of sheets in this spreadsheet (which we
+          need to be able to insert an image). Please try again, or let us know if this keeps
+          happening.
+        </p>
+        <p>
+          Error message:
+          {' '}
+          {listSheetsError}
+        </p>
+      </Modal.Body>
+    </Modal>
+  );
+
   return (
     <>
       {renderInsertModal && (
         <InsertImageModal ref={insertModalRef} documentId={documentId} sheets={documentSheets} />
       )}
-      {listSheetsError && (
-        <Modal show onHide={clearListSheetsError}>
-          <Modal.Header closeButton>
-            Error fetching sheets in spreadsheet
-          </Modal.Header>
-          <Modal.Body>
-            <p>
-              Something went wrong while fetching the list of sheets in this spreadsheet (which we
-              need to be able to insert an image). Please try again, or let us know if this keeps
-              happening.
-            </p>
-            <p>
-              Error message:
-              {' '}
-              {listSheetsError}
-            </p>
-          </Modal.Body>
-        </Modal>
-      )}
+      {listSheetsError && createPortal(errorModal, document.body)}
       <Button variant="secondary" size="sm" onClick={onStartInsert} disabled={loading}>
         <FontAwesomeIcon icon={faImage} />
         {' '}
@@ -1723,7 +1728,7 @@ const PuzzleDeletedModal = ({
     hide();
   }, [puzzleId, hide]);
 
-  return (
+  const modal = (
     <Modal show={show} onHide={hide} backdrop="static">
       <Modal.Header closeButton>
         <Modal.Title>
@@ -1768,6 +1773,8 @@ const PuzzleDeletedModal = ({
       </Modal.Footer>
     </Modal>
   );
+
+  return createPortal(modal, document.body);
 };
 
 const PuzzlePage = React.memo(() => {


### PR DESCRIPTION
React's new-ish createPortal allows you to place a component outside of its rendering tree, which makes sense for modals which are effectively untethered from where they would appear by default in the DOM.

This is a more stable fix for problems we've had in the past with, e.g., overlay triggers, where the modal is inside of the overlay trigger and thus triggers the tooltip.

For some reason, the structural changes to the components which used forwardRef caused the react/prop-types eslint rule to start complaining. Since it's not really useful in a TypeScript world, I just turned it off.

Fixes #1317.