### PR TITLE
Explicitly configure tcp/http modes on haproxy

### DIFF
--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -656,6 +656,7 @@ Resources:
                       log stdout local0
 
                       defaults
+                      mode tcp
                       log global
                       option tcplog
                       option logasap
@@ -687,6 +688,7 @@ Resources:
 
                       backend nginx
                       server nginx localhost:8443 send-proxy
+                      mode http
 
                       backend nginx-http2
                       server nginx-http2 localhost:8444 send-proxy


### PR DESCRIPTION
For some reason, when left in the default TCP mode, haproxy was leaking connections to the backend HTTP/1 nginx service. Explicitly configuring that backend as an HTTP backend seems to fix the issue. This doesn't seem to happen with either the TURN or HTTP/2 backends.