### PR TITLE
Move JR nav items into top nav bar

### DIFF
--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -20,7 +20,7 @@ import Container from "react-bootstrap/esm/Container";
 import type { FallbackProps } from "react-error-boundary";
 import { ErrorBoundary as ReactErrorBoundary } from "react-error-boundary";
 import * as RRBS from "react-router-bootstrap";
-import { useNavigate, Link } from "react-router-dom";
+import { useNavigate, Link, useParams } from "react-router-dom";
 import type { StackFrame } from "stacktrace-js";
 import StackTrace from "stacktrace-js";
 import styled, { css } from "styled-components";
@@ -32,12 +32,13 @@ import Loading from "./Loading";
 import NotificationCenter from "./NotificationCenter";
 import { NavBarHeight } from "./styling/constants";
 import { mediaBreakpointDown } from "./styling/responsive";
+import HuntNav from "./HuntNav";
 
 const Breadcrumb = styled.nav`
   display: flex;
   align-items: center;
   height: ${NavBarHeight};
-  flex: 1;
+  flex: 1 1 auto;
   min-width: 0;
 `;
 
@@ -97,6 +98,15 @@ const NavUsername = styled.span`
 const Brand = styled.img`
   width: ${NavBarHeight};
   height: ${NavBarHeight};
+`;
+
+const HuntNavWrapper = styled.div`
+  ${mediaBreakpointDown(
+    "sm",
+    css`
+      display: none;
+    `,
+  )}
 `;
 
 const ErrorFallback = ({
@@ -180,6 +190,7 @@ const ReactErrorBoundaryFallback = ({
 
 const AppNavbar = () => {
   const userId = useTracker(() => Meteor.userId()!, []);
+  const huntId = useParams<"huntId">().huntId!;
 
   const displayName = useTracker(
     () => Meteor.user()?.displayName ?? "<no name given>",
@@ -229,7 +240,15 @@ const AppNavbar = () => {
   // correct amount of space in the top bar even if we haven't actually picked
   // a nonempty source for it yet.
   return (
-    <NavbarInset fixed="top" bg="light" variant="light" className="py-0">
+    <NavbarInset
+      fixed="top"
+      variant="light"
+      style={{
+        backgroundColor: "#f0f0f0",
+        borderBottom: "1px solid #6c757d",
+      }}
+      className="py-0"
+    >
       <NavbarBrand className="p-0">
         <Link to="/">
           <Brand
@@ -240,6 +259,11 @@ const AppNavbar = () => {
         </Link>
       </NavbarBrand>
       {breadcrumbsComponent}
+      {huntId && (
+        <HuntNavWrapper>
+          <HuntNav />
+        </HuntNavWrapper>
+      )}
       <Nav className="ml-auto">
         <Dropdown as={NavItem}>
           <DropdownToggle id="profileDropdown" as={NavLink}>

--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -28,11 +28,11 @@ import isAdmin from "../../lib/isAdmin";
 import { useBreadcrumbItems } from "../hooks/breadcrumb";
 import lookupUrl from "../lookupUrl";
 import ConnectionStatus from "./ConnectionStatus";
+import HuntNav from "./HuntNav";
 import Loading from "./Loading";
 import NotificationCenter from "./NotificationCenter";
 import { NavBarHeight } from "./styling/constants";
 import { mediaBreakpointDown } from "./styling/responsive";
-import HuntNav from "./HuntNav";
 
 const Breadcrumb = styled.nav`
   display: flex;

--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -68,7 +68,7 @@ const BreadcrumbList = styled.ol`
 const BreadcrumbItem = styled.li`
   display: inline;
   text-indent: 0;
