### PR TITLE
Update prep

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -4,5 +4,10 @@
   ],
   "customSyntax": "postcss-styled-syntax",
   "reportNeedlessDisables": true,
-  "reportInvalidScopeDisables": true
+  "reportInvalidScopeDisables": true,
+  "rules": {
+    "declaration-block-no-redundant-longhand-properties": [true, {
+      "ignoreShorthands": ["overflow", "place-content", "gap"]
+    }]
+  }
 }

--- a/imports/client/components/AccountForm.tsx
+++ b/imports/client/components/AccountForm.tsx
@@ -3,7 +3,9 @@
 import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
-import React, { useCallback, useState } from 'react';
+import React, {
+  type ComponentPropsWithRef, type FC, useCallback, useState,
+} from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
@@ -44,7 +46,7 @@ const StyledModeSwitchLink = styled.div`
   text-align: center;
 `;
 
-const NoPaddingLinkButton = styled(Button)`
+const NoPaddingLinkButton: FC<ComponentPropsWithRef<typeof Button>> = styled(Button)`
   padding: 0;
   vertical-align: baseline;
 `;

--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -6,7 +6,9 @@ import { faEraser } from '@fortawesome/free-solid-svg-icons/faEraser';
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
 import { faSkullCrossbones } from '@fortawesome/free-solid-svg-icons/faSkullCrossbones';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, {
+  type ComponentPropsWithRef, type FC, useCallback, useEffect, useRef,
+} from 'react';
 import Button from 'react-bootstrap/Button';
 import type { FormControlProps } from 'react-bootstrap/FormControl';
 import FormControl from 'react-bootstrap/FormControl';
@@ -114,7 +116,7 @@ const StyledGuessConfidence = styled(GuessConfidence)`
   `)}
 `;
 
-const StyledLinkButton = styled(Button)`
+const StyledLinkButton: FC<ComponentPropsWithRef<typeof Button>> = styled(Button)`
   padding: 0;
   vertical-align: baseline;
 `;

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -3,7 +3,7 @@ import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { faPuzzlePiece } from '@fortawesome/free-solid-svg-icons/faPuzzlePiece';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, {
-  useCallback, useMemo, useRef, useState,
+  type ComponentPropsWithRef, type FC, useCallback, useMemo, useRef, useState,
 } from 'react';
 import Button from 'react-bootstrap/Button';
 import ButtonGroup from 'react-bootstrap/esm/ButtonGroup';
@@ -56,7 +56,7 @@ const PuzzleEditButtonsColumn = styled(PuzzleColumn)`
   order: -1;
 `;
 
-const StyledButton = styled(Button)`
+const StyledButton: FC<ComponentPropsWithRef<typeof Button>> = styled(Button)`
   /* Precedence boost needed to override bootstrap default button padding */
   && {
     /* Resize button to fit in one line-height */

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -10,7 +10,7 @@ import { faReceipt } from '@fortawesome/free-solid-svg-icons/faReceipt';
 import { faUsers } from '@fortawesome/free-solid-svg-icons/faUsers';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import React, {
-  useCallback, useEffect, useRef,
+  type ComponentPropsWithRef, type FC, useCallback, useEffect, useRef,
 } from 'react';
 import Alert from 'react-bootstrap/Alert';
 import Button from 'react-bootstrap/Button';
@@ -110,7 +110,7 @@ const StyledToggleButtonGroup = styled(ToggleButtonGroup)`
   }
 `;
 
-const StyledButton = styled(Button)`
+const StyledButton: FC<ComponentPropsWithRef<typeof Button>> = styled(Button)`
   @media (width < 360px) {
     width: 100%;
   }

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -16,6 +16,8 @@ import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type {
   ChangeEvent,
+  ComponentPropsWithRef,
+  FC,
   MouseEvent,
 } from 'react';
 import React, {
@@ -259,7 +261,7 @@ const PuzzleMetadataAnswer = styled.span`
   border-radius: 4px;
 `;
 
-const AnswerRemoveButton = styled(Button)`
+const AnswerRemoveButton: FC<ComponentPropsWithRef<typeof Button>> = styled(Button)`
   /* Specifier boost needed to override Bootstrap button style */
   && {
     margin: 0 -6px 0 6px;
@@ -1302,7 +1304,7 @@ const AdditionalNotesCell = styled(GuessCell)`
   `)}
 `;
 
