### PR TITLE
Ignore pointer events in FancyEditor placeholders.

### DIFF
--- a/imports/client/components/FancyEditor.tsx
+++ b/imports/client/components/FancyEditor.tsx
@@ -470,6 +470,7 @@ const decorate = ([node, path]: [Node, Path]) => {
 const PlaceholderSpan = styled.span`
   position: absolute;
   opacity: 0.333;
+  pointer-events: none;
 `;
 
 const renderPlaceholder = ({


### PR DESCRIPTION
Fixes issue where clicking the placeholder text doesn't focus on the text box.

See #2381