### PR TITLE
Use transient props to styled-components

### DIFF
--- a/imports/client/components/Avatar.tsx
+++ b/imports/client/components/Avatar.tsx
@@ -55,12 +55,12 @@ const DefaultAvatarInner = ({
   return <AvatarInitial style={style}>{initial}</AvatarInitial>;
 };
 
-const AvatarContainer = styled.div<{ size: number, inline: boolean }>`
-  width: ${({ size }) => size}px;
-  height: ${({ size }) => size}px;
-  font-size: ${({ size }) => 0.6 * size}px;
+const AvatarContainer = styled.div<{ $size: number, $inline: boolean }>`
+  width: ${({ $size }) => $size}px;
+  height: ${({ $size }) => $size}px;
+  font-size: ${({ $size }) => 0.6 * $size}px;
   background-color: white;
-  display: ${({ inline }) => (inline ? 'inline-block' : 'block')};
+  display: ${({ $inline }) => ($inline ? 'inline-block' : 'block')};
 `;
 
 const Avatar = React.memo(({
@@ -77,7 +77,7 @@ const Avatar = React.memo(({
     <DiscordAvatarInner size={size} displayName={displayName} discordAccount={discordAccount} /> :
     <DefaultAvatarInner _id={_id} displayName={displayName} />;
   return (
-    <AvatarContainer className={className} size={size} inline={inline ?? false}>
+    <AvatarContainer className={className} $size={size} $inline={inline ?? false}>
       {content}
     </AvatarContainer>
   );

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -410,7 +410,7 @@ const Callers = ({
         <FontAwesomeIcon fixedWidth icon={callersHeaderIcon} />
         {`${callerCount} caller${callerCount !== 1 ? 's' : ''}`}
       </ChatterSubsectionHeader>
-      <PeopleListDiv collapsed={!callersExpanded}>
+      <PeopleListDiv $collapsed={!callersExpanded}>
         <SelfBox
           muted={muted}
           deafened={deafened}

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -334,7 +334,7 @@ const ChatPeople = ({
                   </>
                 )}
               </PeopleListHeader>
-              <PeopleListDiv collapsed={!callersExpanded}>
+              <PeopleListDiv $collapsed={!callersExpanded}>
                 {rtcViewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}-${viewer.tab}`} popperBoundaryRef={chatterRef} {...viewer} />)}
               </PeopleListDiv>
             </ChatterSubsection>
