### PR TITLE
Fix the build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,7 +69,7 @@ RUN <<'EOF'
 set -eux
 set -o pipefail
 METEOR_RELEASE="$(sed -e 's/.*@//g' .meteor/release)"
-curl -sL https://install.meteor.com?release=\$METEOR_RELEASE | sh
+curl -sL "https://install.meteor.com?release=$METEOR_RELEASE" | sh
 EOF
 
 # Install meteor deps (list is sufficient to do this)


### PR DESCRIPTION
The attempt to pin a specific version of the meteor tool never actually worked, which means the build broke once Meteor 3.0 was officially released.