### PR TITLE
Fix rendering of post-username migration Discord handles

### DIFF
--- a/imports/client/components/FancyEditor.tsx
+++ b/imports/client/components/FancyEditor.tsx
@@ -23,6 +23,7 @@ import {
   useFocused,
 } from "slate-react";
 import styled, { css } from "styled-components";
+import { formatDiscordName } from "../../lib/discord";
 import { indexedById, sortedBy } from "../../lib/listUtils";
 import Avatar from "./Avatar";
 
@@ -250,11 +251,7 @@ function matchUsers(
     const googEmail = u.googleAccount?.toLowerCase() ?? "";
     const foundGoogle = googEmail.includes(needle);
     const startsGoogle = googEmail.startsWith(needle);
-    const discordName = u.discordAccount
-      ? `${u.discordAccount.username.toLowerCase()}#${
-          u.discordAccount.discriminator
-        }`
-      : "";
+    const discordName = formatDiscordName(u.discordAccount) ?? "";
     const foundDiscord = discordName.includes(needle);
     const startsDiscord = discordName.startsWith(needle);
 

--- a/imports/client/components/OthersProfilePage.tsx
+++ b/imports/client/components/OthersProfilePage.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import OverlayTrigger from "react-bootstrap/OverlayTrigger";
 import Tooltip from "react-bootstrap/esm/Tooltip";
 import styled from "styled-components";
+import { formatDiscordName } from "../../lib/discord";
 import { indexedById } from "../../lib/listUtils";
 import Hunts from "../../lib/models/Hunts";
 import type { HuntType } from "../../lib/models/Hunts";
@@ -94,8 +95,7 @@ const OthersProfilePage = ({ user }: { user: Meteor.User }) => {
                   target="_blank"
                   rel="noreferrer"
                 >
-                  {user.discordAccount.username}#
-                  {user.discordAccount.discriminator}
+                  {formatDiscordName(user.discordAccount)}
                 </a>
               ) : (
                 "(none)"

--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -13,6 +13,7 @@ import FormGroup from "react-bootstrap/FormGroup";
 import FormLabel from "react-bootstrap/FormLabel";
 import FormText from "react-bootstrap/FormText";
 import Flags from "../../Flags";
+import { formatDiscordName } from "../../lib/discord";
 import linkUserDiscordAccount from "../../methods/linkUserDiscordAccount";
 import linkUserGoogleAccount from "../../methods/linkUserGoogleAccount";
 import unlinkUserDiscordAccount from "../../methods/unlinkUserDiscordAccount";
@@ -253,11 +254,7 @@ const DiscordLinkBlock = ({ user }: { user: Meteor.User }) => {
   const currentAccount = useMemo(() => {
     if (user.discordAccount) {
       const acct = user.discordAccount;
-      return (
-        <div>
-          Currently linked to {acct.username}#{acct.discriminator}
-        </div>
-      );
+      return <div>Currently linked to {formatDiscordName(acct)}</div>;
     }
 
     return null;

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -27,6 +27,7 @@ import Modal from "react-bootstrap/Modal";
 import { createPortal } from "react-dom";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
+import { formatDiscordName } from "../../lib/discord";
 import isAdmin from "../../lib/isAdmin";
 import type { HuntType } from "../../lib/models/Hunts";
 import { userIsOperatorForHunt } from "../../lib/permission_stubs";
@@ -317,20 +318,19 @@ const ProfileList = ({
       // A user is interesting if for every search key, that search key matches
       // one of their fields.
       return toMatch.every((searchKey) => {
+        /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
         return (
           user.displayName?.toLowerCase().includes(searchKey) ||
           user.emails?.some((e) =>
             e.address.toLowerCase().includes(searchKey),
           ) ||
           user.phoneNumber?.toLowerCase().includes(searchKey) ||
-          (user.discordAccount &&
-            `${user.discordAccount.username.toLowerCase()}#${
-              user.discordAccount.discriminator
-            }`.includes(searchKey)) ||
+          formatDiscordName(user.discordAccount)?.includes(searchKey) ||
           roles?.[user._id]?.some((role) =>
             role.toLowerCase().includes(searchKey),
           )
         );
+        /* eslint-enable @typescript-eslint/prefer-nullish-coalescing */
       });
     };
 

--- a/imports/lib/discord.ts
+++ b/imports/lib/discord.ts
@@ -20,4 +20,11 @@ function getAvatarCdnUrl(
   }
 }
 
-export { API_BASE, DiscordOAuthScopes, getAvatarCdnUrl };
+function formatDiscordName(da?: DiscordAccountType): string | undefined {
+  if (!da?.username) return undefined;
+
+  if (!da.discriminator || da.discriminator === "0") return da.username;
+  return `${da.username}#${da.discriminator}`;
+}
+
+export { API_BASE, DiscordOAuthScopes, getAvatarCdnUrl, formatDiscordName };


### PR DESCRIPTION
It looks like we still see a mix of Discord account references that both have and lack discriminators. At some point in the future once all usernames have been migrated, we may no longer need to track the discriminator at all, but for the time being only display it if it represents a non-migrated value (i.e. is not "0").

Before:

<img width="540" alt="Screenshot 2024-01-07 at 1 36 37 PM" src="https://github.com/deathandmayhem/jolly-roger/assets/28167/d1336b0c-0e66-44c2-819d-fe582a667cc0">

After:

<img width="510" alt="Screenshot 2024-01-07 at 1 34 22 PM" src="https://github.com/deathandmayhem/jolly-roger/assets/28167/19d9c44c-f19c-43b7-b664-59d6be4d1c42">
