### PR TITLE
Switch to tsgo for type checking

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
   "typescript.preferences.preferTypeOnlyAutoImports": true,
   // Use the version of Typescript embedded with the project
   "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.experimental.useTsgo": true,
   // Make sure to run stylelint on Typescript and SCSS (embedded in Typescript)
   // files
   "stylelint.validate": ["css", "less", "postcss", "typescriptreact", "scss"],

--- a/imports/server/discordClientRefresher.ts
+++ b/imports/server/discordClientRefresher.ts
@@ -1,5 +1,6 @@
 import { Meteor } from "meteor/meteor";
-import Discord, { Events, GatewayIntentBits } from "discord.js";
+import * as Discord from "discord.js";
+import { Events, GatewayIntentBits } from "discord.js";
 import Flags from "../Flags";
 import DiscordCache from "../lib/models/DiscordCache";
 import MeteorUsers from "../lib/models/MeteorUsers";

--- a/imports/server/mediasoup.ts
+++ b/imports/server/mediasoup.ts
@@ -6,7 +6,6 @@ import { Meteor } from "meteor/meteor";
 import { Random } from "meteor/random";
 import { Address6 } from "ip-address";
 import { createWorker, type types } from "mediasoup";
-import { AudioLevelObserverImpl } from "mediasoup/node/lib/AudioLevelObserver";
 import Flags from "../Flags";
 import Logger from "../Logger";
 import { ACTIVITY_GRANULARITY } from "../lib/config/activityTracking";
@@ -179,6 +178,10 @@ type ListenIp = {
   // external announced address (v4 or v6 or hostname)
   announcedIp?: string;
 };
