### PR TITLE
Pin @testing-library/react to below v15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,8 @@ updates:
       - dependency-name: "puppeteer"
       - dependency-name: "mediasoup"
         versions: [">=3.13.0"]
+      - dependency-name: "@testing-library/react"
+        versions: [">=15"]
       # marked has had significant API revisions that we need to take manually
       - dependency-name: "marked"
         versions: [">=5"]


### PR DESCRIPTION
v15 dropped support for Node 14 (and introduced usage of the `&&=` operator, which is explicitly unsupported).