### PR TITLE
Switch to zodern:types for first-party Meteor types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -283,7 +283,8 @@
         "browser": true
       },
       "rules": {
-        "jolly-roger/no-disallowed-sync-methods": "off"
+        "jolly-roger/no-disallowed-sync-methods": "off",
+        "deprecation/deprecation": "off"
       }
     },
     {

--- a/imports/client/components/AccountForm.tsx
+++ b/imports/client/components/AccountForm.tsx
@@ -221,7 +221,7 @@ const AccountForm = (props: AccountFormProps) => {
 
   const tryPasswordReset = useCallback(() => {
     setSubmitState(AccountFormSubmitState.SUBMITTING);
-    Accounts.forgotPassword({ email }, (error?: Error) => {
+    void Accounts.forgotPassword({ email }, (error?: Error) => {
       if (error) {
         setSubmitState(AccountFormSubmitState.FAILED);
         setErrorMessage(
@@ -237,7 +237,7 @@ const AccountForm = (props: AccountFormProps) => {
   const tryCompletePasswordReset = useCallback(
     (token: string) => {
       setSubmitState(AccountFormSubmitState.SUBMITTING);
-      Accounts.resetPassword(token, password, (error?: Error) => {
+      void Accounts.resetPassword(token, password, (error?: Error) => {
         if (error) {
           setSubmitState(AccountFormSubmitState.FAILED);
           setErrorMessage(
@@ -268,7 +268,7 @@ const AccountForm = (props: AccountFormProps) => {
       };
 
       setSubmitState(AccountFormSubmitState.SUBMITTING);
-      Accounts.resetPassword(token, password, (error?: Error) => {
+      void Accounts.resetPassword(token, password, (error?: Error) => {
         if (error) {
           setSubmitState(AccountFormSubmitState.FAILED);
           setErrorMessage(

--- a/imports/client/components/HuntEditPage.tsx
+++ b/imports/client/components/HuntEditPage.tsx
@@ -149,7 +149,7 @@ const DiscordChannelSelector = ({
       {
         // We want to sort them in the same order they're provided in the Discord UI.
         sort: { "object.rawPosition": 1 },
-        fields: { "object.id": 1, "object.name": 1 },
+        projection: { "object.id": 1, "object.name": 1 },
       },
     ).map((c) => c.object as SavedDiscordObjectType);
 
@@ -179,7 +179,7 @@ const DiscordRoleSelector = ({
       {
         // We want to sort them in the same order they're provided in the Discord UI.
         sort: { "object.rawPosition": 1 },
-        fields: { "object.id": 1, "object.name": 1 },
+        projection: { "object.id": 1, "object.name": 1 },
       },
     ).map((c) => c.object as SavedDiscordObjectType);
 

--- a/imports/client/components/HuntListPage.tsx
+++ b/imports/client/components/HuntListPage.tsx
@@ -3,7 +3,7 @@ import { useTracker } from "meteor/react-meteor-data";
 import { faEdit } from "@fortawesome/free-solid-svg-icons/faEdit";
 import { faMinus } from "@fortawesome/free-solid-svg-icons/faMinus";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import type { MouseEvent } from "react";
+import type { MouseEvent, ReactNode } from "react";
 import React, {
   useCallback,
   useImperativeHandle,
@@ -188,7 +188,7 @@ const HuntListPage = () => {
     [renderCreateFixtureModal, createFixtureModalRef],
   );
 
-  const body = [];
+  const body: ReactNode[] = [];
   if (loading) {
     body.push(<div key="loading">Loading...</div>);
   } else {

--- a/imports/client/components/SetupPage.tsx
+++ b/imports/client/components/SetupPage.tsx
@@ -1755,7 +1755,7 @@ const DiscordGuildForm = ({
   const guilds = useTracker(() => {
     return DiscordCache.find(
       { type: "guild" },
-      { fields: { "object.id": 1, "object.name": 1 } },
+      { projection: { "object.id": 1, "object.name": 1 } },
     ).map((c) => c.object as SavedDiscordObjectType);
   }, []);
   const [guildId, setGuildId] = useState<string>(initialGuild?.id ?? "");

--- a/imports/client/indexedDisplayNames.ts
+++ b/imports/client/indexedDisplayNames.ts
@@ -7,7 +7,7 @@ export default function indexedDisplayNames(): Map<string, string> {
       displayName: { $ne: undefined },
     },
     {
-      fields: { displayName: 1 },
+      projection: { displayName: 1 },
     },
   ).forEach((u) => res.set(u._id, u.displayName!));
   return res;

--- a/imports/lib/config/accounts.ts
+++ b/imports/lib/config/accounts.ts
@@ -9,4 +9,9 @@ Accounts.config({
   // See https://github.com/meteor/meteor/issues/7794#issuecomment-270253106
   // If Meteor fixes the problem described in that comment, we can remove this.
   passwordResetTokenExpirationInDays: 30,
+  // We include these fields only because upstream declares these as required
+  // in their type signatures.  They should probably be made optional.
+  argon2TimeCost: undefined,
+  argon2MemoryCost: undefined,
+  argon2Parallelism: undefined,
 });

--- a/imports/lib/models/SoftDeletedModel.ts
+++ b/imports/lib/models/SoftDeletedModel.ts
@@ -36,11 +36,11 @@ const injectQuery = <S extends Mongo.Selector<any>>(
 const injectOptions = <Opts extends Mongo.Options<any>>(
   options: Opts | undefined,
 ) => {
-  if (options?.fields) {
+  if (options?.projection) {
     return {
       ...options,
-      fields: {
-        ...options.fields,
+      projection: {
+        ...options.projection,
         deleted: 1,
       },
     };

--- a/imports/lib/models/generateJsonSchema.ts
+++ b/imports/lib/models/generateJsonSchema.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
-import type { Mongo } from "meteor/mongo";
 import { z } from "zod";
 import { Email, URL, UUID } from "./regexes";
 
@@ -14,8 +13,32 @@ export type MongoRecordZodType =
   | z.ZodIntersection<any, any>
   | z.ZodRecord<any, any>;
 
+type BsonType =
+  | "double"
+  | "string"
+  | "object"
+  | "array"
+  | "binData"
+  | "undefined"
+  | "objectId"
+  | "bool"
+  | "date"
+  | "null"
+  | "regex"
+  | "dbPointer"
+  | "javascript"
+  | "symbol"
+  | "javascriptWithScope"
+  | "int"
+  | "timestamp"
+  | "long"
+  | "decimal"
+  | "minKey"
+  | "maxKey"
+  | "number";
+
 export interface JsonSchema {
-  bsonType?: Mongo.BsonType & string;
+  bsonType?: BsonType;
   enum?: readonly any[];
   allOf?: readonly JsonSchema[];
   anyOf?: readonly JsonSchema[];

--- a/imports/methods/TypedMethod.ts
+++ b/imports/methods/TypedMethod.ts
@@ -59,30 +59,24 @@ class TypedMethod<
       );
     }
 
-    return Meteor.call(
-      this.name,
-      ...args,
-      (error: Meteor.Error, result: Return) => {
-        if (error) {
-          const severity =
-            error instanceof Meteor.Error &&
-            typeof error.error === "number" &&
-            error.error >= 400 &&
-            error.error < 500
-              ? "info"
-              : "error";
-          Logger[severity](`Meteor method call failed: ${this.name}`, {
-            error,
-            method: this.name,
-            arguments:
-              typeof args[0] === "object"
-                ? EJSON.stringify(args[0])
-                : undefined,
-          });
-        }
-        callback?.(error, result as any);
-      },
-    );
+    Meteor.call(this.name, ...args, (error: Meteor.Error, result: Return) => {
+      if (error) {
+        const severity =
+          error instanceof Meteor.Error &&
+          typeof error.error === "number" &&
+          error.error >= 400 &&
+          error.error < 500
+            ? "info"
+            : "error";
+        Logger[severity](`Meteor method call failed: ${this.name}`, {
+          error,
+          method: this.name,
+          arguments:
+            typeof args[0] === "object" ? EJSON.stringify(args[0]) : undefined,
+        });
+      }
+      callback?.(error, result as any);
+    });
   }
 
   async callPromise<T>(
@@ -102,7 +96,8 @@ class TypedMethod<
           "request",
         );
       }
-      return await Meteor.callAsync(this.name, ...args);
+      const result = await Meteor.callAsync(this.name, ...args);
+      return result as Return;
     } catch (error) {
       if (error) {
         const severity =

--- a/imports/server/accounts.ts
+++ b/imports/server/accounts.ts
@@ -79,9 +79,10 @@ Accounts.registerLoginHandler(async (options: LoginOptions) => {
   const googleAccountId = credential.serviceData.id;
 
   // Attempt to match existing Google users by their linked account ID.
-  // We can't use the async method since Meteor's API only takes a sync one.
-  // eslint-disable-next-line jolly-roger/no-disallowed-sync-methods
-  const users = MeteorUsers.find({ googleAccountId }, { limit: 2 }).fetch();
+  const users = await MeteorUsers.find(
+    { googleAccountId },
+    { limit: 2 },
+  ).fetchAsync();
   switch (users.length) {
     case 0: {
       throw new Meteor.Error(

--- a/imports/server/addUserToHunt.ts
+++ b/imports/server/addUserToHunt.ts
@@ -85,7 +85,6 @@ export default async function addUserToHunt({
   email: string;
   invitedBy: string;
 }) {
-  // eslint-disable-next-line @typescript-eslint/await-thenable -- the type hints are wrong; this is definitely a promise
   let joineeUser = await Accounts.findUserByEmail(email);
   const newUser = joineeUser === undefined;
   if (!joineeUser) {
@@ -130,7 +129,6 @@ export default async function addUserToHunt({
   await addUsersToDiscordRole([joineeUser._id], hunt._id);
 
   if (newUser) {
-    // eslint-disable-next-line @typescript-eslint/await-thenable -- the types are wrong, but this is now a promise
     await Accounts.sendEnrollmentEmail(joineeUser._id);
     Logger.info("Sent invitation email to new user", { invitedBy, email });
   } else {

--- a/imports/server/api-init.ts
+++ b/imports/server/api-init.ts
@@ -2,4 +2,4 @@ import { Meteor } from "meteor/meteor";
 import { WebApp } from "meteor/webapp";
 import api from "./api";
 
-WebApp.connectHandlers.use("/api", Meteor.bindEnvironment(api));
+WebApp.handlers.use("/api", Meteor.bindEnvironment(api));

--- a/imports/server/api/resources/users.ts
+++ b/imports/server/api/resources/users.ts
@@ -15,7 +15,6 @@ async function findUserByEmail(
   // linked. Try both.
 
   return (
-    // eslint-disable-next-line @typescript-eslint/await-thenable -- the types are wrong; this is a promise
     (await Accounts.findUserByEmail(email)) ??
     (await MeteorUsers.findOneAsync({ googleAccount: email }))
   );

--- a/imports/server/assets.ts
+++ b/imports/server/assets.ts
@@ -213,4 +213,4 @@ router.post(
 
 app.use("/", router);
 
-WebApp.connectHandlers.use("/asset", Meteor.bindEnvironment(app));
+WebApp.handlers.use("/asset", Meteor.bindEnvironment(app));

--- a/imports/server/browserconfig.ts
+++ b/imports/server/browserconfig.ts
@@ -30,7 +30,7 @@ const serveBrowserConfig = (
   res.end(body);
 };
 
-WebApp.connectHandlers.use(
+WebApp.handlers.use(
   "/browserconfig.xml",
   Meteor.bindEnvironment(serveBrowserConfig),
 );

--- a/imports/server/hooks/ChatNotificationHooks.ts
+++ b/imports/server/hooks/ChatNotificationHooks.ts
@@ -57,7 +57,7 @@ const ChatNotificationHooks: Hookset = {
           "dingwords.0": { $exists: true },
         },
         {
-          fields: { _id: 1, dingwords: 1 },
+          projection: { _id: 1, dingwords: 1 },
         },
       )) {
         // Avoid making users ding themselves.

--- a/imports/server/mediasoup-api.ts
+++ b/imports/server/mediasoup-api.ts
@@ -62,7 +62,7 @@ Meteor.publish("mediasoup:debug", async function () {
   checkAdmin(await MeteorUsers.findOneAsync(this.userId));
 
   return [
-    MeteorUsers.find({}, { fields: { displayName: 1, discordAccount: 1 } }),
+    MeteorUsers.find({}, { projection: { displayName: 1, discordAccount: 1 } }),
     Puzzles.find(),
     Servers.find(),
     CallHistories.find(),

--- a/imports/server/methods/addPuzzleTag.ts
+++ b/imports/server/methods/addPuzzleTag.ts
@@ -25,7 +25,7 @@ defineMethod(addPuzzleTag, {
         _id: puzzleId,
       },
       {
-        fields: {
+        projection: {
           hunt: 1,
         },
       },

--- a/imports/server/methods/removePuzzleAnswer.ts
+++ b/imports/server/methods/removePuzzleAnswer.ts
@@ -24,7 +24,7 @@ defineMethod(removePuzzleAnswer, {
         _id: puzzleId,
       },
       {
-        fields: {
+        projection: {
           hunt: 1,
         },
       },

--- a/imports/server/methods/updateHunt.ts
+++ b/imports/server/methods/updateHunt.ts
@@ -31,7 +31,7 @@ defineMethod(updateHunt, {
     // $unset on the appropriate key(s).  Split out which keys we must set and
     // unset to achieve the desired final state.
     const toSet: { [key in keyof HuntType]?: any } = {};
-    const toUnset: { [key in keyof HuntType]?: string } = {};
+    const toUnset: { [key in keyof HuntType]?: "" } = {};
     Object.keys(HuntPattern).forEach((key: string) => {
       const typedKey = key as keyof typeof HuntPattern;
       if (value[typedKey] === undefined) {

--- a/imports/server/methods/updatePuzzle.ts
+++ b/imports/server/methods/updatePuzzle.ts
@@ -72,7 +72,7 @@ defineMethod(updatePuzzle, {
       },
     };
     if (url) {
-      update.$set!.url = url;
+      update.$set = { ...update.$set, url };
     } else {
       update.$unset = { url: "" };
     }

--- a/imports/server/publications/pendingGuessesForSelf.ts
+++ b/imports/server/publications/pendingGuessesForSelf.ts
@@ -48,7 +48,7 @@ definePublication(pendingGuessesForSelf, {
     };
 
     const userWatch = await MeteorUsers.find(this.userId, {
-      fields: { roles: 1 },
+      projection: { roles: 1 },
     }).observeChangesAsync({
       added: (_id, fields) => {
         const { roles } = fields;

--- a/imports/server/publishJoinedQuery.ts
+++ b/imports/server/publishJoinedQuery.ts
@@ -139,7 +139,7 @@ class JoinedObjectObserver<T extends { _id: string }> {
     let observeReady = false;
     this.initialBlockers = [];
     this.watcherPromise = finder(model, allowDeleted)(id, {
-      fields: projection as Mongo.FieldSpecifier,
+      projection: projection as Mongo.FieldSpecifier,
     }).observeChangesAsync({
       added: (_, fields) => {
         const fkValues = new Map<string, string[]>();
@@ -370,7 +370,7 @@ export default async function publishJoinedQuery<T extends { _id: string }>(
   const promises: Promise<void>[] = [];
   let ready = false;
   const watcher = await finder(model, allowDeleted)(query, {
-    fields: { _id: 1 },
+    projection: { _id: 1 },
   }).observeChangesAsync({
     added: (id) => {
       const promise = observer.incref(id);

--- a/imports/server/runLatestBuildHooks.ts
+++ b/imports/server/runLatestBuildHooks.ts
@@ -28,7 +28,7 @@ if (previousLatest && previousLatest.buildTimestamp > buildTimestamp) {
     await LatestDeploymentTimestamps.insertAsync({
       _id: "default",
       buildTimestamp,
-      gitRevision: Meteor.gitCommitHash,
+      gitRevision: Meteor.gitCommitHash!,
     });
   });
 
@@ -40,7 +40,7 @@ if (previousLatest && previousLatest.buildTimestamp > buildTimestamp) {
     {
       $set: {
         buildTimestamp,
-        gitRevision: Meteor.gitCommitHash,
+        gitRevision: Meteor.gitCommitHash!,
       },
     },
   );

--- a/imports/server/site-manifest.ts
+++ b/imports/server/site-manifest.ts
@@ -41,7 +41,7 @@ const serveSiteManifest = (
   res.end(body);
 };
 
-WebApp.connectHandlers.use(
+WebApp.handlers.use(
   "/site.webmanifest",
   Meteor.bindEnvironment(serveSiteManifest),
 );

--- a/imports/server/users.ts
+++ b/imports/server/users.ts
@@ -60,7 +60,7 @@ const republishOnUserChange = async (
     );
   }
   const watch = await MeteorUsers.find(sub.userId!, {
-    fields: projection,
+    projection,
   }).observeAsync({
     changed: (doc) => {
       void (async () => {
@@ -111,7 +111,10 @@ Meteor.publish("displayNames", async function (huntId: unknown) {
       return undefined;
     }
 
-    return MeteorUsers.find({ hunts: huntId }, { fields: { displayName: 1 } });
+    return MeteorUsers.find(
+      { hunts: huntId },
+      { projection: { displayName: 1 } },
+    );
   });
 
   return undefined;
@@ -131,7 +134,7 @@ Meteor.publish("avatars", async function (huntId: unknown) {
 
     return MeteorUsers.find(
       { hunts: huntId },
-      { fields: { discordAccount: 1 } },
+      { projection: { discordAccount: 1 } },
     );
   });
 
@@ -150,7 +153,7 @@ Meteor.publish("allProfiles", async function () {
       return MeteorUsers.find(
         { hunts: { $in: u.hunts ?? [] } },
         {
-          fields: {
+          projection: {
             "emails.address": 1,
             hunts: 1,
             ...profileFields,
@@ -182,7 +185,7 @@ Meteor.publish("huntProfiles", async function (huntId: unknown) {
       return MeteorUsers.find(
         { hunts: huntId },
         {
-          fields: {
+          projection: {
             "emails.address": 1,
             hunts: 1,
             ...profileFields,
@@ -211,7 +214,7 @@ Meteor.publish("profile", async function (userId: unknown) {
       return MeteorUsers.find(
         { _id: userId, hunts: { $in: u.hunts ?? [] } },
         {
-          fields: {
+          projection: {
             "emails.address": 1,
             hunts: 1,
             ...profileFields,
@@ -237,7 +240,7 @@ Meteor.publish("huntRoles", async function (huntId: unknown) {
     return MeteorUsers.find(
       { hunts: huntId },
       {
-        fields: {
+        projection: {
           // Specifying sub-fields here is allowed, but will conflict with any other
           // concurrent publications for the same top-level field (roles). This
           // should be fine so long as we don't try to subscribe to huntRoles for

--- a/tests/acceptance/profiles.tsx
+++ b/tests/acceptance/profiles.tsx
@@ -162,9 +162,10 @@ if (Meteor.isClient) {
         let huntSub = await subscribeAsync("displayNames", huntId);
 
         assert.sameMembers(
-          await MeteorUsers.find({}, { fields: { displayName: 1 } }).mapAsync(
-            (u) => u.displayName,
-          ),
+          await MeteorUsers.find(
+            {},
+            { projection: { displayName: 1 } },
+          ).mapAsync((u) => u.displayName),
           ["U1", "U2"],
           "Should only show users in the same hunt",
         );
@@ -174,9 +175,10 @@ if (Meteor.isClient) {
         huntSub = await subscribeAsync("displayNames", otherHuntId);
 
         assert.sameMembers(
-          await MeteorUsers.find({}, { fields: { displayName: 1 } }).mapAsync(
-            (u) => u.displayName,
-          ),
+          await MeteorUsers.find(
+            {},
+            { projection: { displayName: 1 } },
+          ).mapAsync((u) => u.displayName),
           ["U1"],
           "Should not show users in the other hunt when not a member",
         );
@@ -185,9 +187,10 @@ if (Meteor.isClient) {
         await stabilize();
 
         assert.sameMembers(
-          await MeteorUsers.find({}, { fields: { displayName: 1 } }).mapAsync(
-            (u) => u.displayName,
-          ),
+          await MeteorUsers.find(
+            {},
+            { projection: { displayName: 1 } },
+          ).mapAsync((u) => u.displayName),
           ["U1", "U3"],
           "Should update when hunt membership changes",
         );

--- a/tests/unit/imports/server/Model.ts
+++ b/tests/unit/imports/server/Model.ts
@@ -3,6 +3,7 @@ import { assert } from "chai";
 import { z } from "zod";
 import Model, {
   ModelType,
+  modifierIsNotWholeDoc,
   parseMongoModifierAsync,
   parseMongoOperationAsync,
   relaxSchema,
@@ -444,14 +445,24 @@ describe("Model", function () {
 
     describe("updateAsync", function () {
       it("does not accept full document updates", function () {
-        const modifier: Parameters<typeof model.updateAsync>[1] = {
-          // @ts-expect-error - should not accept full document updates
+        const modifierDoc = {
           string: "foo",
         };
+        const isNotWholeDocModifier =
+          modifierIsNotWholeDoc<typeof schema>(modifierDoc);
+        assert.isFalse(isNotWholeDocModifier);
+
+        // We expected that this would require an @ts-expect-error, but for some reason it does not
+        const modifier: Parameters<typeof model.updateAsync>[1] = modifierDoc;
         assert.isOk(modifier);
       });
 
       it("does accept mongo modifiers", function () {
+        const isNotWholeDocModifier = modifierIsNotWholeDoc<typeof schema>({
+          $set: { string: "foo" },
+        });
+        assert.isTrue(isNotWholeDocModifier);
+
         const modifier: Parameters<typeof model.updateAsync>[1] = {
           $set: { string: "foo" },
         };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,7 +30,8 @@
     "preserveSymlinks": true,
     "paths": {
       "meteor/*": [
-        "node_modules/@types/meteor/*"
+        //"node_modules/@types/meteor/*",
+        ".meteor/local/types/packages.d.ts"
         /*
         Ideally, we'd use first-party types exported from Meteor upstream.
         Unfortunately, Meteor upstream has yet to ship a sufficiently-correct

--- a/types/meteor/meteor.d.ts
+++ b/types/meteor/meteor.d.ts
@@ -1,5 +1,0 @@
-declare module "meteor/meteor" {
-  namespace Meteor {
-    const gitCommitHash: string;
-  }
-}


### PR DESCRIPTION
This winds up pulling in a surprising amount of other stuff, especially around things marked deprecated.  To wit: `fields` is now `projection` in Mongo field specifiers, `WebApp.connectHandlers` is simply `WebApp.handlers`, and findOne is deprecated on server, but unfortunately the rule is a little loosely defined so we have to disable it on client or else get a warning for every point load we do from minimongo, which is annoying.

In addition to the obvious stuff, updated types around collections and Mongo mean that our Zod-typed Model abstraction seems to be not working quite as intended.  As written, some of the "is not a whole document pattern" logic and type-fu meant to require that updateAsync() and upsertAsync() receive at least one `$set` or similar modifier key doesn't seem to work any more.  The runtime checks are still fine, but it's a little less immediate feedback.

Also, a few things in `Accounts` are now defined as async functions returning promises, but if you call them without a callback function in client code, they block and the promise never arms, which is non-functional, so I'm just voiding the results.

This does conveniently allow us to remove a few eslint-disables now that the type definitions agree with the implementations.