### PR TITLE
Drop conflicting indexes first before adding new indexes

### DIFF
--- a/imports/lib/models/APIKeys.ts
+++ b/imports/lib/models/APIKeys.ts
@@ -13,7 +13,7 @@ const APIKey = withCommon(
 );
 
 const APIKeys = new SoftDeletedModel("jr_api_keys", APIKey);
-APIKeys.addIndex({ key: 1 });
+APIKeys.addIndex({ key: 1 }, { unique: true });
 export type APIKeyType = ModelType<typeof APIKeys>;
 
 export default APIKeys;

--- a/imports/lib/models/Model.ts
+++ b/imports/lib/models/Model.ts
@@ -341,6 +341,7 @@ export type IndexOptions = Pick<CreateIndexesOptions, AllowedIndexOptionsType>;
 type NormalizedIndexOptions = [AllowedIndexOptionsType, any][];
 
 export interface ModelIndexSpecification {
+  name: string | undefined;
   index: NormalizedIndexSpecification;
   options: NormalizedIndexOptions;
   // JSON-serialize [index, options] to make it easier to compare against
@@ -614,6 +615,11 @@ class Model<
     const normalizedOptions = normalizeIndexOptions(options);
     const stringified = JSON.stringify([normalizedIndex, normalizedOptions]);
     this.indexes.push({
+      // We currently generate name here in the same way Mongo would implicitly,
+      // but we will explicitly use this field's value for the index name when
+      // actually creating the index, so if we want to support index name
+      // overrides, we could.
+      name: normalizedIndex.map(([k, v]) => `${k}_${v}`).join("_"),
       index: normalizedIndex,
       options: normalizedOptions,
       stringified,

--- a/imports/server/indexes.ts
+++ b/imports/server/indexes.ts
@@ -57,33 +57,73 @@ runIfLatestBuild(async () => {
         };
       });
 
-    const existingIndexSet = new Set(
-      existingIndexes.map(({ stringified }) => stringified),
+    // We wish to compute:
+    // * the set of desired indexes we need to add
+    // * the set of existing indexes we need to drop, which is comprised of:
+    //   * the set of existing indexes with names or definitions that collide with the set of desired new indexes, which need to be dropped before creation
+    //   * the set of extra indexes that do not share a name or structure with a desired index, which we prefer to drop after doing new index creation
+    const existingIndexesByName = new Map(
+      existingIndexes.map((idx) => [idx.name, idx]),
     );
-    const expectedIndexSet = new Set(
-      expectedIndexes.map(({ stringified }) => stringified),
+    const existingIndexesByStructure = new Map(
+      existingIndexes.map((idx) => [idx.stringified, idx]),
+    );
+    const expectedIndexesByName = new Map(
+      expectedIndexes.map((idx) => [idx.name, idx]),
+    );
+    const expectedIndexesByStructure = new Map(
+      expectedIndexes.map((idx) => [idx.stringified, idx]),
     );
 
-    const missingIndexes = expectedIndexes.filter(
-      ({ stringified }) => !existingIndexSet.has(stringified),
-    );
-    const extraIndexes = existingIndexes.filter(({ index, stringified }) => {
-      // Don't (try to) delete the default _id index
-      return (
-        !util.isDeepStrictEqual(index, [["_id", 1]]) &&
-        !expectedIndexSet.has(stringified)
+    // Compute which indexes need to be added.
+    const missingIndexes = expectedIndexes.filter((idx) => {
+      const matchingExistingStructure = existingIndexesByStructure.get(
+        idx.stringified,
+      );
+      const matchingExistingName = existingIndexesByName.get(idx.name);
+      return !(
+        matchingExistingStructure &&
+        matchingExistingName &&
+        matchingExistingStructure === matchingExistingName
       );
     });
 
-    for (const { index, options } of missingIndexes) {
-      Logger.info("Creating new index", {
-        model: model.name,
-        index,
-        options,
-      });
-      await collection.createIndex(index, Object.fromEntries(options));
-    }
-    for (const { name, index, options } of extraIndexes) {
+    // Compute which indexes need to be removed, and when
+    const [extraConflicting, extraNonConflicting] = existingIndexes.reduce(
+      (
+        acc: [ExistingIndexSpecification[], ExistingIndexSpecification[]],
+        idx: ExistingIndexSpecification,
+      ) => {
+        // Don't try to delete the default _id index.
+        if (util.isDeepStrictEqual(idx.index, [["_id", 1]])) return acc;
+        const matchingExpectedStructure = expectedIndexesByStructure.get(
+          idx.stringified,
+        );
+        const matchingExpectedName = expectedIndexesByName.get(idx.name);
+        // If an index matches both name and structure with an expected index,
+        // it is desired, and not extra, so we don't modify the accumulator.
+        if (
+          matchingExpectedName &&
+          matchingExpectedStructure &&
+          matchingExpectedName === matchingExpectedStructure
+        )
+          return acc;
+        if (matchingExpectedName || matchingExpectedStructure) {
+          // It is conflicting if it matches in name but not structure or
+          // structure but not name of some expected index.
+          acc[0].push(idx);
+        } else {
+          // It is nonconflicting if it matches neither.
+          acc[1].push(idx);
+        }
+
+        return acc;
+      },
+      [[], []],
+    );
+
+    const dropIndex = async (idx: ExistingIndexSpecification) => {
+      const { name, index, options } = idx;
       if (!name) {
         Logger.warn("Unable to drop index with no name", {
           model: model.name,
@@ -91,7 +131,7 @@ runIfLatestBuild(async () => {
           options,
           error: new Error("Unable to drop index with no name"),
         });
-        continue;
+        return;
       }
 
       Logger.info("Dropping unexpected index", {
@@ -100,6 +140,29 @@ runIfLatestBuild(async () => {
         options,
       });
       await collection.dropIndex(name);
+    };
+
+    // First, remove conflicting indexes.
+    for (const conflictingIndex of extraConflicting) {
+      await dropIndex(conflictingIndex);
+    }
+    // Then, add new indexes.
+    for (const { name, index, options } of missingIndexes) {
+      Logger.info("Creating new index", {
+        model: model.name,
+        index,
+        options,
+      });
+      // Prefer createIndexes to createIndex so we can specify an explicit name
+      // to match the one in our spec
+      await collection.createIndexes(
+        [{ key: Object.fromEntries(index), name }],
+        Object.fromEntries(options),
+      );
+    }
+    // Finally, drop non-conflicting indexes.
+    for (const extraIndex of extraNonConflicting) {
+      await dropIndex(extraIndex);
     }
   }
 });


### PR DESCRIPTION
The second commit is the actual motivation for this PR: we want `APIKeys` to have a unique index on `key`.

The first commit is what makes that change possible without Mongo throwing an error: Mongo will reject attempts to create two indexes with the same name and different options, as well as two indexes with the same structure and options and different names.  To allow the appearance of "in-place" index changes, we need slightly more clever logic around dropping and creating indexes.

To achieve that, we add a `name` field to our `ModelIndexSpecification`, generate the same `name` Mongo would by default, and then teach `imports/server/indexes.ts` to notice when a requested index would conflict with an existing one, and drop conflicting indexes first before adding new ones.  This results in a small window of time where we might have no index if a previous version of the code had a conflicting one, but in general our data is small and we expect to complete index building before serving traffic, so it's probably generally fine.

One other structural change that I made for consistency is to ensure that we always use our specified `name` field when generating index names, so that just in case our behavior and Mongo's ever diverge, we're at least consistent with the indexes we create and expect to read back, rather than letting mongo generate one format but expecting to read back something else.

Fixes #2434.