### PR TITLE
Fix build on fork PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Log in to the Container registry
+        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -91,7 +92,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           annotations: ${{ steps.meta.outputs.annotations }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push=true,push-by-digest=true,name-canonical=true,oci-mediatypes=true
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push=${{ github.ref == 'refs/heads/main' }},push-by-digest=true,name-canonical=true,oci-mediatypes=true
           cache-from: type=gha,scope=${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=${{ matrix.platform }} # mode=max means cache intermediate images
           build-args: |
@@ -126,6 +127,7 @@ jobs:
           path: ${{ runner.temp }}/digests
       - name: Extract metadata for Docker
         id: meta
+        if: github.ref == 'refs/heads/main'
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -134,12 +136,14 @@ jobs:
         env:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: index
       - name: Log in to the Container registry
+        if: github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create manifest and push
+        if: github.ref == 'refs/heads/main'
         shell: python
         run: |
           import glob
@@ -167,5 +171,6 @@ jobs:
 
           subprocess.check_call(args)
       - name: Inspect image
+        if: github.ref == 'refs/heads/main'
         run: |
           docker buildx imagetools inspect '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}'


### PR DESCRIPTION
Forks don't have access to repo secrets, so they can't push the resulting build product. And we don't really want to accumulate images for branch builds. So for everything but main, run the build but ignore the result.