@@ -376,7 +376,7 @@ const ChatPeople = ({
           <FontAwesomeIcon fixedWidth icon={viewersHeaderIcon} />
           {`${totalViewers} viewer${totalViewers !== 1 ? 's' : ''}`}
         </PeopleListHeader>
-        <PeopleListDiv collapsed={!viewersExpanded}>
+        <PeopleListDiv $collapsed={!viewersExpanded}>
           {viewers.map((viewer) => <ViewerPersonBox key={`person-${viewer.user}`} popperBoundaryRef={chatterRef} {...viewer} />)}
         </PeopleListDiv>
       </ChatterSubsection>

--- a/imports/client/components/FancyEditor.tsx
+++ b/imports/client/components/FancyEditor.tsx
@@ -165,7 +165,7 @@ const insertMention = (editor: Editor, userId: string) => {
   Transforms.move(editor);
 };
 
-const MatchCandidateRow = styled.div<{ selected: boolean }>`
+const MatchCandidateRow = styled.div<{ $selected: boolean }>`
   padding: 2px 3px;
   border-radius: 3px;
   height: 28px;
@@ -174,8 +174,8 @@ const MatchCandidateRow = styled.div<{ selected: boolean }>`
   align-items: center;
   justify-content: flex-start;
   cursor: pointer;
-  ${({ selected }) => css`
-    background: ${selected ? '#e0ecfc' : 'transparent'};
+  ${({ $selected }) => css`
+    background: ${$selected ? '#e0ecfc' : 'transparent'};
   `}
 `;
 
@@ -204,7 +204,7 @@ const MatchCandidate = ({
   return (
     <MatchCandidateRow
       key={user._id}
-      selected={selected}
+      $selected={selected}
       onClick={onClick}
     >
       <StyledAvatar size={24} {...user} />

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -77,9 +77,9 @@ const StyledNotificationActionBar = styled.ul`
   }
 `;
 
-const StyledNotificationActionItem = styled.li<{grow?: boolean}>`
+const StyledNotificationActionItem = styled.li<{ $grow?: boolean }>`
   display: flex;
-  flex-grow: ${(props) => (props.grow ? 1 : 0)};
+  flex-grow: ${(props) => (props.$grow ? 1 : 0)};
 `;
 
 const StyledNotificationRow = styled.div`
@@ -274,16 +274,16 @@ const GuessMessage = React.memo(({
           </StyledGuessDetails>
         </StyledNotificationActionBar>
         <StyledNotificationActionBar>
-          <StyledNotificationActionItem grow>
+          <StyledNotificationActionItem $grow>
             <Button variant={correctButtonVariant} size="sm" className="flex-grow-1" disabled={disableForms} onClick={markCorrect}>Correct</Button>
           </StyledNotificationActionItem>
-          <StyledNotificationActionItem grow>
+          <StyledNotificationActionItem $grow>
             <Button variant={intermediateButtonVariant} size="sm" className="flex-grow-1" disabled={disableForms} active={nextState === 'intermediate'} onClick={toggleStateIntermediate}>Intermediate…</Button>
           </StyledNotificationActionItem>
-          <StyledNotificationActionItem grow>
+          <StyledNotificationActionItem $grow>
             <Button variant={incorrectButtonVariant} size="sm" className="flex-grow-1" disabled={disableForms} onClick={markIncorrect}>Incorrect</Button>
           </StyledNotificationActionItem>
-          <StyledNotificationActionItem grow>
+          <StyledNotificationActionItem $grow>
             <Button variant={rejectButtonVariant} size="sm" className="flex-grow-1" disabled={disableForms} active={nextState === 'rejected'} onClick={toggleStateRejected}>Reject…</Button>
           </StyledNotificationActionItem>
         </StyledNotificationActionBar>

--- a/imports/client/components/Puzzle.tsx
+++ b/imports/client/components/Puzzle.tsx
@@ -29,10 +29,10 @@ import { backgroundColorLookupTable } from './styling/constants';
 import { mediaBreakpointDown } from './styling/responsive';
 
 const PuzzleDiv = styled.div<{
-  solvedness: Solvedness,
+  $solvedness: Solvedness,
 }>`
-  ${({ solvedness }) => css`
-    background-color: ${backgroundColorLookupTable[solvedness]};
+  ${({ $solvedness }) => css`
+    background-color: ${backgroundColorLookupTable[$solvedness]};
   `}
 
   display: flex;
@@ -196,7 +196,7 @@ const Puzzle = React.memo(({
   });
 
   return (
-    <PuzzleDiv solvedness={solvedness}>
+    <PuzzleDiv $solvedness={solvedness}>
       {showEditModal ? (
         <PuzzleModalForm
           key={puzzle._id}

--- a/imports/client/components/PuzzleAnswer.tsx
+++ b/imports/client/components/PuzzleAnswer.tsx
@@ -2,15 +2,15 @@ import React from 'react';
 import styled, { css } from 'styled-components';
 import { MonospaceFontFamily } from './styling/constants';
 
-const PuzzleAnswerSpan = styled.span<{ breakable: boolean, indented: boolean }>`
+const PuzzleAnswerSpan = styled.span<{ $breakable: boolean, $indented: boolean }>`
   text-transform: uppercase;
   font-family: ${MonospaceFontFamily};
   font-weight: 400;
-  ${({ breakable }) => breakable && css`
+  ${({ $breakable }) => $breakable && css`
     overflow-wrap: break-word;
     overflow: hidden;
   `}
-  ${({ indented }) => indented && css`
+  ${({ $indented }) => $indented && css`
     display: block;
     min-width: 0;
     text-indent: -1.2em;
@@ -71,7 +71,7 @@ const PuzzleAnswer = React.memo(({
     ));
   }
   return (
-    <PuzzleAnswerSpan breakable={breakable} indented={indented} className={className}>
+    <PuzzleAnswerSpan $breakable={breakable} $indented={indented} className={className}>
       {formattedAnswer}
     </PuzzleAnswerSpan>
   );

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -195,15 +195,15 @@ const ChatHistoryDiv = styled.div`
 
 const PUZZLE_PAGE_PADDING = 8;
 
-const ChatMessageDiv = styled.div<{ isSystemMessage: boolean; isHighlighted: boolean; }>`
+const ChatMessageDiv = styled.div<{ $isSystemMessage: boolean; $isHighlighted: boolean; }>`
   padding: 0 ${PUZZLE_PAGE_PADDING}px 2px;
   word-wrap: break-word;
   font-size: 14px;
-  ${({ isSystemMessage, isHighlighted }) => isHighlighted && !isSystemMessage && css`
+  ${({ $isSystemMessage, $isHighlighted }) => $isHighlighted && !$isSystemMessage && css`
     background-color: #ffffd0;
   `}
 
-  ${({ isSystemMessage }) => isSystemMessage && css`
+  ${({ $isSystemMessage }) => $isSystemMessage && css`
     background-color: #e0e0e0;
   `}
 `;
@@ -340,7 +340,7 @@ const ChatHistoryMessage = React.memo(({
 
   const senderDisplayName = message.sender !== undefined ? displayNames.get(message.sender) ?? '???' : 'jolly-roger';
   return (
-    <ChatMessageDiv isSystemMessage={isSystemMessage} isHighlighted={isHighlighted && !isSystemMessage}>
+    <ChatMessageDiv $isSystemMessage={isSystemMessage} $isHighlighted={isHighlighted && !isSystemMessage}>
       {!suppressSender && <ChatMessageTimestamp>{ts}</ChatMessageTimestamp>}
       {!suppressSender && <strong>{senderDisplayName}</strong>}
       <ChatMessage
@@ -486,7 +486,7 @@ const ChatHistory = React.forwardRef(({
   return (
     <ChatHistoryDiv ref={ref} onScroll={onScrollObserved}>
       {chatMessages.length === 0 ? (
-        <ChatMessageDiv key="no-message" isSystemMessage={false} isHighlighted={false}>
+        <ChatMessageDiv key="no-message" $isSystemMessage={false} $isHighlighted={false}>
           <span>No chatter yet. Say something?</span>
         </ChatMessageDiv>
       ) : undefined}

--- a/imports/client/components/PuzzleTable.tsx
+++ b/imports/client/components/PuzzleTable.tsx
@@ -16,10 +16,10 @@ const PuzzleTableEl = styled.table`
 `;
 
 const PuzzleTableTr = styled.tr<{
-  solvedness: Solvedness;
+  $solvedness: Solvedness;
 }>`
-  ${({ solvedness }) => css`
-    background-color: ${backgroundColorLookupTable[solvedness]};
+  ${({ $solvedness }) => css`
+    background-color: ${backgroundColorLookupTable[$solvedness]};
   `}
 `;
 
@@ -47,7 +47,7 @@ const PuzzleTableRow = ({ puzzle, segmentAnswers }: {
   const solvedness = computeSolvedness(puzzle);
 
   return (
-    <PuzzleTableTr solvedness={solvedness}>
+    <PuzzleTableTr $solvedness={solvedness}>
       <PuzzleTableCell>
         <Breakable><Link to={linkTarget}>{puzzle.title}</Link></Breakable>
       </PuzzleTableCell>

--- a/imports/client/components/RTCDebugPage.tsx
+++ b/imports/client/components/RTCDebugPage.tsx
@@ -157,9 +157,9 @@ const StyledJSONDisplayTextCol = styled(Col)`
   justify-content: center;
 `;
 
-const StyledJSONDisplayPre = styled.pre<{ collapsed?: boolean }>`
+const StyledJSONDisplayPre = styled.pre<{ $collapsed?: boolean }>`
   margin-bottom: 0;
-  ${({ collapsed }) => collapsed && css`
+  ${({ $collapsed }) => $collapsed && css`
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -180,7 +180,7 @@ const JSONDisplay = ({ json }: { json: string }) => {
         </StyledJSONDisplayButtonCol>
         <StyledJSONDisplayTextCol xs={11}>
           {collapse ? (
-            <StyledJSONDisplayPre collapsed className="text-truncate">
+            <StyledJSONDisplayPre $collapsed className="text-truncate">
               {json}
             </StyledJSONDisplayPre>
           ) : (

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -1635,13 +1635,13 @@ const BrandingRowContent = styled.div`
   justify-content: flex-start;
 `;
 
-const BrandingRowImage = styled.div<{ backgroundImage: string, backgroundSize: string }>`
+const BrandingRowImage = styled.div<{ $backgroundImage: string, $backgroundSize: string }>`
   width: 200px;
   height: 200px;
   background-position: center;
   background-repeat: no-repeat;
-  background-image: url(${(props) => props.backgroundImage});
-  background-size: ${(props) => props.backgroundSize};
+  background-image: url(${(props) => props.$backgroundImage});
+  background-size: ${(props) => props.$backgroundSize};
 `;
 
 const BrandingAssetRow = ({
@@ -1712,8 +1712,8 @@ const BrandingAssetRow = ({
       ) : null}
       <BrandingRowContent>
         <BrandingRowImage
-          backgroundImage={blobUrl}
-          backgroundSize={backgroundSize ?? 'auto'}
+          $backgroundImage={blobUrl}
+          $backgroundSize={backgroundSize ?? 'auto'}
         />
         <label htmlFor={`asset-input-${asset}`}>
           <div>{asset}</div>

--- a/imports/client/components/Tag.tsx
+++ b/imports/client/components/Tag.tsx
@@ -58,14 +58,14 @@ const StyledPopover = styled(Popover)`
 `;
 
 const TagDiv = styled.div<{
-  popoverCapable: boolean;
-  popoverOpen: boolean;
-  isAdministrivia: boolean;
-  isMeta: boolean;
-  isGroup: boolean;
-  isMetaFor: boolean;
-  isNeeds: boolean;
-  isPriority: boolean;
+  $popoverCapable: boolean;
+  $popoverOpen: boolean;
+  $isAdministrivia: boolean;
+  $isMeta: boolean;
+  $isGroup: boolean;
+  $isMetaFor: boolean;
+  $isNeeds: boolean;
+  $isPriority: boolean;
 }>`
   display: inline-flex;
   align-items: center;
@@ -75,11 +75,11 @@ const TagDiv = styled.div<{
   border-radius: 4px;
   background-color: #ddd;
   color: #000;
-  ${({ popoverCapable }) => popoverCapable && css`
+  ${({ $popoverCapable }) => $popoverCapable && css`
     cursor: default;
     position: relative;
   `}
-  ${({ popoverCapable, popoverOpen }) => popoverCapable && popoverOpen && css`
+  ${({ $popoverCapable, $popoverOpen }) => $popoverCapable && $popoverOpen && css`
     &::after {
       content: '';
       display: block;
@@ -91,22 +91,22 @@ const TagDiv = styled.div<{
       z-index: 2;
     }
   `}
-  ${({ isAdministrivia }) => isAdministrivia && css`
+  ${({ $isAdministrivia }) => $isAdministrivia && css`
     background-color: #ff7;
   `}
-  ${({ isMeta }) => isMeta && css`
+  ${({ $isMeta }) => $isMeta && css`
     background-color: #ffd57f;
   `}
-  ${({ isGroup }) => isGroup && css`
+  ${({ $isGroup }) => $isGroup && css`
     background-color: #7fffff;
   `}
-  ${({ isMetaFor }) => isMetaFor && css`
+  ${({ $isMetaFor }) => $isMetaFor && css`
     background-color: #ffb0b0;
   `}
-  ${({ isNeeds }) => isNeeds && css`
+  ${({ $isNeeds }) => $isNeeds && css`
     background-color: #ff4040;
   `}
-  ${({ isPriority }) => isPriority && css`
+  ${({ $isPriority }) => $isPriority && css`
     background-color: #aaf;
   `}
 `;
@@ -309,14 +309,14 @@ const Tag = (props: TagProps) => {
 
   const tagElement = (
     <TagDiv
-      popoverCapable={props.popoverRelated}
-      popoverOpen={showPopover}
-      isAdministrivia={isAdministrivia}
-      isMeta={isMeta}
-      isGroup={isGroup}
-      isMetaFor={isMetaFor}
-      isNeeds={isNeeds}
-      isPriority={isPriority}
+      $popoverCapable={props.popoverRelated}
+      $popoverOpen={showPopover}
+      $isAdministrivia={isAdministrivia}
+      $isMeta={isMeta}
+      $isGroup={isGroup}
+      $isMetaFor={isMetaFor}
+      $isNeeds={isNeeds}
+      $isPriority={isPriority}
     >
       {title}
       {props.onRemove && (

--- a/imports/client/components/styling/PeopleComponents.tsx
+++ b/imports/client/components/styling/PeopleComponents.tsx
@@ -31,7 +31,7 @@ export const AVButton: FC<ComponentPropsWithRef<typeof Button>> = styled(Button)
   }
 `;
 
-export const PeopleListDiv = styled.div<{ collapsed?: boolean }>`
+export const PeopleListDiv = styled.div<{ $collapsed?: boolean }>`
   display: flex;
   flex-wrap: wrap;
   justify-content: flex-end;
@@ -40,7 +40,7 @@ export const PeopleListDiv = styled.div<{ collapsed?: boolean }>`
     margin: -4px -4px 0 0;
   }
 
-  ${({ collapsed }) => collapsed && css`
+  ${({ $collapsed }) => $collapsed && css`
     display: none;
   `}
 `;


### PR DESCRIPTION
By default, styled-components will pass on whatever props you pass a styled component on to the underlying component.  In the cases where we're specifying props to adjust the styling, we don't actually want those props to be propagated, since e.g. `<div>` doesn't know what to do with a `isAdministrivia` property being set on it.

Since this is a common use case, styled-components has multiple mechanisms for controlling propagation of props, but the tersest and most immediately legible is that it treats props that start with a `$` as "transient props", and will not propagate any of them.

We should prefer transient props any time we are passing props to a `styled()` component purely for the purpose of controlling the styles applied.

This should remove a large volume of warnings and errors in the JS console during development.