### PR TITLE
Fix browser back on puzzle pages.

### DIFF
--- a/imports/client/components/DocumentDisplay.tsx
+++ b/imports/client/components/DocumentDisplay.tsx
@@ -51,7 +51,7 @@ const GoogleDocumentDisplay = ({
   let icon: IconDefinition;
   switch (document.value.type) {
     case "spreadsheet":
-      url = `https://docs.google.com/spreadsheets/d/${document.value.id}/edit?ui=2&rm=embedded#gid=0`;
+      url = `https://docs.google.com/spreadsheets/d/${document.value.id}/edit?ui=2&rm=embedded&gid=0#gid=0`;
       deepUrl = `googlesheets://${url}`;
       title = "Sheet";
       icon = faTable;


### PR DESCRIPTION
For some reason, when a Sheets URL is loaded with ?...#gid=0, it redirects to ?...&gid=0#gid=0; this redirect puts a spurious entry in the navigation history, which breaks the first back button press. Embedding the final URL fixes the back button.

Fixes #2162