### PR TITLE
Verify type of key/secret for Google logins

### DIFF
--- a/imports/server/accounts.ts
+++ b/imports/server/accounts.ts
@@ -1,4 +1,5 @@
 import { Accounts } from "meteor/accounts-base";
+import { Match, check } from "meteor/check";
 import { Google } from "meteor/google-oauth";
 import { Meteor } from "meteor/meteor";
 import Mustache from "mustache";
@@ -57,6 +58,12 @@ Accounts.registerLoginHandler((options: LoginOptions) => {
   if (!options.isGoogleJrLogin) {
     return undefined;
   }
+
+  check(options, {
+    isGoogleJrLogin: true,
+    key: Match.Optional(String),
+    secret: Match.Optional(String),
+  });
 
   if (!options.key || !options.secret) {
     throw new Meteor.Error(


### PR DESCRIPTION
I don't believe this constitutes a security issue, because `Google.retrieveCredential` validates that `key` is a string before issuing any database queries, and the key is long and random. It may technically be possible (if you get your hand on a key) to swipe someone else's pending login by passing `secret: {"$ne": null}` or similar.

I think this is largely a case of "if you have root, it's easy to get root", but it seems like good practice to clean it up anyway.