### PR TITLE
Fix creation of indexes with options

### DIFF
--- a/imports/server/indexes.ts
+++ b/imports/server/indexes.ts
@@ -155,10 +155,13 @@ runIfLatestBuild(async () => {
       });
       // Prefer createIndexes to createIndex so we can specify an explicit name
       // to match the one in our spec
-      await collection.createIndexes(
-        [{ key: Object.fromEntries(index), name }],
-        Object.fromEntries(options),
-      );
+      await collection.createIndexes([
+        {
+          key: Object.fromEntries(index),
+          name,
+          ...Object.fromEntries(options),
+        },
+      ]);
     }
     // Finally, drop non-conflicting indexes.
     for (const extraIndex of extraNonConflicting) {


### PR DESCRIPTION
When we switched to using `createIndexes` instead of `createIndex`, we introduced a bug where index options were not being applied correctly.