### PR TITLE
Prep for React 19 upgrade

### DIFF
--- a/imports/client/components/CallSection.tsx
+++ b/imports/client/components/CallSection.tsx
@@ -128,7 +128,7 @@ const SelfBox = ({
   deafened: boolean;
   audioContext: AudioContext;
   stream: MediaStream;
-  popperBoundaryRef: React.RefObject<HTMLElement>;
+  popperBoundaryRef: React.RefObject<HTMLElement | null>;
 }) => {
   const spectraDisabled = useTracker(() => Flags.active("disable.spectra"));
   const { userId, name, discordAccount } = useTracker(() => {
@@ -285,7 +285,7 @@ const PeerBox = ({
   audioContext: AudioContext;
   selfDeafened: boolean;
   peer: PeerType;
-  popperBoundaryRef: React.RefObject<HTMLElement>;
+  popperBoundaryRef: React.RefObject<HTMLElement | null>;
   stream: MediaStream | undefined;
 }) => {
   const spectraDisabled = useTracker(() => Flags.active("disable.spectra"));

--- a/imports/client/components/ChatPeople.tsx
+++ b/imports/client/components/ChatPeople.tsx
@@ -48,7 +48,7 @@ interface ViewerSubscriber {
 
 interface PersonBoxProps extends ViewerSubscriber {
   children?: ReactNode;
-  popperBoundaryRef: React.RefObject<HTMLElement>;
+  popperBoundaryRef: React.RefObject<HTMLElement | null>;
 }
 
 const ViewerPersonBox = ({

--- a/imports/client/hooks/useCallState.ts
+++ b/imports/client/hooks/useCallState.ts
@@ -357,7 +357,7 @@ const useTransport = (
   transportParams: TransportType | undefined,
   dispatch: React.Dispatch<Action>,
 ) => {
-  const connectRef = useRef<() => void>();
+  const connectRef = useRef<(() => void) | undefined>(undefined);
 
   const hasParams = !!device && !!transportParams;
   useEffect(() => {

--- a/imports/client/hooks/useFocusRefOnFindHotkey.ts
+++ b/imports/client/hooks/useFocusRefOnFindHotkey.ts
@@ -1,7 +1,9 @@
 import type { RefObject } from "react";
 import { useCallback, useEffect } from "react";
 
-function useFocusRefOnFindHotkey<T extends HTMLElement>(nodeRef: RefObject<T>) {
+function useFocusRefOnFindHotkey<T extends HTMLElement | null>(
+  nodeRef: RefObject<T>,
+) {
   const maybeStealCtrlF = useCallback(
     (e: KeyboardEvent) => {
       const isMac = navigator.userAgent.includes("Mac");

--- a/imports/client/hooks/useImmediateEffect.ts
+++ b/imports/client/hooks/useImmediateEffect.ts
@@ -15,7 +15,7 @@ export default function useImmediateEffect<T>(
   deps?: Array<T>,
 ) {
   const cleanupRef = useRef<ReturnType<EffectCallback>>(undefined);
-  const depsRef = useRef<Array<T> | undefined>();
+  const depsRef = useRef<Array<T> | undefined>(undefined);
 
   if (!depsRef.current || depsDiffer(depsRef.current, deps)) {
     depsRef.current = deps;


### PR DESCRIPTION
React 19 changed how refs behave. These changes make our code compatible with both the behavior in v18 and v19.

(I think we should theoretically be able to auto-upgrade to React 19 once this + #2575 + https://github.com/ianstormtaylor/slate/pull/5986 land, although it's separately worth taking advantage of some of the new features in v19, like ref-as-prop, the new `useActionState` hook, and potentially the new `use` API for suspending while promises are resolving)