+
+const isAudioLevelObserver = (
+  t: types.RtpObserver,
+): t is types.AudioLevelObserver => t.type === "audiolevel";
 
 class SFU {
   public ips: [ListenIp, ...ListenIp[]];
@@ -609,7 +612,7 @@ class SFU {
   }
 
   onRtpObserverCreated(observer: types.RtpObserver) {
-    if (!(observer instanceof AudioLevelObserverImpl)) {
+    if (!isAudioLevelObserver(observer)) {
       return;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "@types/react-sparklines": "^1.7.5",
         "@types/ws": "^8.18.1",
         "@typescript-eslint/utils": "^8.48.1",
+        "@typescript/native-preview": "^7.0.0-dev.20251214.1",
         "chai": "^6.2.1",
         "chai-as-promised": "^8.0.2",
         "eslint": "^9.39.1",
@@ -101,7 +102,6 @@
         "stylelint-config-standard": "^39.0.1",
         "stylelint-scss": "^6.13.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.9.3",
         "typescript-eslint": "^8.49.0"
       }
     },
@@ -2330,7 +2330,6 @@
       "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -2392,7 +2391,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2436,7 +2434,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2949,7 +2946,6 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.1.0.tgz",
       "integrity": "sha512-fNxRUk1KhjSbnbuBxlWSnBLKLBNun52ZBTcs22H/xEEzM6Ap81ZFTQ4bZBxVQGQgVY0xugKGoRcCbaKjLQ3XZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "7.1.0"
       },
@@ -3676,7 +3672,6 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4829,7 +4824,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5094,7 +5088,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.2.tgz",
       "integrity": "sha512-WOhQTZ4G8xZ1tjJTvKOpyEVSGgOTvJAfDK3FNFgELyaTpzhdgHVHeqW8V+UJvzF5BT+/B54T/1S2K6gd9c7bbA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5154,7 +5147,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -5316,7 +5308,6 @@
       "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.49.0",
         "@typescript-eslint/types": "8.49.0",
@@ -5492,7 +5483,6 @@
       "integrity": "sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
         "@typescript-eslint/scope-manager": "8.49.0",
@@ -5542,6 +5532,123 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@typescript/native-preview": {
+      "version": "7.0.0-dev.20251214.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview/-/native-preview-7.0.0-dev.20251214.1.tgz",
+      "integrity": "sha512-UM/NR04ko1Tjrjx7glA1yYrOWvCErk2B/eHI4BeV0P6i4JrcxESCXB3EdI2h9QyE2H4FvG1VJzb2pB4u7wpdiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsgo": "bin/tsgo.js"
+      },
+      "optionalDependencies": {
+        "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20251214.1",
+        "@typescript/native-preview-darwin-x64": "7.0.0-dev.20251214.1",
+        "@typescript/native-preview-linux-arm": "7.0.0-dev.20251214.1",
+        "@typescript/native-preview-linux-arm64": "7.0.0-dev.20251214.1",
+        "@typescript/native-preview-linux-x64": "7.0.0-dev.20251214.1",
+        "@typescript/native-preview-win32-arm64": "7.0.0-dev.20251214.1",
+        "@typescript/native-preview-win32-x64": "7.0.0-dev.20251214.1"
+      }
+    },
+    "node_modules/@typescript/native-preview-darwin-arm64": {
+      "version": "7.0.0-dev.20251214.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-arm64/-/native-preview-darwin-arm64-7.0.0-dev.20251214.1.tgz",
+      "integrity": "sha512-bDVzeTBS3L3kze4AKt0NgrSKxHMoRJvsyOoPwonnJVmBawmNT9i5KJLmILjmG/pQKsoIprO3wIQ/eHFCc+UCRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@typescript/native-preview-darwin-x64": {
+      "version": "7.0.0-dev.20251214.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-darwin-x64/-/native-preview-darwin-x64-7.0.0-dev.20251214.1.tgz",
+      "integrity": "sha512-833kmlu42eJTbqAr5YmyWXLu6Pmp1FlX0VtUJJyIECiZOsaukYDqv56kMCh5kKFRkdnCG5nk8Ry4JhMHO0pPWQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-arm": {
+      "version": "7.0.0-dev.20251214.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm/-/native-preview-linux-arm-7.0.0-dev.20251214.1.tgz",
+      "integrity": "sha512-sY9Gbwsvf3DqOeG3xiPNjV5M1txC+zDwcBAS8pThje0AlCqjjvs12X3o0SitnJj4IzzRAv43mGR4lZV3p2nRgw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-arm64": {
+      "version": "7.0.0-dev.20251214.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-arm64/-/native-preview-linux-arm64-7.0.0-dev.20251214.1.tgz",
+      "integrity": "sha512-ymqki3Yw8p+mgdKb7TdLF6O6cvvlodNDahl89PEOJ3KTtKZZ3yghAUTqfXH+yLN04CXezixACBYVrYQfH0NpQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-linux-x64": {
+      "version": "7.0.0-dev.20251214.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-linux-x64/-/native-preview-linux-x64-7.0.0-dev.20251214.1.tgz",
+      "integrity": "sha512-ebKRfaF7pySe8hyijeFmXEJ/RZ4HVXTxCX/STXdCtEBHAgGRUfImldpNXmxzBwUxEfb4yOFzK1Gy8WKm2A2lTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@typescript/native-preview-win32-arm64": {
+      "version": "7.0.0-dev.20251214.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-arm64/-/native-preview-win32-arm64-7.0.0-dev.20251214.1.tgz",
+      "integrity": "sha512-kSTKEL5GC4+iJzwPAJTv0gbRWMuLv1iep0I8Zuep/um2BUqpE4kgoB9bVWAQdc0XvUc9FYL7FfGfwKM5tyKdpA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@typescript/native-preview-win32-x64": {
+      "version": "7.0.0-dev.20251214.1",
+      "resolved": "https://registry.npmjs.org/@typescript/native-preview-win32-x64/-/native-preview-win32-x64-7.0.0-dev.20251214.1.tgz",
+      "integrity": "sha512-+9+FqWybjVYSY9fZnWRWU+OMqRPBQWRY7n+RaY40Iuc5XPVUhZsKeV/0xwJetz3gu3XYdPAazSziuH2m+/BDHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@vladfrangu/async_event_emitter": {
       "version": "2.4.7",
       "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
@@ -5571,7 +5678,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6121,7 +6227,6 @@
       "integrity": "sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6991,7 +7096,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11947,7 +12051,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12003,7 +12106,6 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -12211,7 +12313,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -12264,7 +12365,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -12324,7 +12424,6 @@
       "version": "6.28.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.28.0.tgz",
       "integrity": "sha512-kQ7Unsl5YdyOltsPGl31zOjLrDv+m2VcIEcIHqYYD3Lp0UppLjrzcfJqDJwXxFw3TH/yvapbnUvPlAj7Kx5nbg==",
-      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.21.0",
         "react-router": "6.28.0"
@@ -13027,8 +13126,7 @@
       "version": "0.120.0",
       "resolved": "https://registry.npmjs.org/slate/-/slate-0.120.0.tgz",
       "integrity": "sha512-CXK/DADGgMZb4z9RTtXylzIDOxvmNJEF9bXV2bAGkLWhQ3rm7GORY9q0H/W41YJvAGZsLbH7nnrhMYr550hWDQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/slate-dom": {
       "version": "0.119.0",
@@ -13550,7 +13648,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -13915,7 +14012,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14136,7 +14232,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/deathandmayhem/jolly-roger"
   },
   "scripts": {
-    "lint:types": "tsc",
+    "lint:types": "tsgo",
     "lint:biome": "biome check",
     "lint:eslint": "eslint --max-warnings 0 --ext js,jsx,ts,tsx,mjs,mts .",
     "lint:css": "stylelint '**/*.scss' '**/*.tsx'",
@@ -96,6 +96,7 @@
     "@types/react-sparklines": "^1.7.5",
     "@types/ws": "^8.18.1",
     "@typescript-eslint/utils": "^8.48.1",
+    "@typescript/native-preview": "^7.0.0-dev.20251214.1",
     "chai": "^6.2.1",
     "chai-as-promised": "^8.0.2",
     "eslint": "^9.39.1",
@@ -112,7 +113,6 @@
     "stylelint-config-standard": "^39.0.1",
     "stylelint-scss": "^6.13.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3",
     "typescript-eslint": "^8.49.0"
   },
   "meteor": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,26 +22,13 @@
     "noUncheckedIndexedAccess": true,
 
     /* Module Resolution Options */
-    "baseUrl": ".",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "types": ["node", "mocha"],
     "esModuleInterop": true,
     "preserveSymlinks": true,
     "paths": {
-      "meteor/*": [
-        //"node_modules/@types/meteor/*",
-        ".meteor/local/types/packages.d.ts"
-        /*
-        Ideally, we'd use first-party types exported from Meteor upstream.
-        Unfortunately, Meteor upstream has yet to ship a sufficiently-correct
-        set of type definitions that we can use them.  Since zodern:types puts
-        all the decls in a single entrypoint, we cannot take only the correct
-        ones without pulling in the incorrect ones, or without getting
-        duplicate declarations.  So we leave this disabled for now.
-        ".meteor/local/types/packages.d.ts"
-        */
-      ]
+      "meteor/*": ["./.meteor/local/types/packages.d.ts"]
     }
   },
   "exclude": [


### PR DESCRIPTION
From the commit message:

> The go reimplementation of TypeScript is still a preview, but it claims to be feature-complete with TypeScript 5.9 in all of the ways we care about. (Most of the remaining deficiencies are around emitting declarations and compiled code, and most of the behavioral changes are around JSDoc comments; we use none of these features.)
> 
> And on the plus side, it's significantly faster, running on my laptop in about 3s vs. 12s for tsc.
> 
> There were a few small changes required for compatibility:
> 
> * The "baseUrl" option in tsconfig.json is not supported. But the default value is fine. (I also cleaned up a no-longer-accurate comment)
> * tsgo is pickier about default imports vs. namespace imports.
> * tsgo is pickier about importing from files that aren't explicitly referenced in a package's "exports" declaration, so I reworded how we interact with audio level observers in mediasoup.
> 
> None of these changes regress running under tsc, so we can always switch back.

Is this a good idea? I'm not sure. But it does seem to work, and shaves about 42% off of the runtime of `npm run lint` (18s => 10.5s)