### PR TITLE
Add a global unhandledRejection handler

### DIFF
--- a/server/main.ts
+++ b/server/main.ts
@@ -2,6 +2,11 @@
 import "../imports/server/bugsnag";
 import "../imports/server/configureLogger";
 
+process.on("unhandledRejection", (err) => {
+  // biome-ignore lint/suspicious/noConsole: Error logging
+  console.error("Unhandled promise rejection:", err);
+});
+
 // setup database management
 import "../imports/server/schemas";
 import "../imports/server/indexes";


### PR DESCRIPTION
As of recent Node versions, unhandled promise rejections cause the process to crash, which we mostly don't want. This commit adds a global handler to log unhandled rejections instead of crashing the server.