### PR TITLE
Improve validation for image uploads.

### DIFF
--- a/imports/client/components/InsertImageModal.tsx
+++ b/imports/client/components/InsertImageModal.tsx
@@ -249,6 +249,7 @@ const InsertImageModal = React.forwardRef(
                   isInvalid={fileInvalid}
                   required={imageSource === "upload"}
                   ref={fileRef}
+                  accept=".png,.jpg,.jpeg,.gif"
                 />
               </Tab>
               <Tab eventKey="link" title="Link">


### PR DESCRIPTION
The Google App Script insertImage API only appears to support GIF/PNG/JPG images. Attempts to upload other formats (e.g. webp) fail with an internal error.

For uploads, indicate that these are the only accepted file extensions. Clients often treat this as a suggestion rather than a hard requirement if someone is particularly certain that a file will work despite the extension being different.

For links, make a HEAD request for the image and inspect the Content-Type in the response headers. Fail open in cases where we can't definitively determine the Content-Type.

Note that copy-pasting images via the keyboard shortcut works and supports other formats, so this is probably a simpler approach to take in most cases.

See #2285 