### PR TITLE
Coalesce dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,13 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "friday"
     open-pull-requests-limit: 20
+    groups:
+      all:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot has support for grouping updates based on various characteristics. Given that most package updates either require no code changes or are backwards-incompatible and should be ignored, we can reduce PR churn by opening a single PR with all pending changes.

In order to make this more effective, also push updates to happen weekly, instead of daily. I picked Fridays, as that tends to be when I'm most available to look at PRs, and leads into the weekend for maximum flexibility.

Note that none of this applies to security updates, which dependabot will still open immediately.

(Documentation for these configuration options is at https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file. That page also includes the dependabot commands which let you exclude individual dependencies if you want, using `@dependabot ignore <DEPENDENCY> [MAJOR_VERSION [MINOR_VERSION]]`)