### PR TITLE
Allow top navbar to be scrolled away on most pages

### DIFF
--- a/imports/client/components/App.tsx
+++ b/imports/client/components/App.tsx
@@ -43,10 +43,10 @@ const Breadcrumb = styled.nav`
 `;
 
 const ContentContainer = styled.div`
-  margin-top: calc(env(safe-area-inset-top, 0px) + ${NavBarHeight});
-  padding-bottom: max(env(safe-area-inset-bottom, 0px), 20px);
-  padding-left: max(env(safe-area-inset-left, 0px), 15px);
-  padding-right: max(env(safe-area-inset-right, 0px), 15px);
+  padding: /* top right bottom left */ max(env(safe-area-inset-top, 0px), 15px)
+    max(env(safe-area-inset-right, 0px), 15px)
+    max(env(safe-area-inset-bottom, 0px), 20px)
+    max(env(safe-area-inset-left, 0px), 15px);
 `;
 
 /* Using some prefixed styles with widespread support and graceful failure */
@@ -241,7 +241,6 @@ const AppNavbar = () => {
   // a nonempty source for it yet.
   return (
     <NavbarInset
-      fixed="top"
       variant="light"
       style={{
         backgroundColor: "#f0f0f0",
@@ -319,12 +318,13 @@ const App = ({ children }: { children: React.ReactNode }) => {
       </ReactErrorBoundary>
     );
   }
+
   return (
     <div>
       <NotificationCenter />
       <AppNavbar />
       <ConnectionStatus />
-      <ContentContainer className="container-fluid pt-2">
+      <ContentContainer className="container-fluid">
         {errorBoundary}
       </ContentContainer>
     </div>

--- a/imports/client/components/GuessQueuePage.tsx
+++ b/imports/client/components/GuessQueuePage.tsx
@@ -46,7 +46,7 @@ import {
   formatGuessDirection,
 } from "./guessDetails";
 import Breakable from "./styling/Breakable";
-import { guessColorLookupTable, NavBarHeight } from "./styling/constants";
+import { guessColorLookupTable } from "./styling/constants";
 import type { Breakpoint } from "./styling/responsive";
 import { mediaBreakpointDown } from "./styling/responsive";
 
@@ -78,7 +78,7 @@ const StyledHeaderRow = styled.div`
 
 const StyledHeader = styled.div`
   position: sticky;
-  top: ${NavBarHeight};
+  top: 0;
   background-color: white;
   font-weight: bold;
   ${mediaBreakpointDown(

--- a/imports/client/components/styling/FixedLayout.tsx
+++ b/imports/client/components/styling/FixedLayout.tsx
@@ -1,10 +1,31 @@
-import styled from "styled-components";
+import React from "react";
+import styled, { createGlobalStyle } from "styled-components";
 import { NavBarHeight } from "./constants";
 
-export default styled.div`
+const FixedLayoutDiv = styled.div`
   position: fixed;
   inset: /* top right bottom left */ calc(
-      env(safe-area-inset-top, 0) + ${NavBarHeight}
+      env(safe-area-inset-top, 0) + ${NavBarHeight} + 1px
     )
     env(safe-area-inset-right, 0) 0 env(safe-area-inset-left, 0);
 `;
+
+const FixedLayoutGlobal = createGlobalStyle`
+  body {
+    overscroll-behavior: none;
+  }
+`;
+
+const FixedLayout = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>((props, ref) => {
+  return (
+    <>
+      <FixedLayoutGlobal />
+      <FixedLayoutDiv ref={ref} {...props} />
+    </>
+  );
+});
+
+export default FixedLayout;


### PR DESCRIPTION
The always-visible topbar is actually not the best use of space on most pages:

* the topbar is easily found by scrolling back to the top of the page
* not having it take up 50 pixels of vertical space means 50 more rows for more-useful content like the puzzle list or guess queue
* having the top bar scroll away means we don't have to worry as much about having it be strongly-contrasting in color with other content that would slide under the fixed navbar.
* while some SPAs do have a more fixed layout, most other websites that have a navbar like this either do not make it sticky at all, or at least hide it when scrolling down

So let's just make the topbar be scrollable like most of the rest of the web, and give a little more space for content.

The view on `PuzzlePage` will not change at all, since we use a more fixed layout there anyway to position/size the chat and iframe.