### PR TITLE
Add a semi-simple documentation system

### DIFF
--- a/docs/assets.md
+++ b/docs/assets.md
@@ -1,0 +1,55 @@
+---
+files:
+  - imports/client/lookupUrl.ts
+  - imports/lib/models/BlobMappings.ts
+  - imports/lib/publications/blobMappingsAll.ts
+  - imports/server/assets.ts
+  - imports/server/lookupUrl.ts
+  - imports/server/models/Blobs.ts
+  - imports/server/publications/blobMappingsAll.ts
+updated: 2024-01-09
+---
+
+# Custom Asset Pipeline
+
+Jolly Roger includes around a dozen versions of its logo, used as a mixture of
+in-app branding and iconography for various platforms (favicons, etc.).
+Administrators are able to override each of these images individually.
+
+In designing the asset system, there were two primary goals:
+
+- Make assets extremely cacheable, without needing to worry about cache
+  invalidation.
+- Ensure that customized content displays correctly on initial load, even before
+  initial Meteor subscriptions load.
+
+For cacheability, assets are served in a content-addressed manner, under the
+`/asset/:asset` endpoint in `imports/server/assets.ts`; the `:asset` parameter
+is the SHA256 of the image content. This endpoint serves both the default assets
+included in Jolly Roger's source code (using Meteor's [Assets library][Meteor Assets]) and uploaded custom assets (which are stored content-addressed in the
+`Blobs` modal). Either way, assets are served with Cache-Control headers that
+make it clear that they can be cached forever (or as close to forever as
+Cache-Control headers allow). In our standard production configuration, these
+headers should be respected by nginx, allowing most asset requests to be
+serviced without involving Meteor or a database lookup.
+
+Customizations to a given named asset are tracked in the `BlobMappings`
+collection, using the name of the asset as the `_id`. Absence of a record
+indicates that the default asset should be used.
+
+Ensuring that customized content appears correctly for server-side rendered
+content (such as `site.webmanifest` for Android icons) is relatively
+straightforward, as those renders do not need to be reactive. On the client, we
+need to ensure that the data is available both at initial load time and
+subsequently via a reactive subscription, in order to reflect updates.
+
+To ensure that client-side contexts have access to blob mappings immediately at
+load time, any records in `BlobMappings` are included in the initial page
+rendering using Meteor's [runtime configuration hook][addRuntimeConfigHook].
+Once the application JavaScript loads, the client subscribes to the
+`BlobMappings` collection and uses the ready state of that subscription to
+transition away from the load-time configuration. (This handoff is mediated in
+the client implementation of `lookupUrl` (`imports/client/lookupUrl.ts`)
+
+[Meteor Assets]: https://docs.meteor.com/api/assets.html
+[addRuntimeConfigHook]: https://docs.meteor.com/packages/webapp.html#WebApp-addRuntimeConfigHook

--- a/package-lock.json
+++ b/package-lock.json
@@ -2459,22 +2459,31 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
+    "@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      }
+    },
     "@csstools/css-parser-algorithms": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.3.2.tgz",
-      "integrity": "sha512-sLYGdAdEY2x7TSw9FtmdaTrh2wFtRJO5VMbBrA8tEqEod7GEggFmxTSK9XqExib3yMuYNcvcTdCZIP6ukdjAIA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.5.0.tgz",
+      "integrity": "sha512-abypo6m9re3clXA00eu5syw+oaPHbJTPapu9C4pzNsJ4hdZDzushT50Zhu+iIYXgEe1CxnRMn7ngsbV+MLrlpQ==",
       "dev": true
     },
     "@csstools/css-tokenizer": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.1.tgz",
-      "integrity": "sha512-Zmsf2f/CaEPWEVgw29odOj+WEVoiJy9s9NOv5GgNY9mZ1CZ7394By6wONrONrTsnNDv6F9hR02nvFihrGVGHBg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-2.2.3.tgz",
+      "integrity": "sha512-pp//EvZ9dUmGuGtG1p+n17gTHEOqu9jO+FiCUjNN3BDmyhdA2Jq9QsVeR7K8/2QCK17HSsioPlTW9ZkzoWb3Lg==",
       "dev": true
     },
     "@csstools/media-query-list-parser": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.5.tgz",
-      "integrity": "sha512-IxVBdYzR8pYe89JiyXQuYk4aVVoCPhMJkz6ElRwlVysjwURTsTk/bmY/z4FfeRE+CRBMlykPwXEVUg8lThv7AQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-2.1.7.tgz",
+      "integrity": "sha512-lHPKJDkPUECsyAvD60joYfDmp8UERYxHGkFfyLJFTVK/ERJe0sVlIFLXU5XFxdjNDTerp5L4KeaKG+Z5S94qxQ==",
       "dev": true
     },
     "@csstools/selector-specificity": {
@@ -2793,6 +2802,28 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "@juggle/resize-observer": {
       "version": "3.4.0",
@@ -4256,6 +4287,30 @@
         "@types/react-dom": "^18.0.0"
       }
     },
