### PR TITLE
Add per-hunt "terms of use"

### DIFF
--- a/imports/lib/models/Hunts.ts
+++ b/imports/lib/models/Hunts.ts
@@ -25,6 +25,9 @@ const EditableHunt = z.object({
   // If this is true, an operator must mark guesses as correct or not.
   // If this is false, users enter answers directly without the guess step.
   hasGuessQueue: z.boolean(),
+  // If provided, users will be presented with this text as a modal to agree to
+  // before accessing the hunt.
+  termsOfUse: nonEmptyString.optional(),
   // If this is provided, then this is used to generate links to puzzles' guess
   // submission pages. The format is interpreted as a Mustache template
   // (https://mustache.github.io/). It's passed as context a parsed URL
@@ -59,6 +62,7 @@ export const HuntPattern = {
   signupMessage: Match.Optional(String),
   openSignups: Boolean,
   hasGuessQueue: Boolean,
+  termsOfUse: Match.Optional(String),
   submitTemplate: Match.Optional(String),
   homepageUrl: Match.Optional(String),
   puzzleHooksDiscordChannel: Match.Optional(SavedDiscordObjectPattern),

--- a/imports/lib/models/User.ts
+++ b/imports/lib/models/User.ts
@@ -9,6 +9,7 @@ declare module "meteor/meteor" {
     interface User {
       lastLogin?: Date;
       hunts?: string[];
+      huntTermsAcceptedAt?: Record<string, Date>;
       roles?: Record<string, string[]>; // scope -> roles
       displayName?: string;
       googleAccount?: string;
@@ -40,6 +41,7 @@ export const User = z.object({
   profile: z.object({}).optional(),
   roles: z.record(z.string(), nonEmptyString.array()).optional(),
   hunts: foreignKey.array().optional(),
+  huntTermsAcceptedAt: z.record(z.string(), z.date()).optional(),
   displayName: nonEmptyString.optional(),
   googleAccount: nonEmptyString.optional(),
   googleAccountId: nonEmptyString.optional(),

--- a/imports/methods/acceptUserHuntTerms.ts
+++ b/imports/methods/acceptUserHuntTerms.ts
@@ -1,0 +1,5 @@
+import TypedMethod from "./TypedMethod";
+
+export default new TypedMethod<{ huntId: string }, void>(
+  "Users.methods.acceptHuntTerms",
+);

--- a/imports/server/methods/acceptUserHuntTerms.ts
+++ b/imports/server/methods/acceptUserHuntTerms.ts
@@ -1,0 +1,19 @@
+import { check } from "meteor/check";
+import MeteorUsers from "../../lib/models/MeteorUsers";
+import acceptUserHuntTerms from "../../methods/acceptUserHuntTerms";
+import defineMethod from "./defineMethod";
+
+defineMethod(acceptUserHuntTerms, {
+  validate(arg) {
+    check(arg, { huntId: String });
+
+    return arg;
+  },
+
+  async run({ huntId }) {
+    check(this.userId, String);
+    await MeteorUsers.updateAsync(this.userId, {
+      $set: { [`huntTermsAcceptedAt.${huntId}`]: new Date() },
+    });
+  },
+});

--- a/imports/server/methods/index.ts
+++ b/imports/server/methods/index.ts
@@ -1,3 +1,4 @@
+import "./acceptUserHuntTerms";
 import "./addHuntUser";
 import "./addPuzzleAnswer";
 import "./addPuzzleTag";

--- a/imports/server/users.ts
+++ b/imports/server/users.ts
@@ -27,6 +27,7 @@ Accounts.setDefaultPublishFields({
   emails: 1,
   roles: 1,
   hunts: 1,
+  huntTermsAcceptedAt: 1,
   ...profileFields,
 });
 


### PR DESCRIPTION
This is a way to surface rules of engagement for a hunt and require hunters to agree to them before interacting with the hunt.

Here's what it looks like:

<img width="1672" alt="Screenshot 2024-01-08 at 12 36 02 PM" src="https://github.com/deathandmayhem/jolly-roger/assets/28167/4de58fc8-46a0-469e-8829-7725a72d9617">

The modal is pretty aggressively blocking - there's no way to interact with background elements without clicking the "agree" button. Once you agree, that state is stored on your user object.

There's also a preview button on the hunt edit page that you can use to preview the rendering. (We should plausibly go back and add something similar to the signup message field)

<img width="1493" alt="Screenshot 2024-01-08 at 12 37 28 PM" src="https://github.com/deathandmayhem/jolly-roger/assets/28167/f606a646-23eb-4f58-b543-94ad474d1fa7">
<img width="1672" alt="Screenshot 2024-01-08 at 12 37 35 PM" src="https://github.com/deathandmayhem/jolly-roger/assets/28167/14ca70ba-d38a-4f9a-87b3-2c7c1e872d14">
