### PR TITLE
Fix breadcrumbs when looking at a profile from a hunt

### DIFF
--- a/imports/client/components/AllProfileListPage.tsx
+++ b/imports/client/components/AllProfileListPage.tsx
@@ -1,11 +1,9 @@
 import { useSubscribe, useTracker } from "meteor/react-meteor-data";
 import React from "react";
 import MeteorUsers from "../../lib/models/MeteorUsers";
-import { useBreadcrumb } from "../hooks/breadcrumb";
 import ProfileList from "./ProfileList";
 
 const AllProfileListPage = () => {
-  useBreadcrumb({ title: "Users", path: "/users" });
   const profilesLoading = useSubscribe("allProfiles");
   const loading = profilesLoading();
 

--- a/imports/client/components/HuntProfileListPage.tsx
+++ b/imports/client/components/HuntProfileListPage.tsx
@@ -10,12 +10,10 @@ import {
   userMayMakeOperatorForHunt,
   userMayUseDiscordBotAPIs,
 } from "../../lib/permission_stubs";
-import { useBreadcrumb } from "../hooks/breadcrumb";
 import ProfileList from "./ProfileList";
 
 const HuntProfileListPage = () => {
   const huntId = useParams<"huntId">().huntId!;
-  useBreadcrumb({ title: "Hunters", path: `/hunts/${huntId}/hunters` });
 
   const profilesLoading = useSubscribe("huntProfiles", huntId);
   const userRolesLoading = useSubscribe("huntRoles", huntId);

--- a/imports/client/components/HuntersApp.tsx
+++ b/imports/client/components/HuntersApp.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Outlet, useParams } from "react-router-dom";
+import { useBreadcrumb } from "../hooks/breadcrumb";
+
+const HuntersApp = React.memo(() => {
+  const huntId = useParams<"huntId">().huntId!;
+  useBreadcrumb({ title: "Hunters", path: `/hunts/${huntId}/hunters` });
+
+  return <Outlet />;
+});
+
+export default HuntersApp;

--- a/imports/client/components/ProfileList.tsx
+++ b/imports/client/components/ProfileList.tsx
@@ -439,7 +439,11 @@ const ProfileList = ({
               key={user._id}
               action
               as={Link}
-              to={`/users/${user._id}`}
+              to={
+                hunt
+                  ? `/hunts/${hunt._id}/hunters/${user._id}`
+                  : `/users/${user._id}`
+              }
               className="p-1"
             >
               <ListItemContainer>

--- a/imports/client/components/ProfilePage.tsx
+++ b/imports/client/components/ProfilePage.tsx
@@ -14,7 +14,7 @@ const ResolvedProfilePage = ({
   userId: string;
   isSelf: boolean;
 }) => {
-  useBreadcrumb({ title: "Users", path: "/users" });
+  const huntId = useParams<"huntId">().huntId;
 
   const profileLoading = useSubscribe("profile", userId);
   const loading = profileLoading();
@@ -25,7 +25,7 @@ const ResolvedProfilePage = ({
 
   useBreadcrumb({
     title: loading ? "loading..." : user?.displayName ?? "Profile settings",
-    path: `/users/${userId}`,
+    path: huntId ? `/hunts/${huntId}/hunters/${userId}` : `/users/${userId}`,
   });
 
   if (loading) {

--- a/imports/client/components/Routes.tsx
+++ b/imports/client/components/Routes.tsx
@@ -13,6 +13,7 @@ import HuntApp from "./HuntApp";
 import HuntListApp from "./HuntListApp";
 import HuntListPage from "./HuntListPage";
 import HuntProfileListPage from "./HuntProfileListPage";
+import HuntersApp from "./HuntersApp";
 import Loading from "./Loading";
 import LoginForm from "./LoginForm";
 import PasswordResetForm from "./PasswordResetForm";
@@ -21,6 +22,7 @@ import PuzzleListPage from "./PuzzleListPage";
 import PuzzlePage from "./PuzzlePage";
 import RootRedirector from "./RootRedirector";
 import UserInvitePage from "./UserInvitePage";
+import UsersApp from "./UsersApp";
 import { AuthenticatedPage, UnauthenticatedPage } from "./authentication";
 
 const HuntEditPage = React.lazy(() => import("./HuntEditPage"));
@@ -40,8 +42,15 @@ export const AuthenticatedRouteList: RouteObject[] = [
           { path: "announcements", element: <AnnouncementsPage /> },
           { path: "firehose", element: <FirehosePage /> },
           { path: "guesses", element: <GuessQueuePage /> },
-          { path: "hunters", element: <HuntProfileListPage /> },
-          { path: "hunters/invite", element: <UserInvitePage /> },
+          {
+            path: "hunters",
+            element: <HuntersApp />,
+            children: [
+              { path: "", element: <HuntProfileListPage /> },
+              { path: "invite", element: <UserInvitePage /> },
+              { path: ":userId", element: <ProfilePage /> },
+            ],
+          },
           { path: "puzzles/:puzzleId", element: <PuzzlePage /> },
           { path: "puzzles", element: <PuzzleListPage /> },
           { path: "edit", element: <HuntEditPage /> },
@@ -52,8 +61,14 @@ export const AuthenticatedRouteList: RouteObject[] = [
       { path: "", element: <HuntListPage /> },
     ],
   },
-  { path: "/users/:userId", element: <ProfilePage /> },
-  { path: "/users", element: <AllProfileListPage /> },
+  {
+    path: "/users",
+    element: <UsersApp />,
+    children: [
+      { path: ":userId", element: <ProfilePage /> },
+      { path: "", element: <AllProfileListPage /> },
+    ],
+  },
   { path: "/setup", element: <SetupPage /> },
   { path: "/rtcdebug", element: <RTCDebugPage /> },
 ].map((r) => {

--- a/imports/client/components/UsersApp.tsx
+++ b/imports/client/components/UsersApp.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { Outlet } from "react-router-dom";
+import { useBreadcrumb } from "../hooks/breadcrumb";
+
+// We don't have any user specific route configuration, other than setting a
+// breadcrumb.
+const UsersApp = React.memo(() => {
+  useBreadcrumb({ title: "Users", path: "/users" });
+  return <Outlet />;
+});
+
+export default UsersApp;


### PR DESCRIPTION
Historically, we've only had a single route for viewing a user profile under `/users`, but that meant that breadcrumbs broke when you went from a hunt-specific profile list to an individual profile.

This mounts the profile view under both `/users/:userId` and `/hunts/:huntId/hunters/:userId` and makes sure that breadcrumbs behave correctly regardless of how you get there.

🎁 @flipdog 