### PR TITLE
Rework how we extract lint failures into GitHub annotations

### DIFF
--- a/.github/problem-matchers/eslint.json
+++ b/.github/problem-matchers/eslint.json
@@ -1,0 +1,22 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "eslint-stylish",
+      "pattern": [
+        {
+          "regexp": "^([^\\s].*)$",
+          "file": 1
+        },
+        {
+          "regexp": "^\\s+(\\d+):(\\d+)\\s+(error|warning|info)\\s+(.*)\\s\\s+(.*)$",
+          "line": 1,
+          "column": 2,
+          "severity": 3,
+          "message": 4,
+          "code": 5,
+          "loop": true
+        }
+      ]
+    }
+  ]
+}

--- a/.github/problem-matchers/stylelint.json
+++ b/.github/problem-matchers/stylelint.json
@@ -1,0 +1,21 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "stylelint",
+      "pattern": [
+        {
+          "regexp": "^([^\\s].*)$",
+          "file": 1
+        },
+        {
+          "regexp": "^\\s+(?:(?:\\u001b\\[\\d+m)*(\\d+):(\\d+)(?:\\u001b\\[\\d+m)*)?\\s+(?:\\u001b\\[\\d+m)*(?:✖|×)(?:\\u001b\\[\\d+m)*\\s+(.*)\\s{2,}(?:\\u001b\\[\\d+m)*([^\\u001b]*)(?:\\u001b\\[\\d+m)*$",
+          "line": 1,
+          "column": 2,
+          "message": 3,
+          "code": 4,
+          "loop": true
+        }
+      ]
+    }
+  ]
+}

--- a/.github/problem-matchers/tsc.json
+++ b/.github/problem-matchers/tsc.json
@@ -1,0 +1,18 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "tsc",
+      "pattern": [
+        {
+          "regexp": "^([^\\s].*)[\\(:](\\d+)[,:](\\d+)(?:\\):\\s+|\\s+-\\s+)(error|warning|info)\\s+TS(\\d+)\\s*:\\s*(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "code": 5,
+          "message": 6
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,14 @@ jobs:
           cache-to: type=gha,mode=max # mode=max means cache intermediate images
           build-args: |
             CI=true
-            GITHUB_ACTIONS=true
+      - name: Enable problem matchers
+        run: |
+          echo "::add-matcher::${{ github.workspace }}/.github/problem-matchers/tsc.json"
+          echo "::add-matcher::${{ github.workspace }}/.github/problem-matchers/eslint.json"
+          echo "::add-matcher::${{ github.workspace }}/.github/problem-matchers/stylelint.json"
       - name: Run tests
         run: |
-          docker run -e PATH_PREFIX=${{ github.workspace }} -e CI=true -e GITHUB_ACTIONS=true --rm ${{ env.TEST_TAG }}
+          docker run -e PATH_PREFIX=${{ github.workspace }} -e CI=true --rm ${{ env.TEST_TAG }}
       - name: Build production Docker image
         uses: docker/build-push-action@v5
         with:
@@ -65,4 +69,3 @@ jobs:
           cache-to: type=gha,mode=max # mode=max means cache intermediate images
           build-args: |
             CI=true
-            GITHUB_ACTIONS=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,6 @@ FROM buildenv as meteorenv
 WORKDIR /app
 
 ARG CI=true
-ARG GITHUB_ACTIONS=
 
 # Install Meteor
 COPY .meteor/release /app/.meteor/release
@@ -97,7 +96,7 @@ COPY <<'EOF' /test.sh
 set -eux
 set -o pipefail
 export METEOR_ALLOW_SUPERUSER=1
-meteor npm run lint | sed -e "s,/app/,\${PATH_PREFIX:+\${PATH_PREFIX}/},g"
+meteor npm run lint | sed -e "s,/app/,${PATH_PREFIX:+${PATH_PREFIX}/},g"
 meteor npm run test
 EOF
 CMD ["/bin/bash", "/test.sh"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,26 +10,6 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
     },
-    "@actions/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
-      "dev": true,
-      "requires": {
-        "@actions/http-client": "^2.0.1",
-        "uuid": "^8.3.2"
-      }
-    },
-    "@actions/http-client": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.0.tgz",
-      "integrity": "sha512-q+epW0trjVUUHboliPb4UF9g2msf+w61b32tAkFEwL/IwP0DQWgbCMM0Hbe3e3WXSKz5VcUXbzJQgy8Hkra/Lg==",
-      "dev": true,
-      "requires": {
-        "tunnel": "^0.0.6",
-        "undici": "^5.25.4"
-      }
-    },
     "@aws-crypto/crc32": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
@@ -2679,12 +2659,6 @@
       "version": "8.56.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
       "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