+    "@tsconfig/node10": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
+      "dev": true
+    },
     "@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -5109,6 +5164,12 @@
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
       }
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true
     },
     "argparse": {
       "version": "2.0.1",
@@ -7063,6 +7124,12 @@
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
       }
+    },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true
     },
     "cross-fetch": {
       "version": "3.1.6",
@@ -9233,6 +9300,15 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
     },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "dev": true,
+      "requires": {
+        "is-extendable": "^0.1.0"
+      }
+    },
     "extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -9849,6 +9925,39 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "dev": true,
+      "requires": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
+    },
     "h264-profile-level-id": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-1.0.1.tgz",
@@ -10134,6 +10243,13 @@
       "requires": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+          "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+        }
       }
     },
     "ipaddr.js": {
@@ -10232,6 +10348,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "dev": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
       "dev": true
     },
     "is-extglob": {
@@ -11022,6 +11144,12 @@
           "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
     },
     "map-obj": {
       "version": "4.3.0",
@@ -14756,6 +14884,16 @@
       "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.14.1.tgz",
       "integrity": "sha512-RjZyX3nVwJyCuTo5tGPx+PZWkDMCg7oOLpSlhjDdZfwUoNqG1mM8nyj31IGHyaPWXhjbP7cdK3qZ2bmkJ1GzRw=="
     },
+    "section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "dev": true,
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      }
+    },
     "semver": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
