### PR TITLE
Replace try/finally blocks with new "using" syntax

### DIFF
--- a/client/main.ts
+++ b/client/main.ts
@@ -2,6 +2,9 @@
 import '../imports/client/bugsnag';
 import '../imports/client/configureLogger';
 
+// Polyfills
+import 'disposablestack/auto';
+
 // explicitly import all the stuff from lib/ since mainModule skips autoloading
 // things
 import '../imports/lib/config/accounts';

--- a/imports/server/gdriveActivityFetcher.ts
+++ b/imports/server/gdriveActivityFetcher.ts
@@ -154,40 +154,35 @@ async function fetchActivityLoop() {
 
     await withLock('drive-activity', async (renew) => {
       // Ensure that we continue to hold the lock as long as we're alive.
-      let renewInterval;
-      try {
-        const renewalFailure = new Promise<boolean>((r) => {
-          renewInterval = Meteor.setInterval(async () => {
-            try {
-              await renew();
-            } catch (e) {
-              // We failed to renew the lock
-              r(true);
-            }
-          }, PREEMPT_TIMEOUT / 2);
-        });
-
-        // As long as we are alive and the feature flag is not active, hold the
-        // lock and keep looping
-        while (true) {
-          if (await Flags.activeAsync(FEATURE_FLAG_NAME)) {
-            return; // from withLock
+      using cleanup = new DisposableStack();
+      const renewalFailure = new Promise<boolean>((r) => {
+        const renewInterval = Meteor.setInterval(async () => {
+          try {
+            await renew();
+          } catch (e) {
+            // We failed to renew the lock
+            r(true);
           }
+        }, PREEMPT_TIMEOUT / 2);
+        cleanup.defer(() => Meteor.clearInterval(renewInterval));
+      });
 
-          await fetchDriveActivity();
-
-          // Wake up every 5 seconds (+/- 1 second of jitter)
-          const sleep = new Promise<boolean>((r) => {
-            Meteor.setTimeout(() => r(false), 4 * 1000 + Math.random() * 2 * 1000);
-          });
-          const renewalFailed = await Promise.race([sleep, renewalFailure]);
-          if (renewalFailed) {
-            return; // from withLock
-          }
+      // As long as we are alive and the feature flag is not active, hold the
+      // lock and keep looping
+      while (true) {
+        if (await Flags.activeAsync(FEATURE_FLAG_NAME)) {
+          return; // from withLock
         }
-      } finally {
-        if (renewInterval) {
-          Meteor.clearInterval(renewInterval);
+
+        await fetchDriveActivity();
+
+        // Wake up every 5 seconds (+/- 1 second of jitter)
+        const sleep = new Promise<boolean>((r) => {
+          Meteor.setTimeout(() => r(false), 4 * 1000 + Math.random() * 2 * 1000);
+        });
+        const renewalFailed = await Promise.race([sleep, renewalFailure]);
+        if (renewalFailed) {
+          return; // from withLock
         }
       }
     });

--- a/imports/server/withLock.ts
+++ b/imports/server/withLock.ts
@@ -33,82 +33,67 @@ export default async function withLock<T>(
   critSection: (renew: () => Promise<void>) => Promise<T>
 ) {
   while (true) {
-    let handle: Meteor.LiveQueryHandle | undefined;
-    let lock: string | undefined;
-    let timeoutHandle: number | undefined;
+    await using cleanup = new AsyncDisposableStack();
 
-    const cleanupWatches = () => {
-      if (handle) {
-        handle.stop();
-        handle = undefined;
-      }
-      if (timeoutHandle) {
-        Meteor.clearTimeout(timeoutHandle);
+    const cursor = Locks.find({ name });
+
+    // Setup the watch now so we don't race between when we check
+    // for the lock and when we wait for preemption
+    const removed = new Promise<undefined>((resolve) => {
+      const handle = cursor.observeChanges({
+        removed() {
+          resolve(undefined);
+        },
+      });
+      cleanup.defer(() => handle.stop());
+    });
+
+    const lock = await tryAcquire(name);
+    if (lock) {
+      cleanup.defer(() => release(lock));
+      return critSection(() => renew(lock));
+    }
+
+    // Lock is held, so wait until we can preempt
+    const timedOut = new Promise<LockType | undefined>((resolve) => {
+      let timeoutHandle: number | undefined;
+      cleanup.defer(() => {
+        if (timeoutHandle) Meteor.clearTimeout(timeoutHandle);
+      });
+      const waitForDeadline = async () => {
         timeoutHandle = undefined;
-      }
-    };
-    try {
-      const cursor = Locks.find({ name });
+        const otherLock = (await cursor.fetchAsync())[0];
+        if (!otherLock) {
+          // Lock was deleted, so removed promise will resolve
+          resolve(undefined);
+          return;
+        }
 
-      // Setup the watch now so we don't race between when we check
-      // for the lock and when we wait for preemption
-      const removed = new Promise<undefined>((resolve) => {
-        handle = cursor.observeChanges({
-          removed() {
-            resolve(undefined);
-          },
-        });
+        const deadline =
+          (otherLock.renewedAt || otherLock.createdAt).getTime() +
+          PREEMPT_TIMEOUT;
+        const timeout = deadline - Date.now();
+
+        if (timeout <= 0) {
+          // Lock is expired, so we can preempt it
+          resolve(otherLock);
+          return;
+        }
+
+        // Otherwise wait until expiration and then check again
+        timeoutHandle = Meteor.setTimeout(waitForDeadline, timeout);
+      };
+      void waitForDeadline();
+    });
+
+    // If we time out, then preempt
+    const preemptableLock = await Promise.race([removed, timedOut]);
+    if (preemptableLock) {
+      Logger.warn('Preempting lock', { id: preemptableLock._id, name });
+      await Locks.removeAsync({
+        _id: preemptableLock._id,
+        renewedAt: preemptableLock.renewedAt,
       });
-
-      lock = await tryAcquire(name);
-      if (lock) {
-        const lockId = lock;
-        return await critSection(() => renew(lockId));
-      }
-
-      // Lock is held, so wait until we can preempt
-      const timedOut = new Promise<LockType | undefined>((resolve) => {
-        const waitForDeadline = async () => {
-          const otherLock = (await cursor.fetchAsync())[0];
-          if (!otherLock) {
-            // Lock was deleted, so removed promise will resolve
-            resolve(undefined);
-            return;
-          }
-
-          const deadline =
-            (otherLock.renewedAt || otherLock.createdAt).getTime() +
-            PREEMPT_TIMEOUT;
-          const timeout = deadline - Date.now();
-
-          if (timeout <= 0) {
-            // Lock is expired, so we can preempt it
-            resolve(otherLock);
-            return;
-          }
-
-          // Otherwise wait until expiration and then check again
-          timeoutHandle = Meteor.setTimeout(waitForDeadline, timeout);
-        };
-        void waitForDeadline();
-      });
-
-      // If we time out, then preempt
-      const preemptableLock = await Promise.race([removed, timedOut]);
-      cleanupWatches();
-      if (preemptableLock) {
-        Logger.warn('Preempting lock', { id: preemptableLock._id, name });
-        await Locks.removeAsync({
-          _id: preemptableLock._id,
-          renewedAt: preemptableLock.renewedAt,
-        });
-      }
-    } finally {
-      cleanupWatches();
-
-      if (lock) {
-        await release(lock);
-      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5424,7 +5424,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
       "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "is-array-buffer": "^3.0.1"
@@ -6429,7 +6428,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.1.tgz",
       "integrity": "sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==",
-      "dev": true,
       "requires": {
         "array-buffer-byte-length": "^1.0.0",
         "call-bind": "^1.0.2",
@@ -6443,7 +6441,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
           "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
-          "dev": true,
           "requires": {
             "has-property-descriptors": "^1.0.0",
             "object-keys": "^1.1.1"
@@ -6453,7 +6450,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
           "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
-          "dev": true,
           "requires": {
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
@@ -6464,14 +6460,12 @@
         "has-symbols": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-          "dev": true
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         },
         "is-array-buffer": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
           "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
-          "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "get-intrinsic": "^1.2.0",
@@ -6482,7 +6476,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
           "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-          "dev": true,
           "requires": {
             "call-bind": "^1.0.2"
           }
@@ -6557,8 +6550,7 @@
     "available-typed-arrays": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-      "dev": true
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "awaitqueue": {
       "version": "3.0.1",
@@ -7414,7 +7406,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -7500,6 +7491,208 @@
         "setimmediate": "^1.0.5",
         "tweetnacl": "^1.0.3",
         "ws": "^7.4.4"
+      }
+    },
+    "disposablestack": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/disposablestack/-/disposablestack-1.1.1.tgz",
+      "integrity": "sha512-Kt80F3SgFOnAGyUj+VbOhLEdrjnii4sphhqlTgaSiLaVRaKr3QsW6QGgILxiEt2pBOG694f9fcVtuuNP7cFWnQ==",
+      "requires": {
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "es-set-tostringtag": "^2.0.1",
+        "get-intrinsic": "^1.2.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.5",
+        "suppressed-error": "^1.0.0"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+          "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+          "requires": {
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.22.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
+          "integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
+          "requires": {
+            "array-buffer-byte-length": "^1.0.0",
+            "arraybuffer.prototype.slice": "^1.0.1",
+            "available-typed-arrays": "^1.0.5",
+            "call-bind": "^1.0.2",
+            "es-set-tostringtag": "^2.0.1",
+            "es-to-primitive": "^1.2.1",
+            "function.prototype.name": "^1.1.5",
+            "get-intrinsic": "^1.2.1",
+            "get-symbol-description": "^1.0.0",
+            "globalthis": "^1.0.3",
+            "gopd": "^1.0.1",
+            "has": "^1.0.3",
+            "has-property-descriptors": "^1.0.0",
+            "has-proto": "^1.0.1",
+            "has-symbols": "^1.0.3",
+            "internal-slot": "^1.0.5",
+            "is-array-buffer": "^3.0.2",
+            "is-callable": "^1.2.7",
+            "is-negative-zero": "^2.0.2",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.2",
+            "is-string": "^1.0.7",
+            "is-typed-array": "^1.1.10",
+            "is-weakref": "^1.0.2",
+            "object-inspect": "^1.12.3",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.4",
+            "regexp.prototype.flags": "^1.5.0",
+            "safe-array-concat": "^1.0.0",
+            "safe-regex-test": "^1.0.0",
+            "string.prototype.trim": "^1.2.7",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
+            "typed-array-buffer": "^1.0.0",
+            "typed-array-byte-length": "^1.0.0",
+            "typed-array-byte-offset": "^1.0.0",
+            "typed-array-length": "^1.0.4",
+            "unbox-primitive": "^1.0.2",
+            "which-typed-array": "^1.1.10"
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-proto": "^1.0.1",
+            "has-symbols": "^1.0.3"
+          }
+        },
+        "has-bigints": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+          "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+        },
+        "internal-slot": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+          "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+          "requires": {
+            "get-intrinsic": "^1.2.0",
+            "has": "^1.0.3",
+            "side-channel": "^1.0.4"
+          }
+        },
+        "is-array-buffer": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+          "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "get-intrinsic": "^1.2.0",
+            "is-typed-array": "^1.1.10"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+          "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+        },
+        "is-shared-array-buffer": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+          "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+          "requires": {
+            "call-bind": "^1.0.2"
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "object-inspect": {
+          "version": "1.12.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+          "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
+        },
+        "object.assign": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+          "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "has-symbols": "^1.0.3",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "regexp.prototype.flags": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+          "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.2.0",
+            "functions-have-names": "^1.2.3"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+          "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.20.4"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+          "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.20.4"
+          }
+        },
+        "unbox-primitive": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+          "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-bigints": "^1.0.2",
+            "has-symbols": "^1.0.3",
+            "which-boxed-primitive": "^1.0.2"
+          }
+        },
+        "which-typed-array": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+          "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+          "requires": {
+            "available-typed-arrays": "^1.0.5",
+            "call-bind": "^1.0.2",
+            "for-each": "^0.3.3",
+            "gopd": "^1.0.1",
+            "has-tostringtag": "^1.0.0"
+          }
+        }
       }
     },
     "doctrine": {
@@ -7610,7 +7803,6 @@
       "version": "1.19.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
       "integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -7637,20 +7829,17 @@
         "has-symbols": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-          "dev": true
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         },
         "is-callable": {
           "version": "1.2.4",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
-          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
-          "dev": true
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w=="
         },
         "is-string": {
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
           "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-          "dev": true,
           "requires": {
             "has-tostringtag": "^1.0.0"
           }
@@ -7900,7 +8089,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
       "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.3",
         "has": "^1.0.3",
@@ -7911,7 +8099,6 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-          "dev": true,
           "requires": {
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
@@ -7921,8 +8108,7 @@
         "has-symbols": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-          "dev": true
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         }
       }
     },
@@ -7939,7 +8125,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -9428,7 +9613,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.3"
       }
@@ -9511,7 +9695,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
       "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -9522,8 +9705,7 @@
     "functions-have-names": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
     },
     "gauge": {
       "version": "3.0.2",
@@ -9638,7 +9820,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
       "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
@@ -9758,7 +9939,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
       "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.3"
       }