-const LinkButton = styled(Button)`
+const LinkButton: FC<ComponentPropsWithRef<typeof Button>> = styled(Button)`
   padding: 0;
   vertical-align: baseline;
 `;

--- a/imports/client/components/Tag.tsx
+++ b/imports/client/components/Tag.tsx
@@ -5,7 +5,9 @@ import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import type { ModifierArguments, Modifier, Padding } from '@popperjs/core';
 import detectOverflow from '@popperjs/core/lib/utils/detectOverflow';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, {
+  type ComponentPropsWithRef, type FC, useCallback, useEffect, useState,
+} from 'react';
 import Button from 'react-bootstrap/Button';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Popover from 'react-bootstrap/Popover';
@@ -18,7 +20,7 @@ import { removePunctuation } from './PuzzleAnswer';
 import { sortPuzzlesByRelevanceWithinPuzzleGroup } from './RelatedPuzzleList';
 import RelatedPuzzleTable from './RelatedPuzzleTable';
 
-const RemoveTagButton = styled(Button)`
+const RemoveTagButton: FC<ComponentPropsWithRef<typeof Button>> = styled(Button)`
   height: 16px;
   width: 16px;
   line-height: 10px;

--- a/imports/client/components/TagList.tsx
+++ b/imports/client/components/TagList.tsx
@@ -1,7 +1,9 @@
 import { faMinus } from '@fortawesome/free-solid-svg-icons/faMinus';
 import { faPlus } from '@fortawesome/free-solid-svg-icons/faPlus';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import React, { useCallback, useState } from 'react';
+import React, {
+  type ComponentPropsWithRef, type FC, useCallback, useState,
+} from 'react';
 import Button from 'react-bootstrap/Button';
 import ButtonGroup from 'react-bootstrap/ButtonGroup';
 import styled from 'styled-components';
@@ -19,7 +21,7 @@ const TagListEmptyLabel = styled.span`
   margin-right: 4px;
 `;
 
-const TagModifyButton = styled(Button)`
+const TagModifyButton: FC<ComponentPropsWithRef<typeof Button>> = styled(Button)`
   line-height: 22px;
   padding: 0 6px;
   margin: 2px 0;

--- a/imports/client/components/styling/PeopleComponents.tsx
+++ b/imports/client/components/styling/PeopleComponents.tsx
@@ -1,3 +1,4 @@
+import type { FC, ComponentPropsWithRef } from 'react';
 import Button from 'react-bootstrap/Button';
 import styled, { css } from 'styled-components';
 import { PuzzlePagePadding } from './constants';
@@ -17,7 +18,7 @@ export const AVActions = styled.div`
   margin-bottom: ${PuzzlePagePadding};
 `;
 
-export const AVButton = styled(Button)`
+export const AVButton: FC<ComponentPropsWithRef<typeof Button>> = styled(Button)`
   flex: 1;
   padding-right: 2px;
   padding-left: 2px;


### PR DESCRIPTION
Apparently with the grouped configuration, dependabot will throw away any additional commits that I push up when it does a new update run, so let's pull this into a separate PR. These two commits will let us take all updates that are currently pending in #1846.

There's a fix here for some new sensitivity in stylelint. Here's what I wrote before:

> Hmm. Looks like stylelint is getting increasingly picky about various shorthand properties. It now wants us to use `gap` instead of `row-gap` and `column-gap`, `overflow` instead of `overflow-x` and `overflow-y`, and `place-content` instead of `align-content` and `justify-content`.
> 
> IIRC all of the ones we've replaced until now were shorthands for the "top right bottom left" pattern which, I know @zarvox that you have a hard time remembering, but at least they were consistent across properties; these don't feel consistent to me (either with other properties like `margin` and `border` or with each other).
> 
> I think this crosses my personal line for style that I disagree with, so I'll push a config change to disable sensitivity to these specific properties.

Additionally, I put in a workaround for https://github.com/styled-components/styled-components/issues/4166, since it doesn't seem like upstream is particularly on top of fixing it directly.