-      "dev": true
-    },
-    "@fastify/busboy": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.0.0.tgz",
-      "integrity": "sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==",
       "dev": true
     },
     "@floating-ui/core": {
@@ -8346,64 +8320,6 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true
-    },
-    "eslint-formatter-gha": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-gha/-/eslint-formatter-gha-1.4.3.tgz",
-      "integrity": "sha512-lnuccy7JUn/KZfRgUw9Sb81x4esxJMpaGXNniv1UKT6llYhRpCuo64SgkYEkkPGSfkRwujuP8Xju5M8oqXt4HQ==",
-      "dev": true,
-      "requires": {
-        "@actions/core": "^1.10.1",
-        "eslint-formatter-json": "^8.0.0",
-        "eslint-formatter-stylish": "^8.0.0"
-      }
-    },
-    "eslint-formatter-json": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-json/-/eslint-formatter-json-8.40.0.tgz",
-      "integrity": "sha512-0bXo4At1EoEU23gFfN7wcDeqRXDHLJnvDOuQKD3Q6FkBlk7L2oVNPYg/sciIWdYrUnCBcKuMit3IWXkdSfzChg==",
-      "dev": true
-    },
-    "eslint-formatter-stylish": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-stylish/-/eslint-formatter-stylish-8.40.0.tgz",
-      "integrity": "sha512-blbD5ZSQnjNEUaG38VCO4WG9nfDQWE8/IOmt8DFRHXUIfZikaIXmsQTdWNFk0/e0j7RgIVRza86MpsJ+aHgFLg==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.0.0",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
     },
     "eslint-import-resolver-meteor": {
       "version": "0.4.0",
@@ -16255,12 +16171,6 @@
         "tslib": "^1.8.1"
       }
     },
-    "tunnel": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true
-    },
     "tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -16413,15 +16323,6 @@
         "@types/react": ">=16.9.11",
         "invariant": "^2.2.4",
         "react-lifecycles-compat": "^3.0.4"
-      }
-    },
-    "undici": {
-      "version": "5.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.27.0.tgz",
-      "integrity": "sha512-l3ydWhlhOJzMVOYkymLykcRRXqbUaQriERtR70B9LzNkZ4bX52Fc8wbTDneMiwo8T+AemZXvXaTx+9o5ROxrXg==",
-      "dev": true,
-      "requires": {
-        "@fastify/busboy": "^2.0.0"
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "url": "https://github.com/deathandmayhem/jolly-roger"
   },
   "scripts": {
-    "lint:types": "tsc --noEmit",
-    "lint:js": "eslint --format gha --max-warnings 0 --ext js,jsx,ts,tsx .",
+    "lint:types": "tsc",
+    "lint:js": "eslint --max-warnings 0 --ext js,jsx,ts,tsx .",
     "lint:css": "stylelint '**/*.scss' '**/*.tsx'",
     "lint:format": "prettier --check .",
-    "lint": "meteor lint && npm-run-all --parallel lint:*",
+    "lint": "meteor lint && npm-run-all --continue-on-error --parallel lint:*",
     "test": "TEST_BROWSER_DRIVER=puppeteer meteor test --full-app --once --driver-package meteortesting:mocha",
     "prepare": "npm explore eslint-plugin-jolly-roger -- npm run build",
     "postshrinkwrap": "lockfix"
@@ -108,7 +108,6 @@
     "eslint": "^8.56.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^9.1.0",
-    "eslint-formatter-gha": "^1.4.3",
     "eslint-import-resolver-meteor": "^0.4.0",
     "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-deprecation": "^1.5.0",


### PR DESCRIPTION
Fix presentation of lint failures as GitHub annotations, originally introduced in #725 and broken (I think) in #1197.

For background, GitHub's annotation extraction requires that file paths be absolute and reflect the working directory that the repository is checked out into. That doesn't work great for us because we do our builds inside of a Docker container under a different path. So we need to rewrite file paths in the outputs that we get from running lint inside Docker. We do that using a Docker argument (i.e. environment variable) that gets passed in. Previously, we needed to escape our use of that variable in the lint script so that Docker itself wouldn't apply variable substitution that we didn't want, but with new style heredocs, Docker wasn't applying those substitutions anymore. We didn't notice at the time because, well, we didn't have any lint failures.

Separately from all of that, we've only historically supported extracting annotations for eslint failures and not failures for our other lint steps. `tsc` and `stylelint` don't support custom output formatters, as far as I can tell, but GitHub _does_ support extracting annotations using regexes (["problem matchers"](https://github.com/actions/toolkit/blob/main/docs/commands.md#problem-matchers)) instead of requiring custom output formatting from the tools themselves. For consistency, switch `eslint` to use a problem matcher as well, rather than having a mix of approaches.

Here's what a PR looks like with failures now:

<img width="1960" alt="Screenshot 2024-01-09 at 4 31 18 PM" src="https://github.com/deathandmayhem/jolly-roger/assets/28167/2bd3b368-675c-4d5f-8743-493498857905">

My biggest complaint with this is that there's no way to tell which tool threw a particular error, but as far as I can tell there's no way to add that information.