### PR TITLE
Fix potential failure loading Sign in with Google button.

### DIFF
--- a/imports/client/components/AccountForm.tsx
+++ b/imports/client/components/AccountForm.tsx
@@ -62,7 +62,7 @@ const NoPaddingLinkButton: FC<ComponentPropsWithRef<typeof Button>> = styled(
 const GoogleSignInButton: FC<ComponentPropsWithRef<typeof Button>> = styled(
   Button,
 )`
-  background-image: url("./google-signin.svg");
+  background-image: url("/google-signin.svg");
   width: 175px;
   height: 40px;
 `;


### PR DESCRIPTION
The URL seems to be considered relative from some prior path in history, e.g. going to /join/ABC ends up looking for /join/google-signin.svg even though we're first redirected to /login. Use an absolute path instead.