### PR TITLE
Workers should clean themselves up if another server thinks they died

### DIFF
--- a/imports/lib/models/Servers.ts
+++ b/imports/lib/models/Servers.ts
@@ -1,12 +1,15 @@
 import { z } from "zod";
-import { nonEmptyString, updatedTimestamp } from "./customTypes";
+import { foreignKey, nonEmptyString } from "./customTypes";
 import type { ModelType } from "./Model";
 import Model from "./Model";
 
 const Server = z.object({
   hostname: nonEmptyString,
   pid: z.number().int(),
-  updatedAt: updatedTimestamp,
+  // updatedAt is *not* set automatically, because we don't want to update it
+  // when other servers are performing garbage collection
+  updatedAt: z.date(),
+  cleanupInProgressBy: foreignKey.optional(),
 });
 
 const Servers = new Model("jr_servers", Server);

--- a/imports/server/garbage-collection.ts
+++ b/imports/server/garbage-collection.ts
@@ -7,38 +7,38 @@ import { Meteor } from "meteor/meteor";
 import { Random } from "meteor/random";
 import Logger from "../Logger";
 import Servers from "../lib/models/Servers";
+import ignoringDuplicateKeyErrors from "./ignoringDuplicateKeyErrors";
+import onExit from "./onExit";
 
 const serverId = Random.id();
 
 // Global registry of callbacks to run when we determine that a backend is dead.
-const globalGCHooks: ((deadServers: string[]) => void | Promise<void>)[] = [];
+const globalGCHooks: ((deadServers: string) => void | Promise<void>)[] = [];
 
 function registerPeriodicCleanupHook(
-  f: (deadServers: string[]) => void | Promise<void>,
+  f: (deadServer: string) => void | Promise<void>,
 ): void {
   globalGCHooks.push(f);
 }
 