@@ -9899,7 +10079,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.3"
       },
@@ -9908,7 +10087,6 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-          "dev": true,
           "requires": {
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
@@ -9918,8 +10096,7 @@
         "has-symbols": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-          "dev": true
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         }
       }
     },
@@ -9979,8 +10156,7 @@
     "has-bigints": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
-      "dev": true
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
     },
     "has-flag": {
       "version": "4.0.0",
@@ -9992,7 +10168,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.1"
       }
@@ -10000,8 +10175,7 @@
     "has-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-      "dev": true
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -10012,7 +10186,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
       "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
       },
@@ -10020,8 +10193,7 @@
         "has-symbols": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-          "dev": true
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
         }
       }
     },
@@ -10209,7 +10381,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
       "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
-      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.0",
         "has": "^1.0.3",
@@ -10271,7 +10442,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
       "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -10282,7 +10452,6 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-          "dev": true,
           "requires": {
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
@@ -10292,8 +10461,7 @@
         "has-symbols": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-          "dev": true
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         }
       }
     },
@@ -10315,7 +10483,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
       "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-      "dev": true,
       "requires": {
         "has-bigints": "^1.0.1"
       }
@@ -10331,8 +10498,7 @@
     "is-callable": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
-      "dev": true
+      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
     },
     "is-core-module": {
       "version": "2.9.0",
@@ -10346,8 +10512,7 @@
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -10399,8 +10564,7 @@
     "is-negative-zero": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-      "dev": true
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
     },
     "is-number": {
       "version": "7.0.0",
@@ -10418,8 +10582,7 @@
     "is-number-object": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
-      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
-      "dev": true
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw=="
     },
     "is-path-inside": {
       "version": "3.0.3",
@@ -10442,7 +10605,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
       "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
@@ -10457,8 +10619,7 @@
     "is-shared-array-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
-      "dev": true
+      "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
     },
     "is-stream": {
       "version": "2.0.1",
@@ -10468,14 +10629,12 @@
     "is-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
-      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
-      "dev": true
+      "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ=="
     },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -10484,7 +10643,6 @@
       "version": "1.1.10",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
       "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
