### PR TITLE
Revert some new haproxy timeouts

### DIFF
--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -698,9 +698,6 @@ Resources:
                     timeout connect 5s
                     timeout client 50s
                     timeout server 50s
-                    timeout http-request 20s
-                    timeout client-fin 20s
-                    timeout tunnel 10m
 
                     frontend inbound
                     bind :443


### PR DESCRIPTION
Our haproxy issues seem to have been caused by a bug in the most recent haproxy release, while these new timeouts have some drawbacks around how they interact with long-held subscriptions.