### PR TITLE
Update CF Lambdas from NodeJS v18 to v22.

### DIFF
--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -186,9 +186,10 @@ Resources:
 
   SshUsersParsingFunction:
     Type: AWS::Lambda::Function
+    Condition: HaveServing
     Properties:
       Description: Generate the SSH users docker config from the raw input parameter
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       Handler: "index.main"
       Role: !GetAtt LambdaExecutionRole.Arn
       Environment:
@@ -213,6 +214,7 @@ Resources:
           };
   SshUsersParsing:
     Type: Custom::SshUsersParsing
+    Condition: HaveServing
     Properties:
       ServiceToken: !GetAtt SshUsersParsingFunction.Arn
       Suite: jammy
@@ -917,7 +919,7 @@ Resources:
     Condition: HaveServing
     Properties:
       Description: Associate the elastic IP with the single EC2 instance whenever it launches successfully
-      Runtime: nodejs18.x
+      Runtime: nodejs22.x
       Handler: "index.main"
       Role: !GetAtt LambdaExecutionRole.Arn
       Code:


### PR DESCRIPTION
v18 is slated to be deprecated on 9/1 and it will become impossible to create new lambda functions with it on 10/1.

Tested by turning down and turning up stack and verifying lambdas executed successfully. SshUsers wasn't triggering properly; as a workaround, added a condition to only create the function/output when serving is on (since the output is only needed by the EC2 template), which ensures it is triggered upon turning serving off and on.