-      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -10509,7 +10667,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
       "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2"
       }
@@ -10527,8 +10684,7 @@
     "isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
     },
     "iserror": {
       "version": "0.0.2",
@@ -12580,8 +12736,7 @@
     "object-inspect": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
-      "dev": true
+      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g=="
     },
     "object-is": {
       "version": "1.1.5",
@@ -12596,14 +12751,12 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
       "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -14751,7 +14904,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.0.tgz",
       "integrity": "sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.0",
@@ -14763,7 +14915,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
           "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
-          "dev": true,
           "requires": {
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
@@ -14774,8 +14925,7 @@
         "has-symbols": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-          "dev": true
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         }
       }
     },
@@ -14788,7 +14938,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
       "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.3",
@@ -14799,7 +14948,6 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
           "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
-          "dev": true,
           "requires": {
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
@@ -14809,8 +14957,7 @@
         "has-symbols": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-          "dev": true
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         }
       }
     },
@@ -15503,7 +15650,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.7.tgz",
       "integrity": "sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
@@ -15514,7 +15660,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
           "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
-          "dev": true,
           "requires": {
             "has-property-descriptors": "^1.0.0",
             "object-keys": "^1.1.1"
@@ -15524,7 +15669,6 @@
           "version": "1.22.1",
           "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
           "integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
-          "dev": true,
           "requires": {
             "array-buffer-byte-length": "^1.0.0",
             "arraybuffer.prototype.slice": "^1.0.1",
@@ -15571,7 +15715,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
           "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
-          "dev": true,
           "requires": {
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
@@ -15582,20 +15725,17 @@
         "has-bigints": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-          "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-          "dev": true
+          "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
         },
         "has-symbols": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-          "dev": true
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         },
         "internal-slot": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
           "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
-          "dev": true,
           "requires": {
             "get-intrinsic": "^1.2.0",
             "has": "^1.0.3",
@@ -15606,7 +15746,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
           "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
-          "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "get-intrinsic": "^1.2.0",
@@ -15616,14 +15755,12 @@
         "is-callable": {
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-          "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-          "dev": true
+          "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
         },
         "is-shared-array-buffer": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
           "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-          "dev": true,
           "requires": {
             "call-bind": "^1.0.2"
           }
@@ -15632,7 +15769,6 @@
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
           "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-          "dev": true,
           "requires": {
             "has-tostringtag": "^1.0.0"
           }
@@ -15640,14 +15776,12 @@
         "object-inspect": {
           "version": "1.12.3",
           "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-          "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
-          "dev": true
+          "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
         },
         "object.assign": {
           "version": "4.1.4",
           "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
           "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
-          "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.4",
@@ -15659,7 +15793,6 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
           "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
-          "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.2.0",
@@ -15670,7 +15803,6 @@
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
           "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
-          "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.4",
@@ -15681,7 +15813,6 @@
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
           "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
-          "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "define-properties": "^1.1.4",
@@ -15692,7 +15823,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
           "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-          "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "has-bigints": "^1.0.2",
@@ -15704,7 +15834,6 @@
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
           "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
-          "dev": true,
           "requires": {
             "available-typed-arrays": "^1.0.5",
             "call-bind": "^1.0.2",
@@ -15719,7 +15848,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
       "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -15729,7 +15857,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
       "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -16158,6 +16285,208 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
+    "suppressed-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/suppressed-error/-/suppressed-error-1.0.0.tgz",
+      "integrity": "sha512-vSxeOCv6K6F7WEmHp1oLaEkLG88U2nvSTwD+Y63VsyR3tyKLbVCfgmnBIQA5KHH5HtQm+AT3WySUuI1cUnUmuw==",
+      "requires": {
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.21.1",
+        "function-bind": "^1.1.1",
+        "functions-have-names": "^1.2.3",
+        "get-intrinsic": "^1.2.0",
+        "globalthis": "^1.0.3",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.0.tgz",
+          "integrity": "sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==",
+          "requires": {
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.22.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.1.tgz",
+          "integrity": "sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==",
+          "requires": {
+            "array-buffer-byte-length": "^1.0.0",
+            "arraybuffer.prototype.slice": "^1.0.1",
+            "available-typed-arrays": "^1.0.5",
+            "call-bind": "^1.0.2",
+            "es-set-tostringtag": "^2.0.1",
+            "es-to-primitive": "^1.2.1",
+            "function.prototype.name": "^1.1.5",
+            "get-intrinsic": "^1.2.1",
+            "get-symbol-description": "^1.0.0",
+            "globalthis": "^1.0.3",
+            "gopd": "^1.0.1",
+            "has": "^1.0.3",
+            "has-property-descriptors": "^1.0.0",
+            "has-proto": "^1.0.1",
+            "has-symbols": "^1.0.3",
+            "internal-slot": "^1.0.5",
+            "is-array-buffer": "^3.0.2",
+            "is-callable": "^1.2.7",
+            "is-negative-zero": "^2.0.2",
+            "is-regex": "^1.1.4",
+            "is-shared-array-buffer": "^1.0.2",
+            "is-string": "^1.0.7",
+            "is-typed-array": "^1.1.10",
+            "is-weakref": "^1.0.2",
+            "object-inspect": "^1.12.3",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.4",
+            "regexp.prototype.flags": "^1.5.0",
+            "safe-array-concat": "^1.0.0",
+            "safe-regex-test": "^1.0.0",
+            "string.prototype.trim": "^1.2.7",
+            "string.prototype.trimend": "^1.0.6",
+            "string.prototype.trimstart": "^1.0.6",
+            "typed-array-buffer": "^1.0.0",
+            "typed-array-byte-length": "^1.0.0",
+            "typed-array-byte-offset": "^1.0.0",
+            "typed-array-length": "^1.0.4",
+            "unbox-primitive": "^1.0.2",
+            "which-typed-array": "^1.1.10"
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
+          "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-proto": "^1.0.1",
+            "has-symbols": "^1.0.3"
+          }
+        },
+        "has-bigints": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+          "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+        },
+        "internal-slot": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.5.tgz",
+          "integrity": "sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==",
+          "requires": {
+            "get-intrinsic": "^1.2.0",
+            "has": "^1.0.3",
+            "side-channel": "^1.0.4"
+          }
+        },
+        "is-array-buffer": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+          "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "get-intrinsic": "^1.2.0",
+            "is-typed-array": "^1.1.10"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+          "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+        },
+        "is-shared-array-buffer": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+          "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+          "requires": {
+            "call-bind": "^1.0.2"
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "object-inspect": {
+          "version": "1.12.3",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+          "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g=="
+        },
+        "object.assign": {
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+          "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "has-symbols": "^1.0.3",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "regexp.prototype.flags": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.0.tgz",
+          "integrity": "sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.2.0",
+            "functions-have-names": "^1.2.3"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+          "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.20.4"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+          "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.4",
+            "es-abstract": "^1.20.4"
+          }
+        },
+        "unbox-primitive": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+          "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-bigints": "^1.0.2",
+            "has-symbols": "^1.0.3",
+            "which-boxed-primitive": "^1.0.2"
+          }
+        },
+        "which-typed-array": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
+          "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+          "requires": {
+            "available-typed-arrays": "^1.0.5",
+            "call-bind": "^1.0.2",
+            "for-each": "^0.3.3",
+            "gopd": "^1.0.1",
+            "has-tostringtag": "^1.0.0"
+          }
+        }
+      }
+    },
     "svg-tags": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