-  color: #6c757d;
+  color: rgba(0, 0, 0, 0.65);
 
   + li {
     padding-left: 0.5rem;

--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -68,7 +68,7 @@ const BreadcrumbList = styled.ol`
 const BreadcrumbItem = styled.li`
   display: inline;
   text-indent: 0;
-  color: rgba(0, 0, 0, 0.65);
+  color: rgba(0 0 0 / 65%);
 
   + li {
     padding-left: 0.5rem;

--- a/imports/client/components/HuntNav.tsx
+++ b/imports/client/components/HuntNav.tsx
@@ -7,12 +7,12 @@ import { faReceipt } from "@fortawesome/free-solid-svg-icons/faReceipt";
 import { faUsers } from "@fortawesome/free-solid-svg-icons/faUsers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React from "react";
+import { Nav } from "react-bootstrap";
 import { NavLink, useParams } from "react-router-dom";
 import styled, { css } from "styled-components";
 import Hunts from "../../lib/models/Hunts";
 import { userMayWritePuzzlesForHunt } from "../../lib/permission_stubs";
 import { mediaBreakpointDown } from "./styling/responsive";
-import { Nav } from "react-bootstrap";
 
 const JRLinkList = styled(Nav)`
   margin-right: 8px;
@@ -194,8 +194,9 @@ const HuntNav = () => {
         {huntLink}
       </JRLinkList>
     );
+  } else {
+    return undefined;
   }
-  return;
 };
 
 export default HuntNav;

--- a/imports/client/components/HuntNav.tsx
+++ b/imports/client/components/HuntNav.tsx
@@ -1,0 +1,201 @@
+import { Meteor } from "meteor/meteor";
+import { useTracker } from "meteor/react-meteor-data";
+import { faBullhorn } from "@fortawesome/free-solid-svg-icons/faBullhorn";
+import { faFaucet } from "@fortawesome/free-solid-svg-icons/faFaucet";
+import { faMap } from "@fortawesome/free-solid-svg-icons/faMap";
+import { faReceipt } from "@fortawesome/free-solid-svg-icons/faReceipt";
+import { faUsers } from "@fortawesome/free-solid-svg-icons/faUsers";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import React from "react";
+import { NavLink, useParams } from "react-router-dom";
+import styled, { css } from "styled-components";
+import Hunts from "../../lib/models/Hunts";
+import { userMayWritePuzzlesForHunt } from "../../lib/permission_stubs";
+import { mediaBreakpointDown } from "./styling/responsive";
+import { Nav } from "react-bootstrap";
+
+const JRLinkList = styled(Nav)`
+  margin-right: 8px;
+  flex: 1 1 auto;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+
+  ${mediaBreakpointDown(
+    "sm",
+    css`
+      justify-content: space-between;
+      align-items: stretch;
+      border: 1px solid #0d6efd;
+      margin-right: 0;
+      padding-right: 0;
+    `,
+  )}
+`;
+
+const StyledPuzzleListLinkAnchor = styled(NavLink)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-height: 50px;
+  overflow: hidden;
+  flex-direction: column;
+  padding: 0 12px;
+  color: rgba(0, 0, 0, 0.65);
+
+  &:hover {
+    color: rgba(0, 0, 0, 0.8);
+    text-decoration: none;
+  }
+
+  ${mediaBreakpointDown(
+    "lg",
+    css`
+      padding: 0 8px;
+    `,
+  )}
+
+  ${mediaBreakpointDown(
+    "sm",
+    css`
+      flex: 1;
+      font-size: 1rem;
+
+      &:hover {
+        background: #f0f0f0;
+      }
+    `,
+  )}
+`;
+
+const HuntLinkAnchor = styled(StyledPuzzleListLinkAnchor)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  ${mediaBreakpointDown(
+    "sm",
+    css`
+      color: white;
+      background: #0d6efd;
+
+      &:hover {
+        background: #0a58ca;
+        color: white;
+      }
+    `,
+  )}
+
+  ${mediaBreakpointDown(
+    "sm",
+    css`
+      margin-left: 0;
+      flex: 1;
+      height: 100%;
+      padding: 6px 0;
+
+      a {
+        border-radius: 0;
+        flex: 1;
+        height: 100%;
+        padding: 4px 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    `,
+  )}
+`;
+
+const StyledPuzzleListLinkLabel = styled.span`
+  ${mediaBreakpointDown(
+    "lg",
+    css`
+      margin-left: 0;
+      font-size: 0.8rem;
+      text-align: center;
+    `,
+  )}
+  ${mediaBreakpointDown(
+    "md",
+    css`
+      display: none;
+    `,
+  )}
+`;
+
+const MenuIcon = styled(FontAwesomeIcon)`
+  ${mediaBreakpointDown(
+    "md",
+    css`
+      margin-bottom: 2px;
+      padding: 0.2rem;
+    `,
+  )}
+`;
+
+const HuntNav = () => {
+  const huntId = useParams<"huntId">().huntId!;
+  const hunt = useTracker(() => Hunts.findOne(huntId)!, [huntId]);
+  const { canUpdate } = useTracker(() => {
+    return {
+      canUpdate: userMayWritePuzzlesForHunt(Meteor.user(), hunt),
+    };
+  }, [hunt]);
+  if (huntId && hunt) {
+    const huntLink = hunt.homepageUrl && (
+      <HuntLinkAnchor
+        to={hunt.homepageUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        title="Open the hunt homepage"
+      >
+        <MenuIcon icon={faMap} />
+        <StyledPuzzleListLinkLabel>Hunt</StyledPuzzleListLinkLabel>
+      </HuntLinkAnchor>
+    );
+    return (
+      <JRLinkList>
+        <StyledPuzzleListLinkAnchor
+          to={`/hunts/${huntId}/announcements`}
+          title="Announcements"
+        >
+          <MenuIcon icon={faBullhorn} />
+          <StyledPuzzleListLinkLabel>Announcements</StyledPuzzleListLinkLabel>
+        </StyledPuzzleListLinkAnchor>
+
+        <StyledPuzzleListLinkAnchor
+          to={`/hunts/${huntId}/guesses`}
+          title="Guess queue"
+        >
+          <MenuIcon icon={faReceipt} />
+          <StyledPuzzleListLinkLabel>Guesses</StyledPuzzleListLinkLabel>
+        </StyledPuzzleListLinkAnchor>
+
+        <StyledPuzzleListLinkAnchor
+          to={`/hunts/${huntId}/hunters`}
+          title="Hunters"
+        >
+          <MenuIcon icon={faUsers} />
+          <StyledPuzzleListLinkLabel>Hunters</StyledPuzzleListLinkLabel>
+        </StyledPuzzleListLinkAnchor>
+
+        {/* Show firehose link only to operators */}
+        {canUpdate && (
+          <StyledPuzzleListLinkAnchor
+            to={`/hunts/${huntId}/firehose`}
+            title="Firehose"
+          >
+            <MenuIcon icon={faFaucet} />
+            <StyledPuzzleListLinkLabel>Firehose</StyledPuzzleListLinkLabel>
+          </StyledPuzzleListLinkAnchor>
+        )}
+        {huntLink}
+      </JRLinkList>
+    );
+  }
+  return;
+};
+
+export default HuntNav;

--- a/imports/client/components/HuntNav.tsx
+++ b/imports/client/components/HuntNav.tsx
@@ -41,10 +41,10 @@ const StyledPuzzleListLinkAnchor = styled(NavLink)`
   overflow: hidden;
   flex-direction: column;
   padding: 0 12px;
-  color: rgba(0, 0, 0, 0.65);
+  color: rgba(0 0 0 / 65%);
 
   &:hover {
-    color: rgba(0, 0, 0, 0.8);
+    color: rgba(0 0 0 / 80%);
     text-decoration: none;
   }
 

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -45,6 +45,7 @@ import {
   useOperatorActionsHiddenForHunt,
 } from "../hooks/persisted-state";
 import useTypedSubscribe from "../hooks/useTypedSubscribe";
+import HuntNav from "./HuntNav";
 import PuzzleList from "./PuzzleList";
 import type {
   PuzzleModalFormHandle,
@@ -54,7 +55,6 @@ import PuzzleModalForm from "./PuzzleModalForm";
 import RelatedPuzzleGroup, { PuzzleGroupDiv } from "./RelatedPuzzleGroup";
 import RelatedPuzzleList from "./RelatedPuzzleList";
 import { mediaBreakpointDown } from "./styling/responsive";
-import HuntNav from "./HuntNav";
 
 const ViewControls = styled.div<{ $canAdd?: boolean }>`
   display: grid;

--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -1,13 +1,8 @@
 import { Meteor } from "meteor/meteor";
 import { useTracker } from "meteor/react-meteor-data";
-import { faBullhorn } from "@fortawesome/free-solid-svg-icons/faBullhorn";
 import { faCaretDown } from "@fortawesome/free-solid-svg-icons/faCaretDown";
 import { faEraser } from "@fortawesome/free-solid-svg-icons/faEraser";
-import { faFaucet } from "@fortawesome/free-solid-svg-icons/faFaucet";
-import { faMap } from "@fortawesome/free-solid-svg-icons/faMap";
 import { faPlus } from "@fortawesome/free-solid-svg-icons/faPlus";
-import { faReceipt } from "@fortawesome/free-solid-svg-icons/faReceipt";
-import { faUsers } from "@fortawesome/free-solid-svg-icons/faUsers";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, {
   type ComponentPropsWithRef,
@@ -26,7 +21,7 @@ import FormLabel from "react-bootstrap/FormLabel";
 import InputGroup from "react-bootstrap/InputGroup";
 import ToggleButton from "react-bootstrap/ToggleButton";
 import ToggleButtonGroup from "react-bootstrap/ToggleButtonGroup";
-import { Link, useParams, useSearchParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import styled, { css } from "styled-components";
 import { sortedBy } from "../../lib/listUtils";
 import Bookmarks from "../../lib/models/Bookmarks";
@@ -59,6 +54,7 @@ import PuzzleModalForm from "./PuzzleModalForm";
 import RelatedPuzzleGroup, { PuzzleGroupDiv } from "./RelatedPuzzleGroup";
 import RelatedPuzzleList from "./RelatedPuzzleList";
 import { mediaBreakpointDown } from "./styling/responsive";
+import HuntNav from "./HuntNav";
 
 const ViewControls = styled.div<{ $canAdd?: boolean }>`
   display: grid;
@@ -148,6 +144,18 @@ const PuzzleListToolbar = styled.div`
   justify-content: space-between;
   align-items: baseline;
   margin-bottom: 0.5em;
+`;
+
+const HuntNavWrapper = styled.div`
+  display: none;
+  ${mediaBreakpointDown(
+    "sm",
+    css`
+      display: flex;
+      width: 100%;
+      margin-bottom: 8px;
+    `,
+  )}
 `;
 
 const PuzzleListView = ({
@@ -627,56 +635,6 @@ const PuzzleListView = ({
   );
 };
 
-const StyledPuzzleListLinkList = styled.ul`
-  list-style: none;
-  display: flex;
-  align-items: stretch;
-  flex-wrap: wrap;
-  width: 100%;
-  margin: 0 0 8px;
-  padding: 0;
-  border-color: #cfcfcf;
-  border-style: solid;
-  border-width: 1px 0;
-`;
-
-const StyledPuzzleListLink = styled.li`
-  display: flex;
-  align-items: stretch;
-  flex: 1 1 0;
-`;
-
-const StyledPuzzleListLinkAnchor = styled(Link)`
-  flex: 1 1 0;
-  display: flex;
-  height: 38px;
-  align-items: center;
-  align-content: center;
-  justify-content: center;
-  text-align: center;
-  padding: 8px 0;
-  font-size: 14px;
-  font-weight: bold;
-
-  &:hover {
-    background-color: #f8f8f8;
-  }
-`;
-
-const StyledPuzzleListExternalLink = styled(StyledPuzzleListLink)`
-  flex: 0 0 40px;
-`;
-
-const StyledPuzzleListLinkLabel = styled.span`
-  margin-left: 4px;
-  ${mediaBreakpointDown(
-    "sm",
-    css`
-      display: none;
-    `,
-  )}
-`;
-
 const PuzzleListPage = () => {
   const huntId = useParams<"huntId">().huntId!;
 
@@ -698,63 +656,20 @@ const PuzzleListPage = () => {
   // Don't bother including this in loading - it's ok if they trickle in
   useTypedSubscribe(puzzleActivityForHunt, { huntId });
 
-  const huntLink = hunt.homepageUrl && (
-    <StyledPuzzleListExternalLink>
-      <Button
-        as="a"
-        href={hunt.homepageUrl}
-        className="rounded-0"
-        target="_blank"
-        rel="noopener noreferrer"
-        title="Open the hunt homepage"
-      >
-        <FontAwesomeIcon icon={faMap} />
-      </Button>
-    </StyledPuzzleListExternalLink>
-  );
-  const puzzleList = loading ? (
+  return loading ? (
     <span>loading...</span>
   ) : (
-    <PuzzleListView
-      huntId={huntId}
-      canAdd={canAdd}
-      canUpdate={canUpdate}
-      loading={loading}
-    />
-  );
-  return (
     <div>
-      <StyledPuzzleListLinkList>
-        {huntLink}
-        <StyledPuzzleListLink>
-          <StyledPuzzleListLinkAnchor to={`/hunts/${huntId}/announcements`}>
-            <FontAwesomeIcon icon={faBullhorn} />
-            <StyledPuzzleListLinkLabel>Announcements</StyledPuzzleListLinkLabel>
-          </StyledPuzzleListLinkAnchor>
-        </StyledPuzzleListLink>
-        <StyledPuzzleListLink>
-          <StyledPuzzleListLinkAnchor to={`/hunts/${huntId}/guesses`}>
-            <FontAwesomeIcon icon={faReceipt} />
-            <StyledPuzzleListLinkLabel>Guess queue</StyledPuzzleListLinkLabel>
-          </StyledPuzzleListLinkAnchor>
-        </StyledPuzzleListLink>
-        <StyledPuzzleListLink>
-          <StyledPuzzleListLinkAnchor to={`/hunts/${huntId}/hunters`}>
-            <FontAwesomeIcon icon={faUsers} />
-            <StyledPuzzleListLinkLabel>Hunters</StyledPuzzleListLinkLabel>
-          </StyledPuzzleListLinkAnchor>
-        </StyledPuzzleListLink>
-        {/* Show firehose link only to operators */}
-        {canUpdate && (
-          <StyledPuzzleListLink>
-            <StyledPuzzleListLinkAnchor to={`/hunts/${huntId}/firehose`}>
-              <FontAwesomeIcon icon={faFaucet} />
-              <StyledPuzzleListLinkLabel>Firehose</StyledPuzzleListLinkLabel>
-            </StyledPuzzleListLinkAnchor>
-          </StyledPuzzleListLink>
-        )}
-      </StyledPuzzleListLinkList>
-      {puzzleList}
+      <HuntNavWrapper>
+        <HuntNav />
+      </HuntNavWrapper>
+
+      <PuzzleListView
+        huntId={huntId}
+        canAdd={canAdd}
+        canUpdate={canUpdate}
+        loading={loading}
+      />
     </div>
   );
 };


### PR DESCRIPTION
I can never ever see the blue items menu (hunt website + JR utility links) even when looking for it:
- partly because it's not in an expected place for navigation,
- partly because it gets stretched super wide on non-small windows such that it doesn't even look like a set of buttons.

Now they're in the nav bar (if a hunt ID is set; they don't appear on the hunts index page).

This also improves contrast on the top nav bg a little and adds a bottom border to the nav bar (in the same color as the vertical panes separator).

In small windows the menu appears in the old spot and looks more or less like the old one. Not idea having it move, but I'm still trying to decide whether to have multiple dropdown menus in the nav on the smallest screens or something else. Definitely more fiddling possible to refine the flex/collapse behavior but I think this is workable for now; it aggressively clips so the new menu should never cause the navbar to break out in height.

<img width="1281" alt="Screenshot 2024-01-09 at 07 31 49" src="https://github.com/deathandmayhem/jolly-roger/assets/689247/cd2cb985-7b27-45aa-a0bd-c64d68695adb">

<img width="1078" alt="Screenshot 2024-01-09 at 07 16 02" src="https://github.com/deathandmayhem/jolly-roger/assets/689247/a2b2eaab-a2e5-4375-bad3-cfde2cc077d4">

<img width="471" alt="Screenshot 2024-01-09 at 07 15 39" src="https://github.com/deathandmayhem/jolly-roger/assets/689247/272d94d3-ca12-4bd1-956a-854329a34da8">

<img width="402" alt="Screenshot 2024-01-09 at 07 15 18" src="https://github.com/deathandmayhem/jolly-roger/assets/689247/52bfcb09-cdec-44a4-8190-08d2ea983d56">
