### PR TITLE
Switch back to ungrouped dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,6 @@ updates:
       interval: "weekly"
       day: "friday"
     open-pull-requests-limit: 20
-    groups:
-      all:
-        patterns:
-          - "*"
     ignore:
       # All of these dependencies require Node v16 or greater
       - dependency-name: "@types/node"


### PR DESCRIPTION
In practice, we're seeing too many cases where a small number of incompatible updates blocks all other updates from going through, meaning that the end result is we're just not taking updates in a timely manner.