### PR TITLE
Skip updates for eslint-plugin-deprecation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
         versions: [">=6"]
       - dependency-name: "@typescript-eslint/utils"
         versions: [">=6"]
+      - dependency-name: "eslint-plugin-deprecation"
+        versions: [">=2"]
       - dependency-name: "discord.js"
         versions: [">=13"]
       - dependency-name: "glob"


### PR DESCRIPTION
Now that it's using typescript-eslint/utils 6.x it no longer supports Node 14.

(See #1826)