### PR TITLE
Group together updates that need to be taken together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,16 @@ updates:
         versions: [">=5"]
       - dependency-name: "@types/marked"
         versions: [">=5"]
+    groups:
+      aws:
+        patterns:
+          - "@aws-sdk/*"
+      google:
+        patterns:
+          - "@googleapis/*"
+      fontawesome:
+        patterns:
+          - "@fortawesome/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
We've seen some cases - e.g. #1997 and #1999 - where two different packages are sufficiently co-dependent that they can't be updated independently. Fortunately, this is easy to express in dependabot config.

This should be better than our attempts at an "all" group by virtue of being a bit more limited