-let firstUpsert = true;
 async function cleanup() {
-  const result = await Servers.upsertAsync(
-    { _id: serverId },
+  const updated = await Servers.updateAsync(
+    {
+      _id: serverId,
+      cleanupInProgressBy: { $exists: false },
+    },
     {
       $set: {
-        pid: process.pid,
-        hostname: os.hostname(),
+        updatedAt: new Date(),
       },
     },
   );
-  if (!firstUpsert && result.insertedId) {
-    Logger.warn("Server record unexpectedly deleted", {
-      serverId,
-      pid: process.pid,
-      hostname: os.hostname(),
-      error: new Error("Server record unexpectedly deleted"),
-    });
+  if (updated === 0) {
+    // Someone else is cleaning us up. The observer below should notice this and
+    // exit, but we should go ahead and short-circuit to avoid doing any more
+    // work
+    return;
   }
-  firstUpsert = false;
 
   // Servers disappearing should be a fairly rare occurrence, so it's
   // OK for the timeouts here to be generous. Servers get 120 seconds
@@ -48,6 +48,7 @@ async function cleanup() {
   const deadServers = await Servers.find({
     updatedAt: { $lt: timeout },
   }).mapAsync((server) => server._id);
+
   if (deadServers.length === 0) {
     return;
   }
@@ -55,22 +56,40 @@ async function cleanup() {
   Logger.info("Cleaning up dead servers", {
     deadServers: deadServers.join(","),
   });
-
-  // Run all hooks.
-  for (const f of globalGCHooks) {
-    await f(deadServers);
+  for (const deadServer of deadServers) {
+    await cleanupDeadServer(deadServer);
   }
-
-  // Delete the record of the server, now that we've cleaned up after it.
-  await Servers.removeAsync({ _id: { $in: deadServers } });
 }
 
 export async function cleanupDeadServer(id: string) {
+  // First mark that we're cleaning up the server so that if it wakes back up it
+  // knows to abort
+  const updated = await Servers.updateAsync(
+    { _id: id, cleanupInProgressBy: { $exists: false } },
+    {
+      $set: { cleanupInProgressBy: serverId },
+    },
+  );
+  if (updated === 0) {
+    // Someone else is already cleaning this up
+    return;
+  }
+
   for (const f of globalGCHooks) {
-    await f([id]);
+    await f(id);
   }
   await Servers.removeAsync(id);
 }
+
+registerPeriodicCleanupHook(async (deadServer) => {
+  // If a server died while cleaning up another server, we want to unmark it as
+  // being cleaned up so that someone else picks it up
+  await Servers.updateAsync(
+    { cleanupInProgressBy: deadServer },
+    { $unset: { cleanupInProgressBy: "" } },
+    { multi: true },
+  );
+});
 
 function periodic() {
   Meteor.setTimeout(periodic, 15000 + 15000 * Random.fraction());
@@ -79,12 +98,54 @@ function periodic() {
   });
 }
 
-// Defer the first run to give other startup hooks a chance to run
-Meteor.startup(() =>
-  Meteor.defer(() => {
-    Logger.info("New server starting", { serverId });
+Meteor.startup(() => {
+  // Defer the first run so that other startup hooks run first, but don't catch
+  // this async function's errors, because if it fails we want the failure to
+  // bubble up and abort the process
+  setImmediate(async () => {
+    Logger.info("New server starting", {
+      serverId,
+      pid: process.pid,
+      hostname: os.hostname(),
+    });
+
+    if (!Meteor.isAppTest) {
+      const aborted = () => {
+        Logger.error("Server record unexpectedly marked for deletion", {
+          serverId,
+          pid: process.pid,
+          hostname: os.hostname(),
+        });
+        process.exit(1);
+      };
+
+      const handle = await Servers.find(serverId).observeChangesAsync({
+        changed(_, fields) {
+          if (fields.cleanupInProgressBy) {
+            aborted();
+          }
+        },
+        removed() {
+          aborted();
+        },
+      });
+
+      onExit(() => handle.stop());
+    }
+
+    // Ignore duplicate key errors because they could be caused by retries (we
+    // don't expect any actual collisions on server ID)
+    await ignoringDuplicateKeyErrors(async () => {
+      await Servers.insertAsync({
+        _id: serverId,
+        pid: process.pid,
+        hostname: os.hostname(),
+        updatedAt: new Date(),
+      });
+    });
+
     periodic();
-  }),
-);
+  });
+});
 
 export { serverId, registerPeriodicCleanupHook };

--- a/imports/server/mediasoup.ts
+++ b/imports/server/mediasoup.ts
@@ -1678,28 +1678,28 @@ const getLocalIPAddresses = (): ListenIp[] => {
     });
 };
 
-registerPeriodicCleanupHook(async (deadServers) => {
+registerPeriodicCleanupHook(async (deadServer) => {
   await MonitorConnectAcks.removeAsync({
-    receivingServer: { $in: deadServers },
+    receivingServer: deadServer,
   });
   await MonitorConnectRequests.removeAsync({
-    initiatingServer: { $in: deadServers },
+    initiatingServer: deadServer,
   });
 
-  await ConsumerAcks.removeAsync({ createdServer: { $in: deadServers } });
-  await Consumers.removeAsync({ createdServer: { $in: deadServers } });
+  await ConsumerAcks.removeAsync({ createdServer: deadServer });
+  await Consumers.removeAsync({ createdServer: deadServer });
 
-  await ProducerServers.removeAsync({ createdServer: { $in: deadServers } });
-  await ProducerClients.removeAsync({ createdServer: { $in: deadServers } });
+  await ProducerServers.removeAsync({ createdServer: deadServer });
+  await ProducerClients.removeAsync({ createdServer: deadServer });
 
-  await ConnectAcks.removeAsync({ createdServer: { $in: deadServers } });
-  await ConnectRequests.removeAsync({ createdServer: { $in: deadServers } });
+  await ConnectAcks.removeAsync({ createdServer: deadServer });
+  await ConnectRequests.removeAsync({ createdServer: deadServer });
 
-  await TransportStates.removeAsync({ createdServer: { $in: deadServers } });
-  await Transports.removeAsync({ createdServer: { $in: deadServers } });
-  await TransportRequests.removeAsync({ createdServer: { $in: deadServers } });
+  await TransportStates.removeAsync({ createdServer: deadServer });
+  await Transports.removeAsync({ createdServer: deadServer });
+  await TransportRequests.removeAsync({ createdServer: deadServer });
 
-  await Routers.removeAsync({ createdServer: { $in: deadServers } });
+  await Routers.removeAsync({ createdServer: deadServer });
 });
 
 // A note: the current behavior of Meteor.startup is that it blocks the

--- a/imports/server/subscribers.ts
+++ b/imports/server/subscribers.ts
@@ -12,8 +12,8 @@ import { registerPeriodicCleanupHook, serverId } from "./garbage-collection";
 import Subscribers from "./models/Subscribers";
 
 // Clean up leaked subscribers from dead servers periodically.
-async function cleanupHook(deadServers: string[]) {
-  await Subscribers.removeAsync({ server: { $in: deadServers } });
+async function cleanupHook(deadServer: string) {
+  await Subscribers.removeAsync({ server: deadServer });
 }
 registerPeriodicCleanupHook(cleanupHook);
 


### PR DESCRIPTION
We've seen weird cases where a process's database records get garbage collected while they are still running (likely due to scheduling weirdness or temporary hangs). This causes problems as there can still be in-memory resources (e.g. Mediasoup transports) that don't get cleaned up and recreated when this happens. So if a server sees that it has been garbage collected by another process, it should exit to try and restore normalcy.

As a guard against aggressive cascading, only do this if the process is part of a worker pool, and therefore will be replaced by the pool manager.

I'm hopeful this will improve #2169, if not resolve it.