### PR TITLE
Drop dependency on p-throttle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11893,11 +11893,6 @@
         "p-limit": "^3.0.2"
       }
     },
-    "p-throttle": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/p-throttle/-/p-throttle-5.1.0.tgz",
-      "integrity": "sha512-+N+s2g01w1Zch4D0K3OpnPDqLOKmLcQ4BvIFq3JC0K29R28vUOjWpO+OJZBNt8X9i3pFCksZJZ0YXkUGjaFE6g=="
-    },
     "pac-proxy-agent": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-6.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "meteor-node-stubs": "^1.2.5",
     "mime-types": "^2.1.35",
     "mustache": "^4.2.0",
-    "p-throttle": "^5.1.0",
     "portscanner": "^2.2.0",
     "react": "^18.2.0",
     "react-bootstrap": "^2.9.1",


### PR DESCRIPTION
We stopped using this in c2d07b3485e21e329926d8c0dbd89db4caa20990.

(Supersedes #1875)