### PR TITLE
Allow track IDs to be opaque strings

### DIFF
--- a/imports/lib/models/mediasoup/ProducerClients.ts
+++ b/imports/lib/models/mediasoup/ProducerClients.ts
@@ -13,7 +13,7 @@ const ProducerClient = withCommon(
     transport: foreignKey,
     transportRequest: foreignKey,
     // client-generated GUID for client to pair ProducerClient/ProducerServer with local track
-    trackId: z.string().uuid(),
+    trackId: nonEmptyString,
     kind: z.enum(["audio", "video"]),
     rtpParameters: nonEmptyString, // JSON-encoded
     paused: z.boolean(),

--- a/imports/lib/models/mediasoup/ProducerServers.ts
+++ b/imports/lib/models/mediasoup/ProducerServers.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { ModelType } from "../Model";
 import SoftDeletedModel from "../SoftDeletedModel";
-import { foreignKey } from "../customTypes";
+import { foreignKey, nonEmptyString } from "../customTypes";
 import withCommon from "../withCommon";
 
 const ProducerServer = withCommon(
@@ -11,7 +11,7 @@ const ProducerServer = withCommon(
     peer: foreignKey,
     transport: foreignKey,
     producerClient: foreignKey,
-    trackId: z.string().uuid(), // client-generated GUID
+    trackId: nonEmptyString, // client-generated GUID
     producerId: z.string().uuid(),
   }),
 );


### PR DESCRIPTION
We assumed these would always be UUIDs, but it seems like at least modern Firefox returns track IDs that are not (pure) UUIDs. (They seem to have curly braces around them).

Since we just use the track ID to connect the ProducerClient and ProducerServer records, we need them to be present, but we can treat them as opaque.

cc @egnor (Thanks for the bug report!)