@@ -15158,9 +15296,10 @@
       }
     },
     "sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
     },
     "stack-generator": {
       "version": "2.0.5",
@@ -15713,6 +15852,12 @@
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
+    "strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "dev": true
+    },
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -16145,6 +16290,35 @@
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        }
+      }
+    },
     "tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -16390,6 +16564,12 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -16702,6 +16882,12 @@
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   },
   "scripts": {
     "lint:types": "tsc",
-    "lint:js": "eslint --max-warnings 0 --ext js,jsx,ts,tsx .",
+    "lint:js": "eslint --max-warnings 0 --ext js,jsx,ts,tsx,mjs,mts .",
     "lint:css": "stylelint '**/*.scss' '**/*.tsx'",
     "lint:format": "prettier --check .",
+    "lint:docs": "ts-node-esm tests/check_docs.mts",
     "lint": "meteor lint && npm-run-all --continue-on-error --parallel lint:*",
     "test": "TEST_BROWSER_DRIVER=puppeteer meteor test --full-app --once --driver-package meteortesting:mocha",
     "prepare": "npm explore eslint-plugin-jolly-roger -- npm run build",
@@ -119,6 +120,7 @@
     "eslint-plugin-meteor": "^7.3.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "gray-matter": "^4.0.3",
     "lockfix": "^2.2.1",
     "mocha": "^10.2.0",
     "npm-run-all": "^4.1.5",
@@ -129,6 +131,7 @@
     "stylelint": "^15.11.0",
     "stylelint-config-standard": "^34.0.0",
     "stylelint-scss": "^5.3.2",
+    "ts-node": "^10.9.1",
     "typescript": "^5.3.3"
   },
   "meteor": {

--- a/tests/check_docs.mts
+++ b/tests/check_docs.mts
@@ -1,0 +1,170 @@
+/**
+ * Require that documentation is kept up to date as the referenced files change.
+ *
+ * To do this, for each file in the docs directory, we look at the set of files
+ * listed in the front matter and check when each of them last changed. If any
+ * of them is more recent than the last commit to the doc file, then the doc is
+ * out of date. (If the files have changed but the documentation doesn't require
+ * changing, then you can update the "updated" date in the documentation, which
+ * will bring the latest commit to the doc up to date with the changes to the
+ * files it documents)
+ */
+import child from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import matter from "gray-matter";
+
+const execFile = promisify(child.execFile);
+
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
+
+interface NewerFile {
+  file: string;
+  commit: string;
+}
+
+type DocError =
+  | {
+      type: "out-of-date";
+      doc: string;
+      newerFiles: NewerFile[];
+    }
+  | {
+      type: "missing-front-matter";
+      doc: string;
+    }
+  | {
+      type: "missing-updated-field";
+      doc: string;
+    }
+  | {
+      type: "missing-files";
+      doc: string;
+    };
+
+const checkDoc = async (doc: string): Promise<DocError | undefined> => {
+  const docMatter = matter(await fs.readFile(doc));
+
+  if (!docMatter.data.updated) {
+    return {
+      type: "missing-updated-field",
+      doc,
+    };
+  }
+
+  // First: figure out how recent the documentation is by looking at the last
+  // commit to the file.
+  const { stdout: fileRevision } = await execFile("git", [
+    "rev-list",
+    "-1",
+    "HEAD",
+    "--",
+    doc,
+  ]);
+  const docRevision = fileRevision.trim();
+
+  // If the doc file has no revision, then it's probably a new file being
+  // written, which is fine (definitionally newer than antyhing that's been
+  // committed)
+  if (!docRevision) return undefined;
+
+  // Next: figure out if any of the referenced files are more recent than our
+  // doc revision
+  const files: string[] = docMatter.data.files;
+  if (
+    !files ||
+    !Array.isArray(files) ||
+    !files.every((file) => typeof file === "string")
+  ) {
+    return {
+      type: "missing-files",
+      doc,
+    };
+  }
+
+  const fileChecks = await Promise.all(
+    files.map(async (file) => {
+      const { stdout: updated } = await execFile("git", [
+        "rev-list",
+        "-1",
+        "HEAD",
+        `^${docRevision}`,
+        "--",
+        file,
+      ]);
+      if (updated.trim().length > 0) {
+        return { file, commit: updated.trim() };
+      }
+
+      return undefined;
+    }),
+  );
+  const newerFiles = fileChecks.filter(
+    (fc): fc is NewerFile => fc !== undefined,
+  );
+  if (newerFiles.length > 0) {
+    return {
+      type: "out-of-date",
+      doc,
+      newerFiles,
+    };
+  }
+
+  return undefined;
+};
+
+const main = async () => {
+  const docsDir = path.join(dirname, "..", "docs");
+  const docs = await fs.readdir(docsDir);
+
+  const results = await Promise.all(
+    docs.map((doc) => checkDoc(path.join(docsDir, doc))),
+  );
+  const errors = results.filter(
+    (result): result is DocError => result !== undefined,
+  );
+
+  if (errors.length > 0) {
+    process.stderr.write("Documentation errors:\n\n");
+    for (const error of errors) {
+      switch (error.type) {
+        case "out-of-date":
+          process.stderr.write(
+            `  ${path.basename(error.doc)} is out of date\n`,
+          );
+          for (const newerFile of error.newerFiles) {
+            process.stderr.write(
+              `    ${newerFile.file} was updated in ${newerFile.commit}\n`,
+            );
+          }
+          process.stderr.write(
+            `  To fix this, either update ${path.basename(
+              error.doc,
+            )} or, if no changes are needed, change the updated field to today's date.\n`,
+          );
+          break;
+        case "missing-front-matter":
+          process.stderr.write(`  ${error.doc} is missing front matter\n`);
+          break;
+        case "missing-updated-field":
+          process.stderr.write(`  ${error.doc} is missing updated field\n`);
+          break;
+        case "missing-files":
+          process.stderr.write(`  ${error.doc} is missing files field\n`);
+          break;
+        default:
+          process.stderr.write(`  unknown error type ${error}\n`);
+      }
+      process.stderr.write("\n");
+    }
+
+    process.exit(1);
+  }
+
+  process.exit(0);
+};
+
+await main();


### PR DESCRIPTION
Some higher-level information about a codebase are hard to document inline in code. For systems that span multiple files, functions, etc., it's useful to have a more centralized source of documentation. However, the inherent risk of any such centralized documentation is that it quickly becomes out of date.

Introduce a `docs` folder, containing such higher-level documentation. However, to mitigate against docs becoming out of date, additionally introduce some validation in the form of a new, homegrown linter. This linter requires that some metadata be included with each documentation file: specifically, which files the documentation covers and when the documentation was last updated. If the files are ever updated without a corresponding update to the docs, the linter will fail.

Here's what an error message looks like if a documentation file is out of date:

```
> jolly-roger@0.0.1 lint:docs /Users/evan/src/jolly-roger
> ts-node-esm tests/check_docs.mts

Documentation errors:

  assets.md is out of date
    imports/lib/models/BlobMappings.ts was updated in 4a64684c3dfe9cbd94ff30a018541f0c430c8b6b
    imports/server/models/Blobs.ts was updated in 4a64684c3dfe9cbd94ff30a018541f0c430c8b6b
  To fix this, either update assets.md or, if no changes are needed, change the updated field to match the most recent commit to those files.
```

This introduces the system for #1279, although I'm not going to claim it fixes it until we have a bit more of a library of documentation.

(As an aside, I experimented with using a third-party service - swimm.io - which does something similar to my linter. I ultimately rejected it in favor of this approach because (a) their documentation files are committed to the repo, but in a `.swm` hidden directory making them less discoverable (b) their files can't be edited directly but have to be edited through their web app, limiting ability of others to contribute (c) it's not entirely clear how their detection of out-of-date documentation works and thus how likely it would be to false-negative when updates are necessary. You can see what their committed docs look like on [`evan/custom-asset-docs`](https://github.com/deathandmayhem/jolly-roger/compare/evan/custom-asset-docs?expand=1) if you're curious.)