### PR TITLE
Audio call styling changes

### DIFF
--- a/imports/client/components/Avatar.tsx
+++ b/imports/client/components/Avatar.tsx
@@ -30,10 +30,8 @@ const DiscordAvatarInner = ({
 };
 
 const AvatarInitial = styled.div`
-  width: 90%;
-  height: 90%;
-  margin: 5%;
-  border-radius: 50%;
+  width: 100%;
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -83,12 +81,20 @@ const DefaultAvatarInner = ({
   return <AvatarInitial style={style}>{initial}</AvatarInitial>;
 };
 
-const AvatarContainer = styled.div<{ $size: number; $inline: boolean }>`
+const AvatarContainer = styled.div<{
+  $size: number;
+  $inline: boolean;
+  $isSelf: boolean;
+}>`
   width: ${({ $size }) => $size}px;
   height: ${({ $size }) => $size}px;
   font-size: ${({ $size }) => 0.6 * $size}px;
   background-color: white;
+  font-weight: 700;
   display: ${({ $inline }) => ($inline ? "inline-block" : "block")};
+  box-shadow: ${({ $isSelf }) =>
+    $isSelf ? "0 0 4px rgba(13, 110, 253, 0.5)" : "none"};
+  border: ${({ $isSelf }) => ($isSelf ? "0.5px solid #0D6EFD" : "none")};
 `;
 
 const Avatar = React.memo(
@@ -99,6 +105,7 @@ const Avatar = React.memo(
     displayName,
     discordAccount,
     className,
+    isSelf = false,
   }: {
     size: number;
     inline?: boolean;
@@ -106,6 +113,7 @@ const Avatar = React.memo(
     displayName?: string;
     discordAccount?: DiscordAccountType;
     className?: string;
+    isSelf?: boolean;
   }) => {
     const content =
       discordAccount && getAvatarCdnUrl(discordAccount) ? (
@@ -122,6 +130,7 @@ const Avatar = React.memo(
         className={className}
         $size={size}
         $inline={inline ?? false}
+        $isSelf={isSelf}
       >
         {content}
       </AvatarContainer>

--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -40,12 +40,12 @@ import {
 
 const CallStateIcon = styled.span`
   font-size: 10px;
-  width: 12px;
-  height: 14px;
+  width: 14px;
+  height: 15px;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: red; /* TODO: lift $danger from react-bootstrap somehow? */
+  color: #dc3545;
   position: absolute;
   right: 0;
   background: white;
@@ -54,21 +54,28 @@ const CallStateIcon = styled.span`
 const MutedIcon = styled(CallStateIcon)`
   top: 0;
   border-bottom-left-radius: 6px;
+  border: 0.5px solid #0d6efd;
+  border-left: 0.5px solid #bbb;
+  border-bottom: 1px solid #bbb;
 `;
 
 const DeafenedIcon = styled(CallStateIcon)`
   bottom: 0;
   border-top-left-radius: 6px;
-  font-size: 8px;
+  border: 0.5px solid #0d6efd;
+  border-left: 0.5px solid #bbb;
+  border-top: 1px solid #bbb;
   text-align: right;
+  color: black;
+  font-size: 9px;
 `;
 
 const RemoteMuteButton = styled.div`
   position: absolute;
   inset: 0;
   font-size: 24px;
-  width: 40px;
-  height: 40px;
+  width: 44px;
+  height: 44px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -165,7 +172,8 @@ const SelfBox = ({
           _id={userId}
           displayName={name}
           discordAccount={discordAccount}
-          size={40}
+          size={44}
+          isSelf
         />
         <div>
           {muted && (
@@ -180,8 +188,8 @@ const SelfBox = ({
           )}
           {!spectraDisabled && !muted && !deafened ? (
             <Spectrum
-              width={40}
-              height={40}
+              width={44}
+              height={44}
               audioContext={audioContext}
               stream={stream}
             />
@@ -352,7 +360,7 @@ const PeerBox = ({
             _id={userId}
             displayName={name}
             discordAccount={discordAccount}
-            size={40}
+            size={44}
           />
           <div>
             {muted && (
@@ -370,8 +378,8 @@ const PeerBox = ({
             stream &&
             stream.getTracks().length > 0 ? (
               <Spectrum
-                width={40}
-                height={40}
+                width={44}
+                height={44}
                 audioContext={audioContext}
                 stream={stream}
               />

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -82,7 +82,7 @@ const ViewerPersonBox = ({
           _id={user}
           displayName={name}
           discordAccount={discordAccount}
-          size={40}
+          size={44}
         />
         {children}
       </PeopleItemDiv>
@@ -97,7 +97,7 @@ const PeopleListHeader = styled(ChatterSubsectionHeader)`
 
 const ChatterSection = styled.section`
   flex: 0;
-  background-color: #ebd0e3;
+  background-color: #f3e5e5;
   font-size: 12px;
   line-height: 12px;
   padding: ${PuzzlePagePadding};

--- a/imports/client/components/Spectrum.tsx
+++ b/imports/client/components/Spectrum.tsx
@@ -76,8 +76,8 @@ const Spectrum = ({
           const WIDTH = width;
           const HEIGHT = height;
           canvasCtx.clearRect(0, 0, WIDTH, HEIGHT);
-          const barWidth = WIDTH / (bufferLength.current / 2);
-          let x = 0;
+          const barWidth = Math.floor((WIDTH - 4) / (bufferLength.current / 2));
+          let x = 2;
           for (let i = 0; i < bufferLength.current / 2; i++) {
             const currentAmplitude = analyserBuffer.current![i]!;
             // minimum bar height reduces some flickering

--- a/imports/client/components/styling/PeopleComponents.tsx
+++ b/imports/client/components/styling/PeopleComponents.tsx
@@ -36,10 +36,14 @@ export const AVButton: FC<ComponentPropsWithRef<typeof Button>> = styled(
 export const PeopleListDiv = styled.div<{ $collapsed?: boolean }>`
   display: flex;
   flex-wrap: wrap;
-  justify-content: flex-end;
+  justify-content: flex-start;
+  padding-right: 12px;
+  max-height: 120px;
+  overflow-y: auto;
+  overflow-x: hidden;
 
   &:not(:empty) {
-    margin: -4px -4px 0 0;
+    margin: -4px -4px 0 16px;
   }
 
   ${({ $collapsed }) =>
@@ -51,8 +55,8 @@ export const PeopleListDiv = styled.div<{ $collapsed?: boolean }>`
 
 export const PeopleItemDiv = styled.div`
   flex: 0 0 auto;
-  width: 40px;
-  height: 40px;
+  width: 44px;
+  height: 44px;
   background: white;
   cursor: default;
   display: flex;


### PR DESCRIPTION
- Background color is peachy instead of pink
- Border and blue glow on "self" box
- Initial letter is bold
- Tweaks to mute/deafen icons/colors/sizes
- Fix weird alignment of volume bars

This is on top of @ebroder 's prettier branch so there's a bunch of changes associated with that (or prettier auto-fixes in the files I touched >.<). I could go through it by hand after the fact to take those out but I wanted to get this pushed up already :P