### PR TITLE
Fix CloudFormation config for S3 image uploads

### DIFF
--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -309,6 +309,11 @@ Resources:
                 Resource: "*"
               - Effect: Allow
                 Action:
+                  - s3:ListBucket
+                  - s3:GetBucketLocation
+                Resource: !Sub "arn:aws:s3:::${ImageUploadBucket}"
+              - Effect: Allow
+                Action:
                   - s3:PutObject
                 Resource: !Sub "arn:aws:s3:::${ImageUploadBucket}/*"
 
@@ -858,7 +863,7 @@ Resources:
                 ${PapertrailDockerConfig}
 
                 - docker run --name coturn -d --restart=unless-stopped --network=host -e DETECT_EXTERNAL_IP=yes coturn/coturn -v --min-port=50000 --log-file=stdout --realm=${AppUrl} --use-auth-secret --static-auth-secret=${TurnSecret}
-                - docker run --name jolly-roger -d --network=host --restart=unless-stopped -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION -e PORT=3000 -e ROOT_URL=https://${AppUrl} -e TURN_SERVER=turns:${AppUrl}:443?transport=tcp -e TURN_SECRET=${TurnSecret} ghcr.io/deathandmayhem/jolly-roger
+                - docker run --name jolly-roger -d --network=host --restart=unless-stopped -e AWS_REGION=$AWS_DEFAULT_REGION -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION -e PORT=3000 -e ROOT_URL=https://${AppUrl} -e TURN_SERVER=turns:${AppUrl}:443?transport=tcp -e TURN_SECRET=${TurnSecret} ghcr.io/deathandmayhem/jolly-roger
                 - docker run --name nginx -d --network=host --restart=unless-stopped -v /etc/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf -v /usr/share/nginx/html/502.html:/usr/share/nginx/html/502.html nginx
                 - docker run --name watchtower -d --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --interval 30 --cleanup
                 - docker run --name haproxy -d --restart=unless-stopped --user root --network=host -v /etc/haproxy:/usr/local/etc/haproxy:ro haproxy


### PR DESCRIPTION
We need to specify an AWS region. We will immediately query for the actual region of the S3 bucket we're interacting with, but we still need this first. Additionally, we need the s3:GetBucketLocation and s3:ListBucket permissions in order to do this.