### PR TITLE
Don't use publishJoinedQuery for firehose

### DIFF
--- a/imports/server/publications/chatMessagesForFirehose.ts
+++ b/imports/server/publications/chatMessagesForFirehose.ts
@@ -3,7 +3,6 @@ import ChatMessages from "../../lib/models/ChatMessages";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import Puzzles from "../../lib/models/Puzzles";
 import chatMessagesForFirehose from "../../lib/publications/chatMessagesForFirehose";
-import publishJoinedQuery from "../publishJoinedQuery";
 import definePublication from "./definePublication";
 
 definePublication(chatMessagesForFirehose, {
@@ -24,24 +23,9 @@ definePublication(chatMessagesForFirehose, {
       return [];
     }
 
-    publishJoinedQuery(
-      this,
-      {
-        model: ChatMessages,
-        foreignKeys: [
-          {
-            field: "puzzle",
-            join: {
-              model: Puzzles,
-              allowDeleted: true,
-            },
-          },
-        ],
-      },
-      { hunt: huntId },
-    );
-
-    this.ready();
-    return undefined;
+    return [
+      ChatMessages.find({ hunt: huntId }),
+      Puzzles.findAllowingDeleted({ hunt: huntId }),
+    ];
   },
 });


### PR DESCRIPTION
This is one of our most database-intensive pages, and there's no reason to blow up the amount of server-side work we have to do to support it.