### PR TITLE
Local voice mute

### DIFF
--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -45,13 +45,13 @@ const CallStateIcon = styled.span`
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #dc3545;
   position: absolute;
   right: 0;
   background: white;
 `;
 
-const MutedIcon = styled(CallStateIcon)`
+const MutedIcon = styled(CallStateIcon)<{ $local?: boolean }>`
+  color: ${(props) => (props.$local ? "#6c757d" : "#dc3545")};
   top: 0;
   border-bottom-left-radius: 6px;
   border: 0.5px solid #0d6efd;
@@ -270,9 +270,9 @@ const RemoteMuteConfirmModal = React.forwardRef(
           <div>
             <h4>Mute for me</h4>
             <p>
-              Toggle hearing audio from {name} while you remain connected. This
-              will not affect what others hear and you can (un)mute them here
-              anytime.
+              Toggle hearing audio from {name}. This will not affect what others
+              hear and you can (un)mute them here anytime. You will need to set
+              this each time you connect to a call.
             </p>
             <Button
               variant={isLocallyMuted ? "primary" : "outline-primary"}
@@ -406,6 +406,9 @@ const PeerBox = ({
             <div>{name}</div>
             {muted && <div>Muted (no one can hear them)</div>}
             {deafened && <div>Deafened (they can&apos;t hear anyone)</div>}
+            {isLocalMuted && !muted && (
+              <div>Muted by you (others can hear them)</div>
+            )}
           </ChatterTooltip>
         }
       >
@@ -419,6 +422,11 @@ const PeerBox = ({
           <div>
             {muted && (
               <MutedIcon>
+                <FontAwesomeIcon icon={faMicrophoneSlash} />
+              </MutedIcon>
+            )}
+            {!muted && isLocalMuted && (
+              <MutedIcon $local>
                 <FontAwesomeIcon icon={faMicrophoneSlash} />
               </MutedIcon>
             )}


### PR DESCRIPTION
My first non-accidental PR!

This introduces the concept of local voice mute. The main use case I can think of is when multiple users are in the same location and can hear each other without the call, but want to use it to collaborate with users in other locations.

A user can mute any other user, and this is tracked separately to the other user's RTC mute status. We also still display the spectrogram when the user speaks even when they are locally muted, as a signal that they are communicating something (and as a gentle cue for the user to unmute them if needed).

For simplicity (and I think alignment with encouraging collaboration), I've implemented this as a client-side mute only. This setting does not persist at all; each time you connect to a call, you will need to re-mute anyone you've muted before. 

I'm considering retaining this setting for specific users across calls (at least in the same hunt), since (I _think_ most of the time) when you've muted a user because you're in the same space, you will probably remain in the same space, and having to re-mute someone repeatedly could be frustrating.

On one hand, having to unmute someone might be frustrating; on the other, it's only a couple of clicks away. Persisting mute might also be a smidge more complex, but I think it would be very doable if desired.