### PR TITLE
Properly store deleted puzzle group collapse state.

### DIFF
--- a/imports/client/components/PuzzleListPage.tsx
+++ b/imports/client/components/PuzzleListPage.tsx
@@ -479,7 +479,7 @@ const PuzzleListView = ({
               includeCount={false}
               canUpdate={canUpdate}
               suppressedTagIds={[]}
-              trackPersistentExpand={searchString !== ""}
+              trackPersistentExpand={searchString === ""}
             />
           )}
         </div>


### PR DESCRIPTION
As best as I can tell, this was a typo. Regular puzzle groups have their state stored as long as there is no active search query. This makes sense - as commit 2e09393894024aa7c44a7b2ddac106d656ba6140 notes, it would cause confusion when searching if we paid attention to collapse state when showing search results. However, the deleted group behaves the _opposite_ way - the state is _only_ persisted during searching. I can't imagine why persisting the state in this case would be desirable, but not during the no-search case. So this change makes everything consistent.

See #2278