### PR TITLE
Add bookmarking for puzzles

### DIFF
--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -1,6 +1,8 @@
+import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons/faStar';
 import { faEdit } from '@fortawesome/free-solid-svg-icons/faEdit';
 import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
+import { faStar as faStarSolid } from '@fortawesome/free-solid-svg-icons/faStar';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, {
   type ComponentPropsWithRef, type FC, useCallback, useMemo, useRef, useState,
@@ -14,6 +16,7 @@ import type { PuzzleType } from '../../lib/models/Puzzles';
 import type { TagType } from '../../lib/models/Tags';
 import type { Solvedness } from '../../lib/solvedness';
 import { computeSolvedness } from '../../lib/solvedness';
+import bookmarkPuzzle from '../../methods/bookmarkPuzzle';
 import updatePuzzle from '../../methods/updatePuzzle';
 import { useOperatorActionsHiddenForHunt } from '../hooks/persisted-state';
 import PuzzleActivity from './PuzzleActivity';
@@ -51,7 +54,7 @@ const PuzzleColumn = styled.div`
   overflow: hidden;
 `;
 
-const PuzzleEditButtonsColumn = styled(PuzzleColumn)`
+const PuzzleControlButtonsColumn = styled(PuzzleColumn)`
   align-self: flex-start;
   order: -1;
 `;
@@ -109,9 +112,10 @@ const TagListColumn = styled(TagList)`
 `;
 
 const Puzzle = React.memo(({
-  puzzle, allTags, canUpdate, suppressTags, segmentAnswers,
+  puzzle, bookmarked, allTags, canUpdate, suppressTags, segmentAnswers,
 }: {
   puzzle: PuzzleType;
+  bookmarked: boolean;
   // All tags associated with the hunt.
   allTags: TagType[];
   canUpdate: boolean;
@@ -156,7 +160,7 @@ const Puzzle = React.memo(({
   const editButtons = useMemo(() => {
     if (showEdit) {
       return (
-        <ButtonGroup size="sm">
+        <>
           <StyledButton onClick={onShowEditModal} variant="light" title="Edit puzzle...">
             <FontAwesomeIcon icon={faEdit} />
           </StyledButton>
@@ -165,11 +169,15 @@ const Puzzle = React.memo(({
               <FontAwesomeIcon icon={faMinus} />
             </StyledButton>
           )}
-        </ButtonGroup>
+        </>
       );
     }
     return null;
   }, [showEdit, puzzle.deleted, onShowEditModal, onShowDeleteModal]);
+
+  const toggleBookmark = useCallback(() => {
+    bookmarkPuzzle.call({ puzzleId: puzzle._id, bookmark: !bookmarked });
+  }, [puzzle._id, bookmarked]);
 
   // id, title, answer, tags
   const linkTarget = `/hunts/${puzzle.hunt}/puzzles/${puzzle._id}`;
@@ -206,11 +214,14 @@ const Puzzle = React.memo(({
           puzzle={puzzle}
         />
       )}
-      {showEdit && (
-        <PuzzleEditButtonsColumn>
-          {editButtons}
-        </PuzzleEditButtonsColumn>
-      )}
+      <PuzzleControlButtonsColumn>
+        <ButtonGroup size="sm">
+          <StyledButton onClick={toggleBookmark} variant="light" title="Bookmark puzzle">
+            <FontAwesomeIcon icon={bookmarked ? faStarSolid : faStarRegular} />
+          </StyledButton>
+          {showEdit && editButtons}
+        </ButtonGroup>
+      </PuzzleControlButtonsColumn>
       <PuzzleTitleColumn>
         <Link to={linkTarget}>{puzzle.title}</Link>
       </PuzzleTitleColumn>

--- a/imports/client/components/PuzzleList.tsx
+++ b/imports/client/components/PuzzleList.tsx
@@ -4,10 +4,11 @@ import type { TagType } from '../../lib/models/Tags';
 import Puzzle from './Puzzle';
 
 const PuzzleList = React.memo(({
-  puzzles, allTags, canUpdate, suppressTags, segmentAnswers,
+  puzzles, bookmarked, allTags, canUpdate, suppressTags, segmentAnswers,
 }: {
   // The puzzles to show in this list
   puzzles: PuzzleType[];
+  bookmarked: Set<string>;
   // All tags for this hunt, including those not used by any puzzles
   allTags: TagType[];
   canUpdate: boolean;
@@ -24,6 +25,7 @@ const PuzzleList = React.memo(({
           <Puzzle
             key={puzzle._id}
             puzzle={puzzle}
+            bookmarked={bookmarked.has(puzzle._id)}
             allTags={allTags}
             canUpdate={canUpdate}
             suppressTags={suppressTags}

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -2,6 +2,7 @@
 import { Meteor } from 'meteor/meteor';
 import { Random } from 'meteor/random';
 import { useFind, useSubscribe, useTracker } from 'meteor/react-meteor-data';
+import { faStar as faStarRegular } from '@fortawesome/free-regular-svg-icons/faStar';
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons/faArrowLeft';
 import { faArrowRight } from '@fortawesome/free-solid-svg-icons/faArrowRight';
 import { faCheck } from '@fortawesome/free-solid-svg-icons/faCheck';
@@ -12,6 +13,7 @@ import { faKey } from '@fortawesome/free-solid-svg-icons/faKey';
 import { faPaperPlane } from '@fortawesome/free-solid-svg-icons/faPaperPlane';
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons/faSpinner';
+import { faStar as faStarSolid } from '@fortawesome/free-solid-svg-icons/faStar';
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type {
@@ -55,6 +57,7 @@ import styled, { css } from 'styled-components';
 import { calendarTimeFormat, shortCalendarTimeFormat } from '../../lib/calendarTimeFormat';
 import { messageDingsUser } from '../../lib/dingwordLogic';
 import { indexedById, sortedBy } from '../../lib/listUtils';
+import Bookmarks from '../../lib/models/Bookmarks';
 import type { ChatMessageType } from '../../lib/models/ChatMessages';
 import ChatMessages from '../../lib/models/ChatMessages';
 import Documents from '../../lib/models/Documents';
@@ -75,6 +78,7 @@ import puzzleForPuzzlePage from '../../lib/publications/puzzleForPuzzlePage';
 import { computeSolvedness } from '../../lib/solvedness';
 import addPuzzleAnswer from '../../methods/addPuzzleAnswer';
 import addPuzzleTag from '../../methods/addPuzzleTag';
+import bookmarkPuzzle from '../../methods/bookmarkPuzzle';
 import createGuess from '../../methods/createGuess';
 import ensurePuzzleDocument from '../../methods/ensurePuzzleDocument';
 import type { ImageSource } from '../../methods/insertDocumentImage';
@@ -286,13 +290,13 @@ const PuzzleMetadataActionRow = styled(PuzzleMetadataRow)`
   a {
     margin-right: 8px;
   }
+`;
+
+const PuzzleMetadataButtons = styled.div`
+  margin-left: auto;
 
   button {
     margin: 2px 0 2px 8px;
-
-    &:first-of-type {
-      margin-left: auto;
-    }
   }
 `;
 
@@ -1013,9 +1017,10 @@ const InsertImage = ({ documentId }: { documentId: string }) => {
 };
 
 const PuzzlePageMetadata = ({
-  puzzle, displayNames, document, isDesktop,
+  puzzle, bookmarked, displayNames, document, isDesktop,
 }: {
   puzzle: PuzzleType;
+  bookmarked: boolean;
   displayNames: Map<string, string>;
   document?: DocumentType;
   isDesktop: boolean;
@@ -1072,6 +1077,10 @@ const PuzzlePageMetadata = ({
     }
   }, []);
 
+  const toggleBookmark = useCallback(() => {
+    bookmarkPuzzle.call({ puzzleId, bookmark: !bookmarked });
+  }, [puzzleId, bookmarked]);
+
   const tagsById = indexedById(allTags);
   const maybeTags: (TagType | undefined)[] = puzzle.tags.map((tagId) => { return tagsById.get(tagId); });
   const tags: TagType[] = maybeTags.filter<TagType>((t): t is TagType => t !== undefined);
@@ -1123,6 +1132,13 @@ const PuzzlePageMetadata = ({
     </Button>
   ) : null;
 
+  const bookmarkText = bookmarked ? 'Unbookmark puzzle' : 'Bookmark puzzle';
+  const bookmarkButton = (
+    <Button onClick={toggleBookmark} variant="link" size="sm" title={bookmarkText}>
+      <FontAwesomeIcon icon={bookmarked ? faStarSolid : faStarRegular} />
+    </Button>
+  );
+
   let guessButton = null;
   if (puzzle.expectedAnswerCount > 0) {
     guessButton = hasGuessQueue ? (
@@ -1166,11 +1182,14 @@ const PuzzlePageMetadata = ({
         onSubmit={onEdit}
       />
       <PuzzleMetadataActionRow>
+        {bookmarkButton}
         {puzzleLink}
         {documentLink}
-        {editButton}
-        {imageInsert}
-        {guessButton}
+        <PuzzleMetadataButtons>
+          {editButton}
+          {imageInsert}
+          {guessButton}
+        </PuzzleMetadataButtons>
       </PuzzleMetadataActionRow>
       <PuzzleMetadataRow>
         {answersElement}
@@ -1844,6 +1863,7 @@ const PuzzlePage = React.memo(() => {
   ), [puzzleDataLoading, puzzleId]);
 
   const activePuzzle = useTracker(() => Puzzles.findOneAllowingDeleted(puzzleId), [puzzleId]);
+  const bookmarked = useTracker(() => !!Bookmarks.findOne({ puzzle: puzzleId, user: Meteor.userId()! }), [puzzleId]);
 
   const selfUser = useTracker(() => Meteor.user()!, []);
 
@@ -1916,6 +1936,7 @@ const PuzzlePage = React.memo(() => {
   const metadata = (
     <PuzzlePageMetadata
       puzzle={activePuzzle}
+      bookmarked={bookmarked}
       document={document}
       displayNames={displayNames}
       isDesktop={isDesktop}

--- a/imports/client/components/RelatedPuzzleGroup.tsx
+++ b/imports/client/components/RelatedPuzzleGroup.tsx
@@ -11,7 +11,7 @@ import { useHuntPuzzleListCollapseGroup } from '../hooks/persisted-state';
 import RelatedPuzzleList from './RelatedPuzzleList';
 import Tag from './Tag';
 
-const PuzzleGroupDiv = styled.div`
+export const PuzzleGroupDiv = styled.div`
   &:not(:last-child) {
     margin-bottom: 16px;
   }
@@ -43,12 +43,13 @@ const NoSharedTagLabel = styled.div`
 `;
 
 const RelatedPuzzleGroup = ({
-  huntId, group, noSharedTagLabel = '(no tag)', allTags, includeCount, canUpdate, suppressedTagIds, trackPersistentExpand,
+  huntId, group, noSharedTagLabel = '(no tag)', allTags, bookmarked, includeCount, canUpdate, suppressedTagIds, trackPersistentExpand,
 }: {
   huntId: string;
   group: PuzzleGroup;
   // noSharedTagLabel is used to label the group only if sharedTag is undefined.
   noSharedTagLabel?: string;
+  bookmarked: Set<string>;
   allTags: TagType[];
   includeCount?: boolean;
   canUpdate: boolean;
@@ -99,6 +100,7 @@ const RelatedPuzzleGroup = ({
         <PuzzleListWrapper>
           <RelatedPuzzleList
             relatedPuzzles={relatedPuzzles}
+            bookmarked={bookmarked}
             allTags={allTags}
             canUpdate={canUpdate}
             sharedTag={sharedTag}
@@ -115,6 +117,7 @@ const RelatedPuzzleGroup = ({
                 huntId={huntId}
                 group={subgroup}
                 noSharedTagLabel={noSharedTagLabel}
+                bookmarked={bookmarked}
                 allTags={allTags}
                 includeCount={includeCount}
                 canUpdate={canUpdate}

--- a/imports/client/components/RelatedPuzzleList.tsx
+++ b/imports/client/components/RelatedPuzzleList.tsx
@@ -29,9 +29,10 @@ function sortPuzzlesByRelevanceWithinPuzzleGroup(
 }
 
 const RelatedPuzzleList = React.memo(({
-  relatedPuzzles, allTags, canUpdate, sharedTag, suppressedTagIds, segmentAnswers,
+  relatedPuzzles, bookmarked, allTags, canUpdate, sharedTag, suppressedTagIds, segmentAnswers,
 }: {
   relatedPuzzles: PuzzleType[];
+  bookmarked: Set<string>;
   allTags: TagType[];
   canUpdate: boolean;
   sharedTag: TagType | undefined;
@@ -50,6 +51,7 @@ const RelatedPuzzleList = React.memo(({
   return (
     <PuzzleList
       puzzles={sortedPuzzles}
+      bookmarked={bookmarked}
       allTags={allTags}
       canUpdate={canUpdate}
       suppressTags={suppressedTagIds}

--- a/imports/lib/models/BookmarkNotifications.ts
+++ b/imports/lib/models/BookmarkNotifications.ts
@@ -1,0 +1,28 @@
+import { z } from 'zod';
+import type { Solvedness } from '../solvedness';
+import type { ModelType } from './Model';
+import SoftDeletedModel from './SoftDeletedModel';
+import { answer, foreignKey } from './customTypes';
+import withCommon from './withCommon';
+
+const BookmarkNotificationSolvedness: z.ZodType<Solvedness> = z.enum(['noAnswers', 'solved', 'unsolved']);
+
+// A notification triggered when a bookmarked puzzle changes state
+const BookmarkNotification = withCommon(z.object({
+  // userId of the user who will receive this notification
+  user: foreignKey,
+  // puzzle that changed state
+  puzzle: foreignKey,
+  // hunt in which the puzzle resides
+  hunt: foreignKey,
+  // the new answer
+  answer,
+  // how solved the puzzle is
+  solvedness: BookmarkNotificationSolvedness,
+}));
+
+const BookmarkNotifications = new SoftDeletedModel('jr_bookmark_notifications', BookmarkNotification);
+BookmarkNotifications.addIndex({ deleted: 1, user: 1 });
+export type BookmarkNotificationType = ModelType<typeof BookmarkNotifications>;
+
+export default BookmarkNotifications;

--- a/imports/lib/models/Bookmarks.ts
+++ b/imports/lib/models/Bookmarks.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+import type { ModelType } from './Model';
+import SoftDeletedModel from './SoftDeletedModel';
+import { foreignKey } from './customTypes';
+import withCommon from './withCommon';
+
+// Broadcast announcements that have not yet been viewed by a given
+// user
+const Bookmark = withCommon(z.object({
+  hunt: foreignKey,
+  puzzle: foreignKey,
+  user: foreignKey,
+}));
+
+const Bookmarks = new SoftDeletedModel('jr_bookmarks', Bookmark);
+Bookmarks.addIndex({ user: 1, hunt: 1, puzzle: 1 }, { unique: true });
+Bookmarks.addIndex({ puzzle: 1 });
+export type BookmarkType = ModelType<typeof Bookmarks>;
+
+export default Bookmarks;

--- a/imports/lib/models/facade.ts
+++ b/imports/lib/models/facade.ts
@@ -1,6 +1,7 @@
 /* eslint-disable filenames/match-exported */
 import Announcements from './Announcements';
 import BlobMappings from './BlobMappings';
+import Bookmarks from './Bookmarks';
 import ChatMessages from './ChatMessages';
 import ChatNotifications from './ChatNotifications';
 import DiscordCache from './DiscordCache';
@@ -34,6 +35,7 @@ import Transports from './mediasoup/Transports';
 const Models = {
   Announcements,
   BlobMappings,
+  Bookmarks,
   ChatMessages,
   ChatNotifications,
   DiscordCache,

--- a/imports/lib/publications/bookmarkNotificationsForSelf.ts
+++ b/imports/lib/publications/bookmarkNotificationsForSelf.ts
@@ -1,0 +1,5 @@
+import TypedPublication from './TypedPublication';
+
+export default new TypedPublication<void>(
+  'BookmarkNotifications.publications.forSelf'
+);

--- a/imports/methods/bookmarkPuzzle.ts
+++ b/imports/methods/bookmarkPuzzle.ts
@@ -1,0 +1,5 @@
+import TypedMethod from './TypedMethod';
+
+export default new TypedMethod<{ puzzleId: string, bookmark: boolean }, void>(
+  'Puzzles.methods.bookmark'
+);

--- a/imports/methods/dismissBookmarkNotification.ts
+++ b/imports/methods/dismissBookmarkNotification.ts
@@ -1,0 +1,5 @@
+import TypedMethod from './TypedMethod';
+
+export default new TypedMethod<{ bookmarkNotificationId: string }, void>(
+  'BookmarkNotifications.methods.dismiss'
+);

--- a/imports/server/GlobalHooks.ts
+++ b/imports/server/GlobalHooks.ts
@@ -1,3 +1,4 @@
+import BookmarkNotificationHooks from './hooks/BookmarkNotificationHooks';
 import ChatHooks from './hooks/ChatHooks';
 import ChatNotificationHooks from './hooks/ChatNotificationHooks';
 import DiscordHooks from './hooks/DiscordHooks';
@@ -11,5 +12,6 @@ GlobalHooks.addHookSet(DiscordHooks);
 GlobalHooks.addHookSet(ChatNotificationHooks);
 GlobalHooks.addHookSet(TagCleanupHooks);
 GlobalHooks.addHookSet(ChatHooks);
+GlobalHooks.addHookSet(BookmarkNotificationHooks);
 
 export default GlobalHooks;

--- a/imports/server/hooks/BookmarkNotificationHooks.ts
+++ b/imports/server/hooks/BookmarkNotificationHooks.ts
@@ -1,0 +1,25 @@
+import BookmarkNotifications from '../../lib/models/BookmarkNotifications';
+import Bookmarks from '../../lib/models/Bookmarks';
+import Puzzles from '../../lib/models/Puzzles';
+import { computeSolvedness } from '../../lib/solvedness';
+import type Hookset from './Hookset';
+
+const BookmarkNotificationHooks: Hookset = {
+  async onPuzzleSolved(puzzleId, answer) {
+    const puzzle = (await Puzzles.findOneAsync(puzzleId))!;
+    const solvedness = computeSolvedness(puzzle);
+    const bookmarked = await Bookmarks.find({ puzzle: puzzleId }).fetchAsync();
+
+    await Promise.all(bookmarked.map(async (bookmark) => {
+      await BookmarkNotifications.insertAsync({
+        user: bookmark.user,
+        puzzle: puzzleId,
+        hunt: puzzle.hunt,
+        solvedness,
+        answer,
+      });
+    }));
+  },
+};
+
+export default BookmarkNotificationHooks;

--- a/imports/server/methods/bookmarkPuzzle.ts
+++ b/imports/server/methods/bookmarkPuzzle.ts
@@ -1,0 +1,48 @@
+import { check } from 'meteor/check';
+import { Meteor } from 'meteor/meteor';
+import Bookmarks from '../../lib/models/Bookmarks';
+import Puzzles from '../../lib/models/Puzzles';
+import bookmarkPuzzle from '../../methods/bookmarkPuzzle';
+import ignoringDuplicateKeyErrors from '../ignoringDuplicateKeyErrors';
+import defineMethod from './defineMethod';
+
+defineMethod(bookmarkPuzzle, {
+  validate(arg) {
+    check(arg, {
+      puzzleId: String,
+      bookmark: Boolean,
+    });
+    return arg;
+  },
+
+  async run({ puzzleId, bookmark }) {
+    check(this.userId, String);
+
+    const user = (await Meteor.users.findOneAsync(this.userId))!;
+
+    const puzzle = await Puzzles.findOneAsync(puzzleId);
+    if (!puzzle) {
+      throw new Meteor.Error(404, `No puzzle known with id ${puzzleId}`);
+    }
+
+    if (!user.hunts?.includes(puzzle.hunt)) {
+      throw new Meteor.Error(403, `User ${this.userId} is not a member of hunt ${puzzle.hunt}`);
+    }
+
+    if (bookmark) {
+      await ignoringDuplicateKeyErrors(async () => {
+        await Bookmarks.insertAsync({
+          hunt: puzzle.hunt,
+          user: user._id,
+          puzzle: puzzleId,
+        });
+      });
+    } else {
+      await Bookmarks.removeAsync({
+        hunt: puzzle.hunt,
+        user: user._id,
+        puzzle: puzzleId,
+      });
+    }
+  },
+});

--- a/imports/server/methods/dismissBookmarkNotification.ts
+++ b/imports/server/methods/dismissBookmarkNotification.ts
@@ -1,0 +1,21 @@
+import { check } from 'meteor/check';
+import BookmarkNotifications from '../../lib/models/BookmarkNotifications';
+import dismissBookmarkNotification from '../../methods/dismissBookmarkNotification';
+import defineMethod from './defineMethod';
+
+defineMethod(dismissBookmarkNotification, {
+  validate(arg) {
+    check(arg, { bookmarkNotificationId: String });
+
+    return arg;
+  },
+
+  async run({ bookmarkNotificationId }) {
+    check(this.userId, String);
+
+    await BookmarkNotifications.removeAsync({
+      _id: bookmarkNotificationId,
+      user: this.userId,
+    });
+  },
+});

--- a/imports/server/methods/index.ts
+++ b/imports/server/methods/index.ts
@@ -1,6 +1,7 @@
 import './addHuntUser';
 import './addPuzzleAnswer';
 import './addPuzzleTag';
+import './bookmarkPuzzle';
 import './bulkAddHuntUsers';
 import './configureClearGdriveCreds';
 import './configureCollectGoogleAccountIds';

--- a/imports/server/methods/index.ts
+++ b/imports/server/methods/index.ts
@@ -24,6 +24,7 @@ import './createPuzzle';
 import './demoteOperator';
 import './destroyHunt';
 import './destroyPuzzle';
+import './dismissBookmarkNotification';
 import './dismissChatNotification';
 import './dismissPendingAnnouncement';
 import './ensurePuzzleDocument';

--- a/imports/server/publications/bookmarkNotificationsForSelf.ts
+++ b/imports/server/publications/bookmarkNotificationsForSelf.ts
@@ -1,0 +1,28 @@
+import BookmarkNotifications from '../../lib/models/BookmarkNotifications';
+import Hunts from '../../lib/models/Hunts';
+import Puzzles from '../../lib/models/Puzzles';
+import bookmarkNotificationsForSelf from '../../lib/publications/bookmarkNotificationsForSelf';
+import publishJoinedQuery from '../publishJoinedQuery';
+import definePublication from './definePublication';
+
+definePublication(bookmarkNotificationsForSelf, {
+  run() {
+    if (!this.userId) {
+      return [];
+    }
+
+    publishJoinedQuery(this, {
+      model: BookmarkNotifications,
+      foreignKeys: [{
+        field: 'puzzle',
+        join: { model: Puzzles, allowDeleted: true },
+      }, {
+        field: 'hunt',
+        join: { model: Hunts },
+      }],
+    }, { user: this.userId });
+    this.ready();
+
+    return undefined;
+  },
+});

--- a/imports/server/publications/index.ts
+++ b/imports/server/publications/index.ts
@@ -1,5 +1,6 @@
 import './announcementsForAnnouncementsPage';
 import './blobMappingsAll';
+import './bookmarkNotificationsForSelf';
 import './chatMessagesForFirehose';
 import './chatMessagesForPuzzle';
 import './discordChannelsForConfiguredGuild';

--- a/imports/server/publications/puzzleForPuzzlePage.ts
+++ b/imports/server/publications/puzzleForPuzzlePage.ts
@@ -1,4 +1,5 @@
 import { check } from 'meteor/check';
+import Bookmarks from '../../lib/models/Bookmarks';
 import Documents from '../../lib/models/Documents';
 import Guesses from '../../lib/models/Guesses';
 import MeteorUsers from '../../lib/models/MeteorUsers';
@@ -39,6 +40,10 @@ definePublication(puzzleForPuzzlePage, {
     publishCursor(merger.newSub(), Guesses.name, Guesses.find({ hunt: huntId, puzzle: puzzleId }));
     publishCursor(merger.newSub(), Tags.name, Tags.find({ hunt: huntId }));
     publishCursor(merger.newSub(), Puzzles.name, Puzzles.find({ hunt: huntId }));
+    publishCursor(merger.newSub(), Bookmarks.name, Bookmarks.find({
+      hunt: huntId,
+      user: this.userId,
+    }));
 
     // Also publish this puzzle, even if it's deleted, and its replacement
     publishJoinedQuery(merger.newSub(), {

--- a/imports/server/publications/puzzlesForPuzzleList.ts
+++ b/imports/server/publications/puzzlesForPuzzleList.ts
@@ -1,4 +1,5 @@
 import { check, Match } from 'meteor/check';
+import Bookmarks from '../../lib/models/Bookmarks';
 import MeteorUsers from '../../lib/models/MeteorUsers';
 import Puzzles from '../../lib/models/Puzzles';
 import Tags from '../../lib/models/Tags';
@@ -27,6 +28,7 @@ definePublication(puzzlesForPuzzleList, {
     return [
       Puzzles[includeDeleted ? 'findAllowingDeleted' : 'find']({ hunt: huntId }),
       Tags.find({ hunt: huntId }),
+      Bookmarks.find({ hunt: huntId, user: this.userId }),
     ];
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1285,6 +1285,14 @@
         }
       }
     },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.1.tgz",
+      "integrity": "sha512-m6ShXn+wvqEU69wSP84coxLbNl7sGVZb+Ca+XZq6k30SzuP3X4TfPqtycgUh9ASwlNh5OfQCd8pDIWxl+O+LlQ==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "6.5.1"
+      }
+    },
     "@fortawesome/free-solid-svg-icons": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@bugsnag/js": "^7.22.2",
     "@bugsnag/plugin-react": "^7.19.0",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
+    "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@googleapis/drive": "^8.4.0",


### PR DESCRIPTION
Some of our team members have asked for a way to more easily keep track of puzzles they care about, even when they're not currently looking at them.

Bookmarked puzzles are shown in a section at the top of the puzzle list page (in addition to showing up in their normal place in the list):

<img width="850" alt="Screenshot 2023-09-01 at 12 01 37 PM" src="https://github.com/deathandmayhem/jolly-roger/assets/28167/03582ae4-5ca2-4781-ad7b-6593fad0a40d">

When a puzzle is solved, users that have that puzzle bookmarked get a notification:

<img width="403" alt="Screenshot 2023-09-01 at 12 00 23 PM" src="https://github.com/deathandmayhem/jolly-roger/assets/28167/a1b024b2-deea-4180-8fa4-7490a2dbaa3e">

One thing that's missing right now is a UI element on the individual puzzle page for bookmarking a puzzle, as I'm not entirely sure where to put it.

@Apophenia I'm curious if this seems like it would work for your use case, since you were one of the people who requested this.

Fixes #1368.