### PR TITLE
Enable AWS IAM authentication with MongoDB.

### DIFF
--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -47,7 +47,13 @@
 #   be configured as the CertificateArn paramater.
 #
 # - Store the MongoDB URL using `credstash put mongo @<path>`. The free account
-#   from mongodb.com (for instance) should be sufficient.
+#   from mongodb.com (for instance) should be sufficient. You can configure a
+#   user using the "AWS IAM" authentication method, the type "IAM Role", and the
+#   ARN "arn:aws:iam::<AWS Account ID>:role/JollyRogerAppInstanceRole"; then you
+#   can specify authMechanism=MONGODB-AWS in the URL and do not need to provide
+#   a username/password. You will need to configure the user with the "Atlas
+#   admin" built-in role, and to enable connections from 0.0.0.0/0 (all IPs)
+#   since the EC2 instance IPs aren't static.
 #
 # - Signup for a Mailgun account (or any mail provider that supports SMTP
 #   submission), and add an SMTP URL with the SMTP credentials from your mailgun
@@ -294,6 +300,7 @@ Resources:
   AppInstanceRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: "JollyRogerAppInstanceRole"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -46,14 +46,19 @@
 # - Set up a certificate in AWS Certificate Manager for the domain. The ARN will
 #   be configured as the CertificateArn paramater.
 #
-# - Store the MongoDB URL using `credstash put mongo @<path>`. The free account
-#   from mongodb.com (for instance) should be sufficient. You can configure a
-#   user using the "AWS IAM" authentication method, the type "IAM Role", and the
-#   ARN "arn:aws:iam::<AWS Account ID>:role/JollyRogerAppInstanceRole"; then you
-#   can specify authMechanism=MONGODB-AWS in the URL and do not need to provide
-#   a username/password. You will need to configure the user with the "Atlas
+# - Provide the MongoDB URL. The free account from mongodb.com (for instance)
+#   should be sufficient. You can configure a user using the "AWS IAM"
+#   authentication method, the type "IAM Role", and the ARN
+#   "arn:aws:iam::<AWS Account ID>:role/JollyRogerAppInstanceRole"; then you can
+#   specify authMechanism=MONGODB-AWS in the URL and do not need to provide a
+#   username/password. You will need to configure the user with the "Atlas
 #   admin" built-in role, and to enable connections from 0.0.0.0/0 (all IPs)
 #   since the EC2 instance IPs aren't static.
+#
+#   You can either set the MongoUrl and MongoOplogUrl parameters here, or set
+#   them using `credstash put mongo @<path>` and
+#   `credstash put mongo/oplog @<path>` (e.g. if you're using regular username/
+#   password credentials as part of the URLs).
 #
 # - Signup for a Mailgun account (or any mail provider that supports SMTP
 #   submission), and add an SMTP URL with the SMTP credentials from your mailgun
@@ -114,6 +119,14 @@ Parameters:
     Type: String
     AllowedPattern: "^[A-Za-z0-9]+$"
     NoEcho: true
+  MongoUrl:
+    Description: MONGO_URL to use with Meteor. Can leave unset and use "mongo" key in credstash if using username/password authentication.
+    Type: String
+    Default: ""
+  MongoOplogUrl:
+    Description: MONGO_OPLOG_URL to use with Meteor. Can leave unset and use "mongo/oplog" key in credstash if using username/password authentication.
+    Type: String
+    Default: ""
   EnableCloudWatch:
     Description: Enable CloudWatch logging
     Type: String
@@ -884,7 +897,7 @@ Resources:
                 ${PapertrailDockerConfig}
 
                 - docker run --name coturn -d --restart=unless-stopped --network=host -e DETECT_EXTERNAL_IP=yes coturn/coturn -v --min-port=40000 --max-port=49999 --log-file=stdout --realm=${AppUrl} --use-auth-secret --static-auth-secret=${TurnSecret}
-                - docker run --name jolly-roger -d --network=host --restart=unless-stopped -e AWS_REGION=$AWS_DEFAULT_REGION -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION -e PORT=3000 -e ROOT_URL=https://${AppUrl} -e TURN_SERVER=turns:${AppUrl}:443?transport=tcp -e TURN_SECRET=${TurnSecret} ${DockerPackage}
+                - docker run --name jolly-roger -d --network=host --restart=unless-stopped -e AWS_REGION=$AWS_DEFAULT_REGION -e AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION -e PORT=3000 -e ROOT_URL=https://${AppUrl} -e TURN_SERVER=turns:${AppUrl}:443?transport=tcp -e TURN_SECRET=${TurnSecret} -e MONGO_URL="${MongoUrl}" -e MONGO_OPLOG_URL="${MongoOplogUrl}" ${DockerPackage}
                 - docker run --name nginx -d --network=host --restart=unless-stopped -v /etc/nginx/conf.d/default.conf:/etc/nginx/conf.d/default.conf -v /usr/share/nginx/html/502.html:/usr/share/nginx/html/502.html nginx
                 - docker run --name watchtower -d --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower --interval 30 --cleanup
                 - docker run --name haproxy -d --restart=unless-stopped --user root --network=host -v /etc/haproxy:/usr/local/etc/haproxy:ro haproxy:2.9.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -7092,6 +7092,11 @@
         "debug": "^4.3.4"
       }
     },
+    "aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+    },
     "axe-core": {
       "version": "4.8.2",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.8.2.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@googleapis/people": "^3.0.7",
     "@googleapis/script": "^3.2.0",
     "@popperjs/core": "^2.11.8",
+    "aws4": "^1.12.0",
     "bcrypt": "^5.1.1",
     "bootstrap": "^5.3.2",
     "classnames": "^2.5.1",

--- a/scripts/run_jolly_roger.sh
+++ b/scripts/run_jolly_roger.sh
@@ -18,10 +18,10 @@ if [ -z "${CLUSTER_WORKERS_COUNT+set}" ]; then
     fi
 fi
 
-if [ -z "${MONGO_URL+set}" ]; then
+if [ -z "${MONGO_URL}" ]; then
     export MONGO_URL="$(credstash get mongo)"
 fi
-if [ -z "${MONGO_OPLOG_URL+set}" ]; then
+if [ -z "${MONGO_OPLOG_URL}" ]; then
     export MONGO_OPLOG_URL="$(credstash get mongo/oplog)"
 fi
 if [ -z "${MAIL_URL+set}" ]; then


### PR DESCRIPTION
- Use a fixed name for the role used to run EC2 instances so it can be referenced in the MongoDB config. Note that if you try to set up JR instances across multiple regions, it will now fail due to the role name being duplicated. If this is a concern, we could append the region name to the role (but this would require one user per region in MongoDB).
- Include aws4 in dependencies as required for AWS authentication.