### PR TITLE
Swap port allocations between mediasoup and coturn

### DIFF
--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -349,18 +349,18 @@ Resources:
         - Description: Mediasoup RTC ports
           CidrIp: 0.0.0.0/0
           IpProtocol: udp
-          FromPort: 10000
-          ToPort: 49999
+          FromPort: 50000
+          ToPort: 65535
         - Description: Mediasoup RTC ports
           CidrIp: 0.0.0.0/0
           IpProtocol: tcp
-          FromPort: 10000
-          ToPort: 49999
+          FromPort: 50000
+          ToPort: 65535
         - Description: TURN relay ports
           CidrIp: 0.0.0.0/0
           IpProtocol: udp
-          FromPort: 50000
-          ToPort: 65535
+          FromPort: 40000
+          ToPort: 49999
         - Description: ICMP echo request
           CidrIp: 0.0.0.0/0
           IpProtocol: icmp
@@ -865,7 +865,7 @@ Resources:
 
                 ${PapertrailDockerConfig}
 
-                - docker run --name coturn -d --restart=unless-stopped --network=host -e DETECT_EXTERNAL_IP=yes coturn/coturn -v --min-port=50000 --log-file=stdout --realm=${AppUrl} --use-auth-secret --static-auth-secret=${TurnSecret}
+                - docker run --name coturn -d --restart=unless-stopped --network=host -e DETECT_EXTERNAL_IP=yes coturn/coturn -v --min-port=40000 --max-port=49999 --log-file=stdout --realm=${AppUrl} --use-auth-secret --static-auth-secret=${TurnSecret}
                 - docker run --name jolly-roger -d --network=host --restart=unless-stopped -e AWS_REGION=$AWS_DEFAULT_REGION -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION -e PORT=3000 -e ROOT_URL=https://${AppUrl} -e TURN_SERVER=turns:${AppUrl}:443?transport=tcp -e TURN_SECRET=${TurnSecret} ghcr.io/deathandmayhem/jolly-roger
                 - docker run --name nginx -d --network=host --restart=unless-stopped -v /etc/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf -v /usr/share/nginx/html/502.html:/usr/share/nginx/html/502.html nginx
                 - docker run --name watchtower -d --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --interval 30 --cleanup

--- a/imports/server/mediasoup.ts
+++ b/imports/server/mediasoup.ts
@@ -364,8 +364,8 @@ class SFU {
   ) {
     process.env.DEBUG = "mediasoup:WARN:* mediasoup:ERROR:*";
     const worker = await createWorker({
-      rtcMinPort: 10000,
-      rtcMaxPort: 49999,
+      rtcMinPort: 50000,
+      rtcMaxPort: 65535,
     });
     const monitorRouter = await worker.createRouter({
       mediaCodecs,


### PR DESCRIPTION
MIT's network is documented to allow UDP connections on ports 50000+. By moving mediasoup into that port range, we can hopefully avoid needing a TURN relay on this network.

The deployment of these two changes will be a bit messy, as they can't be pushed out atomically with each other. That should be fine as long as they deploy when Jolly Roger isn't being heavily used.