### PR TITLE
Configure dependabot ignores by file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,26 @@ updates:
       all:
         patterns:
           - "*"
+    ignore:
+      # All of these dependencies require Node v16 or greater
+      - dependency-name: "@types/node"
+        versions: [">=14"]
+      - dependency-name: "@typescript-eslint/eslint-plugin"
+        versions: [">=6"]
+      - dependency-name: "@typescript-eslint/parser"
+        versions: [">=6"]
+      - dependency-name: "@typescript-eslint/utils"
+        versions: [">=6"]
+      - dependency-name: "discord.js"
+        versions: [">=13"]
+      - dependency-name: "glob"
+        versions: [">=9"]
+      - dependency-name: "puppeteer"
+      # marked has had significant API revisions that we need to take manually
+      - dependency-name: "marked"
+        versions: [">=5"]
+      - dependency-name: "@types/marked"
+        versions: [">=5"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
This both gives us better persistent tracking of updates that we intentionally aren't taking and also gives us a workaround for a current bug where the "@dependabot ignore" directive doesn't work for "@"-prefixed packages.

Once merged, I'll go through and issue unignore directives for each of these, so that they don't override the ignore directives in the config file.

(As a note, I have filed a bug with GH about the error in the @dependabot directives and they've acknowledged that they're working on it. This still seems like a better approach, though)