### PR TITLE
Update mediasoup to 3.19.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,6 @@ updates:
       - dependency-name: "glob"
         versions: [">=9"]
       - dependency-name: "puppeteer"
-      - dependency-name: "mediasoup"
-        versions: [">=3.13.0"]
       - dependency-name: "@testing-library/react"
         versions: [">=15"]
       - dependency-name: "chai"

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "ip-address": "^10.0.1",
         "logfmt": "^1.4.0",
         "marked": "^16.2.1",
-        "mediasoup": "^3.12.16",
+        "mediasoup": "^3.19.2",
         "mediasoup-client": "^3.15.6",
         "meteor-node-stubs": "^1.2.12",
         "mime-types": "^3.0.1",
@@ -9114,6 +9114,27 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -11643,6 +11664,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/ini": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@types/ini/-/ini-4.1.1.tgz",
+      "integrity": "sha512-MIyNUZipBTbyUNnhvuXJTY7B6qNI78meck9Jbv3wk0OgNwRyOOVEKDutAkOs1snB/tx0FafyR6/SN4Ps0hZPeg==",
+      "license": "MIT"
+    },
     "node_modules/@types/jquery": {
       "version": "3.5.29",
       "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.29.tgz",
@@ -13518,6 +13545,15 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chromium-bidi": {
@@ -15738,6 +15774,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.2.10",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.2.10.tgz",
+      "integrity": "sha512-7JlN9ZvLDG1McO3kbX0k4v+SUAg48L1rIwEvN6ZQl/eCtgJz9UylTMzE9wrmYrcorgxm3CX/3T/w5VAub99UUw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/flatted": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
@@ -16424,14 +16466,19 @@
       }
     },
     "node_modules/h264-profile-level-id": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-1.0.1.tgz",
-      "integrity": "sha512-D3Rln/jKNjKDW5ZTJTK3niSoOGE+pFqPvRHHVgQN3G7umcn/zWGPUo8Q8VpDj16x3hKz++zVviRNRmXu5cpN+Q==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.2.3.tgz",
+      "integrity": "sha512-LhhB3zIIu2TTZFyBC57s+pBddH6eTz8NMr6CwlWWRdy2kurhxxOU5TS0CguJ3i9MEc2B6a0aElAwBxMqS6FdLA==",
+      "license": "ISC",
       "dependencies": {
-        "debug": "^4.1.1"
+        "debug": "^4.4.1"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mediasoup"
       }
     },
     "node_modules/hard-rejection": {
@@ -17934,20 +17981,23 @@
       }
     },
     "node_modules/mediasoup": {
-      "version": "3.12.16",
-      "resolved": "https://registry.npmjs.org/mediasoup/-/mediasoup-3.12.16.tgz",
-      "integrity": "sha512-yLk/OBlHKrosfFBWKVGLpAQ55tssQ/9+EteOrt/C5xgS8OHOpGTIIrP0/OFjfCA/lhxAr1xV8qUTXM3D7NGxJA==",
+      "version": "3.19.2",
+      "resolved": "https://registry.npmjs.org/mediasoup/-/mediasoup-3.19.2.tgz",
+      "integrity": "sha512-M69EtTAkwY9AMoMHQiWVfFxEXgoT+5gN8LA90k9TUbIdDd5cefyeiY5ogxUe+suzjqOc/sh9vdTzECdDRE4u+Q==",
       "hasInstallScript": true,
+      "license": "ISC",
       "dependencies": {
-        "debug": "^4.3.4",
-        "h264-profile-level-id": "^1.0.1",
+        "@types/ini": "^4.1.1",
+        "debug": "^4.4.1",
+        "flatbuffers": "^25.2.10",
+        "h264-profile-level-id": "^2.2.3",
+        "ini": "^5.0.0",
         "node-fetch": "^3.3.2",
-        "supports-color": "^9.4.0",
-        "tar": "^6.2.0",
-        "uuid": "^9.0.1"
+        "supports-color": "^10.2.0",
+        "tar": "^7.4.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "funding": {
         "type": "opencollective",
@@ -17979,40 +18029,57 @@
         "url": "https://opencollective.com/mediasoup"
       }
     },
-    "node_modules/mediasoup-client/node_modules/h264-profile-level-id": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/h264-profile-level-id/-/h264-profile-level-id-2.2.3.tgz",
-      "integrity": "sha512-LhhB3zIIu2TTZFyBC57s+pBddH6eTz8NMr6CwlWWRdy2kurhxxOU5TS0CguJ3i9MEc2B6a0aElAwBxMqS6FdLA==",
-      "license": "ISC",
-      "dependencies": {
-        "debug": "^4.4.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mediasoup"
-      }
-    },
-    "node_modules/mediasoup-client/node_modules/supports-color": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/mediasoup/node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/mediasoup/node_modules/ini": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
+      "integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/mediasoup/node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mediasoup/node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mediasoup/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mediasoup/node_modules/node-fetch": {
@@ -18032,16 +18099,30 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
-    "node_modules/mediasoup/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
+    "node_modules/mediasoup/node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/mediasoup/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/memoize-one": {
@@ -22816,11 +22897,12 @@
       "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
     },
     "node_modules/supports-color": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-9.4.0.tgz",
-      "integrity": "sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ip-address": "^10.0.1",
     "logfmt": "^1.4.0",
     "marked": "^16.2.1",
-    "mediasoup": "^3.12.16",
+    "mediasoup": "^3.19.2",
     "mediasoup-client": "^3.15.6",
     "meteor-node-stubs": "^1.2.12",
     "mime-types": "^3.0.1",


### PR DESCRIPTION
Split into a package update commit and a "the things I did to make the lints pass and the code run".

Tested only the `isDevelopment` local addressing codepath at present.  I don't have a particularly convenient way to test the "using a public IP" codepath short of "deploy it fully and try it out" (which I'm happy to do on merge), and I definitely have not tried the backend-to-backend forwarding, but ~none of the meaningful code there changed on our end as far as I know.

My intuition on protocol support is that we want to support both UDP and TCP for client-to-server connections (as UDP is generally better for low latency, but TCP is sometimes needed for TURN or other fallback paths), and that we would likely prefer UDP for server-to-server connections (since we control the networking on the backend), but I can adjust those if you prefer something else for any reason.