### PR TITLE
Fix missing function invocation in pendingGuessesForSelf

### DIFF
--- a/imports/server/publications/pendingGuessesForSelf.ts
+++ b/imports/server/publications/pendingGuessesForSelf.ts
@@ -88,7 +88,7 @@ definePublication(pendingGuessesForSelf, {
         }
 
         for (const [huntId, subSubscription] of huntGuessWatchers.entries()) {
-          if (!operatorHunts.has) {
+          if (!operatorHunts.has(huntId)) {
             merger.removeSub(subSubscription);
             huntGuessWatchers.delete(huntId);
           }


### PR DESCRIPTION
This bug appears to have been introduced in
518dc82235528ebfd1834fca6dd64a9ccfb20d52.  It appears that the only effect would have been that if an operator for a hunt was demoted, clients connected before the demotion would continue to see pending guesses for that hunt.

I found this via manual inspection of the source file when I was experimenting with trying to make use of Meteor 2.16's `observeChangesAsync` and `observeAsync`.