@@ -16390,7 +16719,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
       "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.2.1",
@@ -16401,7 +16729,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
           "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
-          "dev": true,
           "requires": {
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
@@ -16412,8 +16739,7 @@
         "has-symbols": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-          "dev": true
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
         }
       }
     },
@@ -16421,7 +16747,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
       "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "for-each": "^0.3.3",
@@ -16433,7 +16758,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
       "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
-      "dev": true,
       "requires": {
         "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
@@ -16446,7 +16770,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
       "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
-      "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "for-each": "^0.3.3",
@@ -16468,7 +16791,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
       "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has-bigints": "^1.0.1",
@@ -16479,8 +16801,7 @@
         "has-symbols": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-          "dev": true
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
         }
       }
     },
@@ -16670,7 +16991,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
       "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "dev": true,
       "requires": {
         "is-bigint": "^1.0.1",
         "is-boolean-object": "^1.1.0",
@@ -16683,7 +17003,6 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
           "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-          "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "has-tostringtag": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bootstrap": "^5.3.1",
     "classnames": "^2.3.2",
     "discord.js": "^12.5.3",
+    "disposablestack": "^1.1.1",
     "dompurify": "^3.0.5",
     "element-resize-detector": "^1.2.4",
     "express": "^4.18.2",

--- a/server/main.ts
+++ b/server/main.ts
@@ -2,6 +2,9 @@
 import '../imports/server/bugsnag';
 import '../imports/server/configureLogger';
 
+// Polyfills
+import 'disposablestack/auto';
+
 // setup database management
 import '../imports/server/schemas';
 import '../imports/server/indexes';


### PR DESCRIPTION
(Note that this definitely looks best with a whitespace-insensitive diff)

Maybe not a huge improvement, but I like these for putting the cleanup at the same place as the resource acquisition.

(At some point in the future, I might put together a disposable version of `Meteor.setTimeout` / `Meteor.setInterval` since that seems to be a pattern)