### PR TITLE
Support @-mentioning operators in chat messages

### DIFF
--- a/imports/client/components/ChatMessage.tsx
+++ b/imports/client/components/ChatMessage.tsx
@@ -8,6 +8,7 @@ import styled from "styled-components";
 import type { ChatMessageContentType } from "../../lib/models/ChatMessages";
 import nodeIsImage from "../../lib/nodeIsImage";
 import nodeIsMention from "../../lib/nodeIsMention";
+import nodeIsRoleMention from "../../lib/nodeIsRoleMention";
 import { MentionSpan } from "./FancyEditor";
 
 // This file implements standalone rendering for the MessageElement format
@@ -201,11 +202,13 @@ const ChatMessage = ({
   message,
   displayNames,
   selfUserId,
+  roles,
   imageOnLoad,
 }: {
   message: ChatMessageContentType;
   displayNames: Map<string, string>;
   selfUserId: string;
+  roles: string[];
   imageOnLoad?: () => void;
 }) => {
   const children = message.children.map((child, i) => {
@@ -214,6 +217,13 @@ const ChatMessage = ({
       return (
         <MentionSpan key={i} $isSelf={child.userId === selfUserId}>
           @{`${displayName ?? child.userId}`}
+        </MentionSpan>
+      );
+    } else if (nodeIsRoleMention(child)) {
+      const hasRole = roles.includes(child.roleId);
+      return (
+        <MentionSpan key={i} $isSelf={hasRole}>
+          @{child.roleId}
         </MentionSpan>
       );
     } else if (nodeIsImage(child)) {

--- a/imports/client/components/FirehosePage.tsx
+++ b/imports/client/components/FirehosePage.tsx
@@ -25,6 +25,7 @@ import type { PuzzleType } from "../../lib/models/Puzzles";
 import Puzzles from "../../lib/models/Puzzles";
 import nodeIsImage from "../../lib/nodeIsImage";
 import nodeIsMention from "../../lib/nodeIsMention";
+import nodeIsRoleMention from "../../lib/nodeIsRoleMention";
 import chatMessagesForFirehose from "../../lib/publications/chatMessagesForFirehose";
 import { useBreadcrumb } from "../hooks/breadcrumb";
 import useFocusRefOnFindHotkey from "../hooks/useFocusRefOnFindHotkey";
@@ -66,6 +67,8 @@ function asFlatString(
     .map((child) => {
       if (nodeIsMention(child)) {
         return ` @${displayNames.get(child.userId) ?? "???"} `;
+      } else if (nodeIsRoleMention(child)) {
+        return ` @${child.roleId} `;
       } else if (nodeIsImage(child)) {
         return `[image]`;
       } else {

--- a/imports/lib/models/ChatMessages.ts
+++ b/imports/lib/models/ChatMessages.ts
@@ -4,11 +4,17 @@ import type { ModelType } from "./Model";
 import SoftDeletedModel from "./SoftDeletedModel";
 import withCommon from "./withCommon";
 
-const MentionBlock = z.object({
+const UserMentionBlock = z.object({
   type: z.literal("mention"),
   userId: foreignKey,
 });
-export type ChatMessageMentionNodeType = z.infer<typeof MentionBlock>;
+export type ChatMessageMentionNodeType = z.infer<typeof UserMentionBlock>;
+
+const RoleMentionBlock = z.object({
+  type: z.literal("role-mention"),
+  roleId: z.literal("operator"), // expand this into a union if we add more roles
+});
+export type ChatMessageRoleMentionNodeType = z.infer<typeof RoleMentionBlock>;
 
 const ImageBlock = z.object({
   type: z.literal("image"),
@@ -21,7 +27,12 @@ const TextBlock = z.object({
 });
 export type ChatMessageTextNodeType = z.infer<typeof TextBlock>;
 
-const ContentNode = z.union([MentionBlock, ImageBlock, TextBlock]);
+const ContentNode = z.union([
+  UserMentionBlock,
+  RoleMentionBlock,
+  ImageBlock,
+  TextBlock,
+]);
 export type ChatMessageContentNodeType = z.infer<typeof ContentNode>;
 
 export const ChatMessageContent = z.object({

--- a/imports/lib/nodeIsRoleMention.ts
+++ b/imports/lib/nodeIsRoleMention.ts
@@ -1,0 +1,10 @@
+import type {
+  ChatMessageContentNodeType,
+  ChatMessageRoleMentionNodeType,
+} from "./models/ChatMessages";
+
+export default function nodeIsRoleMention(
+  node: ChatMessageContentNodeType,
+): node is ChatMessageRoleMentionNodeType {
+  return "type" in node && node.type === "role-mention";
+}

--- a/imports/lib/permission_stubs.ts
+++ b/imports/lib/permission_stubs.ts
@@ -1,7 +1,10 @@
 import { Meteor } from "meteor/meteor";
+import type z from "zod";
 import isAdmin, { GLOBAL_SCOPE } from "./isAdmin";
 import type { HuntType } from "./models/Hunts";
 import MeteorUsers from "./models/MeteorUsers";
+import type { Selector } from "./models/Model";
+import type { User } from "./models/User";
 
 function isOperatorForHunt(
   user: Pick<Meteor.User, "roles">,
@@ -48,6 +51,14 @@ export function huntsUserIsOperatorFor(
       acc.add(huntId);
       return acc;
     }, new Set<string>());
+}
+
+export function queryOperatorsForHunt(
+  hunt: Pick<HuntType, "_id">,
+): Selector<z.output<typeof User>> {
+  return {
+    [`roles.${hunt._id}`]: "operator",
+  };
 }
 
 // admins and operators are always allowed to join someone to a hunt

--- a/imports/server/hooks/ChatNotificationHooks.ts
+++ b/imports/server/hooks/ChatNotificationHooks.ts
@@ -7,6 +7,9 @@ import ChatMessages from "../../lib/models/ChatMessages";
 import ChatNotifications from "../../lib/models/ChatNotifications";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import nodeIsMention from "../../lib/nodeIsMention";
+import nodeIsRoleMention from "../../lib/nodeIsRoleMention";
+import { queryOperatorsForHunt } from "../../lib/permission_stubs";
+import Subscribers from "../models/Subscribers";
 import type Hookset from "./Hookset";
 
 const ChatNotificationHooks: Hookset = {
@@ -41,6 +44,38 @@ const ChatNotificationHooks: Hookset = {
             if (mentionedUser?.hunts?.includes(chatMessage.hunt)) {
               usersToNotify.add(mentionedUserId);
             }
+          }
+        }
+        if (nodeIsRoleMention(child)) {
+          const roleId = child.roleId;
+          if (roleId === "operator") {
+            // First check for all active operators
+            const subscribed = await Subscribers.find({
+              name: "operators",
+              [`context.${chatMessage.hunt}`]: true,
+            }).mapAsync((l) => l.user as string);
+
+            const allOperators = await MeteorUsers.find(
+              queryOperatorsForHunt({ _id: chatMessage.hunt }),
+            ).mapAsync((u) => u._id);
+
+            const active = new Set(allOperators).intersection(
+              new Set(subscribed),
+            );
+            active.delete(sender); // don't notify self
+            if (active.size > 0) {
+              active.forEach((userId) => usersToNotify.add(userId));
+            } else {
+              // No active operators; fall back to all operators
+              allOperators.forEach((userId) => {
+                if (userId !== sender) {
+                  usersToNotify.add(userId);
+                }
+              });
+            }
+          } else {
+            // biome-ignore lint/nursery/noUnusedExpressions: exhaustive check
+            roleId satisfies never;
           }
         }
       }),

--- a/imports/server/hooks/DiscordHooks.ts
+++ b/imports/server/hooks/DiscordHooks.ts
@@ -10,6 +10,7 @@ import Puzzles from "../../lib/models/Puzzles";
 import Settings from "../../lib/models/Settings";
 import Tags from "../../lib/models/Tags";
 import nodeIsImage from "../../lib/nodeIsImage";
+import nodeIsRoleMention from "../../lib/nodeIsRoleMention";
 import nodeIsText from "../../lib/nodeIsText";
 import { computeSolvedness } from "../../lib/solvedness";
 import { DiscordBot } from "../discord";
@@ -51,6 +52,9 @@ async function renderChatMessageContent(
       }
       if (nodeIsText(child)) {
         return child.text;
+      }
+      if (nodeIsRoleMention(child)) {
+        return ` @${child.roleId} `;
       }
       const user = await MeteorUsers.findOneAsync(child.userId);
       return ` @${user?.displayName ?? child.userId} `;

--- a/imports/server/methods/sendChatMessage.ts
+++ b/imports/server/methods/sendChatMessage.ts
@@ -25,6 +25,10 @@ defineMethod(sendChatMessage, {
             userId: String,
           },
           {
+            type: "role-mention" as const,
+            roleId: "operator" as const,
+          },
+          {
             type: "image" as const,
             url: String,
           },

--- a/imports/server/models/Subscribers.ts
+++ b/imports/server/models/Subscribers.ts
@@ -13,7 +13,7 @@ export const Subscriber = withTimestamps(
     connection: z.string().regex(Id),
     user: foreignKey,
     name: nonEmptyString,
-    context: z.record(z.string(), nonEmptyString),
+    context: z.record(z.string(), z.union([nonEmptyString, z.boolean()])),
   }),
 );
 

--- a/imports/server/subscribers.ts
+++ b/imports/server/subscribers.ts
@@ -18,12 +18,14 @@ async function cleanupHook(deadServers: string[]) {
 registerPeriodicCleanupHook(cleanupHook);
 
 const contextMatcher = Match.Where(
-  (val: unknown): val is Record<string, string> => {
+  (val: unknown): val is Record<string, string | boolean> => {
     if (!Match.test(val, Object)) {
       return false;
     }
 
-    return Object.values(val).every((v) => Match.test(v, String));
+    return Object.values(val).every(
+      (v) => Match.test(v, String) || Match.test(v, Boolean),
+    );
   },
 );
 


### PR DESCRIPTION
Although I still quite like the idea, I wanted to try a slightly different approach to @welkin25's #2608 PR. This has two major changes by comparison:

- Instead of treating "special users" as a new type of standard mention (with a hard-coded but non-conflicting fake user ID), create a new type of "role" mention. This feels (IMO) analogous to, e.g., Discord, which distinguishes between mentioning users with `<@snowflake>` and roles with `<&@snowflake>`, even though the UI shows both of them together.
- Avoid sending notifications to all operators, instead only sending the notification to operators that we believe are currently actively operating (based on whether they are online and have the operator interface enabled). Of course, since there's some possibility that *no* operators are online/operating, include a fallback to send the notification to all operators.

From the commit message (although it basically says the same thing in different words):

> This introduces the concept of a "role mention" as a separate construct from a user "mention", although for the moment the only role that can be mentioned is "operator".
> 
> To limit the blast radius of such mentions, @operator mentions only notify operators that are currently online and with operating mode enabled. This is detected by introducing a new usage of the subscribers counters - operators with operating mode enabled for any hunt will increment a "operators" subscriber counter with the hunts for which they're actively operating in the context, allowing us to track them down from the server.
> 
> If no operators are online with operating mode enabled, the mention goes out to all operators for the hunt, active or not.