### PR TITLE
Catch all voided promises on server

### DIFF
--- a/imports/server/api/authenticator.ts
+++ b/imports/server/api/authenticator.ts
@@ -1,5 +1,6 @@
 import { DDP } from "meteor/ddp";
 import type express from "express";
+import Logger from "../../Logger";
 import APIKeys from "../../lib/models/APIKeys";
 import expressAsyncWrapper from "../expressAsyncWrapper";
 
@@ -37,7 +38,15 @@ const authenticator: express.Handler = expressAsyncWrapper(
       // If this API key was last used more than 60 seconds ago, update the
       // "last used" time on it. Do not block waiting for the write to complete.
       // Do not throw an error if updating the APIKey fails.
-      void APIKeys.updateAsync({ _id: key._id }, { $set: { lastUsedAt: now } });
+      APIKeys.updateAsync(
+        { _id: key._id },
+        { $set: { lastUsedAt: now } },
+      ).catch((error) => {
+        Logger.error("Ignored failure updating API key", {
+          error,
+          _id: key._id,
+        });
+      });
     }
 
     DDP._CurrentInvocation.withValue(

--- a/imports/server/assets.ts
+++ b/imports/server/assets.ts
@@ -162,6 +162,7 @@ router.post(
     req.on(
       "end",
       Meteor.bindEnvironment(() => {
+        // Entire function body is wrapped in a try/catch, so voiding future is safe.
         void (async () => {
           try {
             // Concatenate chunks into a single buffer representing the entire file contents

--- a/imports/server/garbage-collection.ts
+++ b/imports/server/garbage-collection.ts
@@ -74,7 +74,9 @@ export async function cleanupDeadServer(id: string) {
 
 function periodic() {
   Meteor.setTimeout(periodic, 15000 + 15000 * Random.fraction());
-  void cleanup();
+  cleanup().catch((error) => {
+    Logger.error("Error performing garbage-collection cleanup()", { error });
+  });
 }
 
 // Defer the first run to give other startup hooks a chance to run

--- a/imports/server/gdriveActivityFetcher.ts
+++ b/imports/server/gdriveActivityFetcher.ts
@@ -241,5 +241,8 @@ Meteor.startup(() => {
     // but this will do for now
     return;
   }
+
+  // The entire body of fetchActivityLoop is a while loop wrapping a try-catch,
+  // so voiding this promise is safe.
   void fetchActivityLoop();
 });

--- a/imports/server/googleClientRefresher.ts
+++ b/imports/server/googleClientRefresher.ts
@@ -1,3 +1,4 @@
+import { Meteor } from "meteor/meteor";
 import type { Mongo } from "meteor/mongo";
 import { OAuth } from "meteor/oauth";
 import type { Configuration } from "meteor/service-configuration";
@@ -46,17 +47,20 @@ class GoogleClientRefresher {
       httpMethodsToRetry: ["GET", "PUT", "HEAD", "OPTIONS", "DELETE", "POST"],
     };
 
-    // Watch for config changes, and refresh the gdrive instance if anything changes
     this.oauthConfigCursor = ServiceConfiguration.configurations.find({
       service: "google",
     });
     this.oauthCredentialCursor = Settings.find({ name: "gdrive.credential" });
-    void this.oauthConfigCursor.observeAsync({
+  }
+
+  async startObservers() {
+    // Watch for config changes, and refresh the gdrive instance if anything changes
+    await this.oauthConfigCursor.observeAsync({
       added: (doc) => this.updateOauthConfig(doc),
       changed: (doc) => this.updateOauthConfig(doc),
       removed: () => this.updateOauthConfig(undefined),
     });
-    void this.oauthCredentialCursor.observeAsync({
+    await this.oauthCredentialCursor.observeAsync({
       added: (doc) => this.updateOauthCredentials(doc),
       changed: (doc) => this.updateOauthCredentials(doc),
       removed: () => this.clearOauthCredentials(),
@@ -129,5 +133,8 @@ class GoogleClientRefresher {
 }
 
 const googleClientRefresher = new GoogleClientRefresher();
+Meteor.startup(async () => {
+  await googleClientRefresher.startObservers();
+});
 
 export default googleClientRefresher;

--- a/imports/server/mediasoup.ts
+++ b/imports/server/mediasoup.ts
@@ -277,10 +277,14 @@ class SFU {
       routedServer: serverId,
     }).observeChangesAsync({
       added: (id, fields) => {
-        void this.roomCreated({ _id: id, ...fields } as RoomType);
+        this.roomCreated({ _id: id, ...fields } as RoomType).catch((error) => {
+          Logger.error("mediasoup roomCreated failed", { error, id });
+        });
       },
       removed: (id) => {
-        void this.roomRemoved(id);
+        this.roomRemoved(id).catch((error) => {
+          Logger.error("mediasoup roomRemoved failed", { error, id });
+        });
       },
     });
 
@@ -288,13 +292,23 @@ class SFU {
       routedServer: serverId,
     }).observeChangesAsync({
       added: (id, fields) => {
-        void this.transportRequestCreated({
+        this.transportRequestCreated({
           _id: id,
           ...fields,
-        } as TransportRequestType);
+        } as TransportRequestType).catch((error) => {
+          Logger.error("mediasoup transportRequestCreated failed", {
+            error,
+            id,
+          });
+        });
       },
       removed: (id) => {
-        void this.transportRequestRemoved(id);
+        this.transportRequestRemoved(id).catch((error) => {
+          Logger.error("mediasoup transportRequestRemoved failed", {
+            error,
+            id,
+          });
+        });
       },
     });
 
@@ -302,10 +316,12 @@ class SFU {
       routedServer: serverId,
     }).observeChangesAsync({
       added: (id, fields) => {
-        void this.connectRequestCreated({
+        this.connectRequestCreated({
           _id: id,
           ...fields,
-        } as ConnectRequestType);
+        } as ConnectRequestType).catch((error) => {
+          Logger.error("mediasoup connectRequestCreated failed", { error, id });
+        });
       },
       // nothing to do when this is removed
     });
@@ -314,16 +330,22 @@ class SFU {
       routedServer: serverId,
     }).observeChangesAsync({
       added: (id, fields) => {
-        void this.producerClientCreated({
+        this.producerClientCreated({
           _id: id,
           ...fields,
-        } as ProducerClientType);
+        } as ProducerClientType).catch((error) => {
+          Logger.error("mediasoup producerClientCreated failed", { error, id });
+        });
       },
       changed: (id, fields) => {
-        void this.producerClientChanged(id, fields);
+        this.producerClientChanged(id, fields).catch((error) => {
+          Logger.error("mediasoup producerClientChanged failed", { error, id });
+        });
       },
       removed: (id) => {
-        void this.producerClientRemoved(id);
+        this.producerClientRemoved(id).catch((error) => {
+          Logger.error("mediasoup producerClientRemoved failed", { error, id });
+        });
       },
     });
 
@@ -331,7 +353,12 @@ class SFU {
       routedServer: serverId,
     }).observeChangesAsync({
       added: (id, fields) => {
-        void this.consumerAckCreated({ _id: id, ...fields } as ConsumerAckType);
+        this.consumerAckCreated({
+          _id: id,
+          ...fields,
+        } as ConsumerAckType).catch((error) => {
+          Logger.error("mediasoup consumerAckCreated failed", { error, id });
+        });
       },
       // nothing to do when removed
     });
@@ -340,11 +367,17 @@ class SFU {
       _id: { $ne: serverId },
     }).observeChangesAsync({
       added: (id, fields) => {
-        void this.serverCreated({ _id: id, ...fields } as ServerType);
+        this.serverCreated({ _id: id, ...fields } as ServerType).catch(
+          (error) => {
+            Logger.error("mediasoup serverCreated failed", { error, id });
+          },
+        );
       },
       // don't care about changes
       removed: (id) => {
-        void this.serverRemoved(id);
+        this.serverRemoved(id).catch((error) => {
+          Logger.error("mediasoup serverRemoved failed", { error, id });
+        });
       },
     });
 
@@ -352,13 +385,23 @@ class SFU {
       receivingServer: serverId,
     }).observeChangesAsync({
       added: (id, fields) => {
-        void this.monitorConnectRequestCreated({
+        this.monitorConnectRequestCreated({
           _id: id,
           ...fields,
-        } as MonitorConnectRequestType);
+        } as MonitorConnectRequestType).catch((error) => {
+          Logger.error("mediasoup monitorConnectRequestCreated failed", {
+            error,
+            id,
+          });
+        });
       },
       removed: (id) => {
-        void this.monitorConnectRequestRemoved(id);
+        this.monitorConnectRequestRemoved(id).catch((error) => {
+          Logger.error("mediasoup monitorConnectRequestRemoved failed", {
+            error,
+            id,
+          });
+        });
       },
     });
 
@@ -366,10 +409,15 @@ class SFU {
       initiatingServer: serverId,
     }).observeChangesAsync({
       added: (id, fields) => {
-        void this.monitorConnectAckCreated({
+        this.monitorConnectAckCreated({
           _id: id,
           ...fields,
-        } as MonitorConnectAckType);
+        } as MonitorConnectAckType).catch((error) => {
+          Logger.error("mediasoup monitorConnectAckCreated failed", {
+            error,
+            id,
+          });
+        });
       },
     });
   }
@@ -583,7 +631,12 @@ class SFU {
           router: router.id,
         });
         this.routers.delete(routerAppData.call);
-        void Routers.removeAsync({ routerId: router.id });
+        Routers.removeAsync({ routerId: router.id }).catch((error) => {
+          Logger.error("mediasoup failed to remove shutdown router", {
+            error,
+            routerId: router.id,
+          });
+        });
       }),
     );
     router.observer.on(
@@ -596,18 +649,28 @@ class SFU {
       hunt: routerAppData.hunt,
       call: routerAppData.call,
     };
-    void router.createAudioLevelObserver({
-      threshold: -50,
-      interval: 100,
-      appData,
-    });
-    void Routers.insertAsync({
+    router
+      .createAudioLevelObserver({
+        threshold: -50,
+        interval: 100,
+        appData,
+      })
+      .catch((error) => {
+        Logger.error("mediasoup createAudioLevelObserver failed", {
+          error,
+          hunt: routerAppData.hunt,
+          call: routerAppData.call,
+        });
+      });
+    Routers.insertAsync({
       hunt: routerAppData.hunt,
       call: routerAppData.call,
       createdServer: serverId,
       routerId: router.id,
       rtpCapabilities: JSON.stringify(router.rtpCapabilities),
       createdBy: routerAppData.createdBy,
+    }).catch((error) => {
+      Logger.error("mediasoup failed to insert router", { error });
     });
   }
 
@@ -648,13 +711,19 @@ class SFU {
 
     const updateCallHistory = throttle(
       Meteor.bindEnvironment(() => {
-        void CallHistories.upsertAsync(
+        CallHistories.upsertAsync(
           {
             hunt: observerAppData.hunt,
             call: observerAppData.call,
           },
           { $set: { lastActivity: new Date() } },
-        );
+        ).catch((error) => {
+          Logger.error("mediasoup CallHistories upsert failed", {
+            error,
+            hunt: observerAppData.hunt,
+            call: observerAppData.call,
+          });
+        });
       }),
       RECENT_ACTIVITY_TIME_WINDOW_MS,
     );
@@ -665,7 +734,13 @@ class SFU {
     });
 
     observer.observer.on("volumes", (volumes) => {
-      void updateCallActivity(volumes);
+      updateCallActivity(volumes).catch((error) => {
+        Logger.error("mediasoup updateCallActivity failed", {
+          error,
+          hunt: observerAppData.hunt,
+          call: observerAppData.call,
+        });
+      });
       updateCallHistory.attempt();
     });
 
@@ -702,8 +777,20 @@ class SFU {
         this.transports.delete(
           `${transportAppData.transportRequest}:${transportAppData.direction}`,
         );
-        void Transports.removeAsync({ transportId: transport.id });
-        void TransportStates.removeAsync({ transportId: transport.id });
+        Transports.removeAsync({ transportId: transport.id }).catch((error) => {
+          Logger.error("mediasoup failed to remove transport", {
+            error,
+            transportId: transport.id,
+          });
+        });
+        TransportStates.removeAsync({ transportId: transport.id }).catch(
+          (error) => {
+            Logger.error("mediasoup failed to remove transport states", {
+              error,
+              transportId: transport.id,
+            });
+          },
+        );
       }),
     );
 
@@ -721,7 +808,7 @@ class SFU {
     wtransport.observer.on(
       "icestatechange",
       Meteor.bindEnvironment((iceState: types.IceState) => {
-        void TransportStates.upsertAsync(
+        TransportStates.upsertAsync(
           {
             createdServer: serverId,
             transportId: transport.id,
@@ -732,13 +819,18 @@ class SFU {
               createdBy: transportAppData.createdBy,
             },
           },
-        );
+        ).catch((error) => {
+          Logger.error(
+            "mediasoup failed to upsert TransportStates on icestatechange",
+            { error, transportId: transport.id },
+          );
+        });
       }),
     );
     wtransport.observer.on(
       "iceselectedtuplechange",
       Meteor.bindEnvironment((iceSelectedTuple?: types.TransportTuple) => {
-        void TransportStates.upsertAsync(
+        TransportStates.upsertAsync(
           {
             createdServer: serverId,
             transportId: transport.id,
@@ -751,13 +843,18 @@ class SFU {
               createdBy: transportAppData.createdBy,
             },
           },
-        );
+        ).catch((error) => {
+          Logger.error(
+            "mediasoup failed to upsert TransportStates on iceselectedtuplechange",
+            { error, transportId: transport.id },
+          );
+        });
       }),
     );
     wtransport.observer.on(
       "dtlsstatechange",
       Meteor.bindEnvironment((dtlsState: types.DtlsState) => {
-        void TransportStates.upsertAsync(
+        TransportStates.upsertAsync(
           {
             createdServer: serverId,
             transportId: transport.id,
@@ -768,20 +865,36 @@ class SFU {
               createdBy: transportAppData.createdBy,
             },
           },
-        );
+        ).catch((error) => {
+          Logger.error(
+            "mediasoup failed to upsert TransportStates on dtlsstatechange",
+            { error, transportId: transport.id },
+          );
+        });
       }),
     );
 
     // This casts a wide net, but `createConsumer` will filter it down
     this.producers.forEach((producer) => {
-      void this.createConsumer(transportAppData.direction, transport, producer);
+      this.createConsumer(
+        transportAppData.direction,
+        transport,
+        producer,
+      ).catch((error) => {
+        Logger.error("mediasoup createConsumer failed", {
+          error,
+          direction: transportAppData.direction,
+          transportId: transport.id,
+          producerAppData: producer.appData,
+        });
+      });
     });
 
     this.transports.set(
       `${transportAppData.transportRequest}:${transportAppData.direction}`,
       wtransport,
     );
-    void Transports.insertAsync({
+    Transports.insertAsync({
       call: transportAppData.call,
       createdServer: serverId,
       peer: transportAppData.peer,
@@ -793,6 +906,12 @@ class SFU {
       dtlsParameters: JSON.stringify(wtransport.dtlsParameters),
       createdBy: transportAppData.createdBy,
       turnConfig: generateTurnConfig(),
+    }).catch((error) => {
+      Logger.error("mediasoup Transports.insertAsync failed", {
+        error,
+        call: transportAppData.call,
+        peer: transportAppData.peer,
+      });
     });
   }
 
@@ -802,7 +921,14 @@ class SFU {
       "close",
       Meteor.bindEnvironment(() => {
         this.producers.delete(producerAppData.producerClient);
-        void ProducerServers.removeAsync({ producerId: producer.id });
+        ProducerServers.removeAsync({ producerId: producer.id }).catch(
+          (error) => {
+            Logger.error("mediasoup ProducerServers.removeAsync failed", {
+              error,
+              producerId: producer.id,
+            });
+          },
+        );
       }),
     );
 
@@ -810,16 +936,31 @@ class SFU {
     // transports than we actually want to use, but `createConsumer` will filter
     // it down)
     this.transports.forEach((transport, key) => {
-      void this.createConsumer(key.split(":")[1]!, transport, producer);
+      this.createConsumer(key.split(":")[1]!, transport, producer).catch(
+        (error) => {
+          Logger.error("mediasoup createConsumer failed", {
+            error,
+            key,
+            transportId: transport.id,
+            producerId: producer.id,
+          });
+        },
+      );
     });
 
     const observer = this.observers.get(producerAppData.call);
     if (observer) {
-      void observer.addProducer({ producerId: producer.id });
+      observer.addProducer({ producerId: producer.id }).catch((error) => {
+        Logger.error("mediasoup addProducer failed", {
+          error,
+          observerId: observer.id,
+          producerId: producer.id,
+        });
+      });
     }
 
     this.producers.set(producerAppData.producerClient, producer);
-    void ProducerServers.insertAsync({
+    ProducerServers.insertAsync({
       createdServer: serverId,
       call: producerAppData.call,
       peer: producerAppData.peer,
@@ -828,6 +969,12 @@ class SFU {
       trackId: producerAppData.trackId,
       producerId: producer.id,
       createdBy: producerAppData.createdBy,
+    }).catch((error) => {
+      Logger.error("mediasoup ProducerServers.insertAsync failed", {
+        error,
+        call: producerAppData.call,
+        peer: producerAppData.peer,
+      });
     });
   }
 
@@ -839,26 +986,41 @@ class SFU {
         this.consumers.delete(
           `${consumerAppData.transportRequest}:${consumer.producerId}`,
         );
-        void Consumers.removeAsync({ consumerId: consumer.id });
+        Consumers.removeAsync({ consumerId: consumer.id }).catch((error) => {
+          Logger.error("mediasoup Consumers.removeAsync failed", {
+            error,
+            consumerId: consumer.id,
+          });
+        });
       }),
     );
 
     consumer.observer.on(
       "pause",
       Meteor.bindEnvironment(() => {
-        void Consumers.updateAsync(
+        Consumers.updateAsync(
           { consumerId: consumer.id },
           { $set: { paused: true } },
-        );
+        ).catch((error) => {
+          Logger.error(
+            "mediasoup Consumers.updateAsync failed on consumer pause",
+            { error, consumerId: consumer.id },
+          );
+        });
       }),
     );
     consumer.observer.on(
       "resume",
       Meteor.bindEnvironment(() => {
-        void Consumers.updateAsync(
+        Consumers.updateAsync(
           { consumerId: consumer.id },
           { $set: { paused: false } },
-        );
+        ).catch((error) => {
+          Logger.error(
+            "mediasoup Consumers.updateAsync failed on consumer resume",
+            { error, consumerId: consumer.id },
+          );
+        });
       }),
     );
 
@@ -866,7 +1028,7 @@ class SFU {
       `${consumerAppData.transportRequest}:${consumer.producerId}`,
       consumer,
     );
-    void Consumers.insertAsync({
+    Consumers.insertAsync({
       createdServer: serverId,
       call: consumerAppData.call,
       peer: consumerAppData.peer,
@@ -879,6 +1041,13 @@ class SFU {
       rtpParameters: JSON.stringify(consumer.rtpParameters),
       paused: consumer.paused,
       createdBy: consumerAppData.createdBy,
+    }).catch((error) => {
+      Logger.error("meidasoup failed to insert consumer", {
+        error,
+        call: consumerAppData.call,
+        peer: consumerAppData.peer,
+        consumerId: consumer.id,
+      });
     });
   }
 
@@ -910,13 +1079,18 @@ class SFU {
       transport.observer.on(
         "close",
         Meteor.bindEnvironment(() => {
-          void MonitorConnectRequests.removeAsync({
+          MonitorConnectRequests.removeAsync({
             transportId: transport.id,
+          }).catch((error) => {
+            Logger.error("Failed to remove MonitorConnectRequests", {
+              error,
+              transportId: transport.id,
+            });
           });
         }),
       );
 
-      void (async () => {
+      (async () => {
         const consumer = await transport.consumeData({
           dataProducerId: this.heartbeatDataProducer.id,
           // These options determine the reliability of the packets that we send
@@ -950,16 +1124,28 @@ class SFU {
           producerLabel: consumer.label,
           producerProtocol: consumer.protocol,
         });
-      })();
+      })().catch((error) => {
+        Logger.error("mediasoup failed to consume monitor transport", {
+          error,
+          dataProducerId: this.heartbeatDataProducer.id,
+        });
+      });
     } else if (transportAppData.type === "monitor-received") {
       ptransport.observer.on(
         "close",
         Meteor.bindEnvironment(() => {
-          void MonitorConnectAcks.removeAsync({ transportId: transport.id });
+          MonitorConnectAcks.removeAsync({ transportId: transport.id }).catch(
+            (error) => {
+              Logger.error("mediasoup failed to remove MonitorConnectAcks", {
+                error,
+                transportId: transport.id,
+              });
+            },
+          );
         }),
       );
 
-      void (async () => {
+      (async () => {
         try {
           await ptransport.connect({
             ip: transportAppData.ip,
@@ -1005,7 +1191,14 @@ class SFU {
             error,
           });
         }
-      })();
+      })().catch((error) => {
+        Logger.error("mediasoup failed to produce monitor transport", {
+          error,
+          ip: transportAppData.ip,
+          port: transportAppData.port,
+          transport: ptransport.id,
+        });
+      });
     } else {
       Logger.error("Unexpected monitor transport type", {
         transport: ptransport.id,
@@ -1251,7 +1444,12 @@ class SFU {
             server: server._id,
           },
         );
-        void cleanupDeadServer(server._id);
+        cleanupDeadServer(server._id).catch((error) => {
+          Logger.error("mediasoup cleanupDeadServer failed", {
+            error,
+            serverId: server._id,
+          });
+        });
       }),
     );
     this.heartbeatWatchdogs.set(server._id, watchdog);
@@ -1536,7 +1734,12 @@ Meteor.startup(async () => {
   const observer = await Flags.observeChangesAsync(
     "disable.webrtc",
     (active) => {
-      void updateSFU(!active);
+      updateSFU(!active).catch((error) => {
+        Logger.error(
+          "mediasoup updateSFU failed on disable.webrtc flag change",
+          { error, disable: active },
+        );
+      });
     },
   );
 

--- a/imports/server/onExit.ts
+++ b/imports/server/onExit.ts
@@ -1,13 +1,28 @@
+// biome-ignore-all lint/suspicious/noConsole: signal handlers should minimize dependencies
+
 const exitHandlers: (() => void | Promise<void>)[] = [];
 
 ["SIGINT" as const, "SIGTERM" as const, "SIGHUP" as const].forEach((signal) => {
   process.once(signal, () => {
-    void (async () => {
+    (async () => {
       for (const handler of exitHandlers.splice(0)) {
-        await handler();
+        try {
+          await handler();
+        } catch (e) {
+          console.warn(
+            `ignoring error in onExit handler for signal ${signal}`,
+            e,
+          );
+        }
       }
-      process.kill(process.pid, signal);
-    })();
+    })()
+      .catch((error) => {
+        console.warn(`ignored onExit error`, error);
+      })
+      .finally(() => {
+        // We always want to reissue the signal once we've tried running all the exitHandlers
+        process.kill(process.pid, signal);
+      });
   });
 });
 

--- a/imports/server/publications/pendingGuessesForSelf.ts
+++ b/imports/server/publications/pendingGuessesForSelf.ts
@@ -1,3 +1,4 @@
+import Logger from "../../Logger";
 import type { GuessType } from "../../lib/models/Guesses";
 import Guesses from "../../lib/models/Guesses";
 import Hunts from "../../lib/models/Hunts";
@@ -60,9 +61,15 @@ definePublication(pendingGuessesForSelf, {
           if (!huntGuessWatchers.has(huntId)) {
             const subSubscription = merger.newSub();
             huntGuessWatchers.set(huntId, subSubscription);
-            void publishJoinedQuery(subSubscription, huntGuessSpec, {
+            publishJoinedQuery(subSubscription, huntGuessSpec, {
               state: "pending",
               hunt: huntId,
+            }).catch((error) => {
+              Logger.error(
+                "pendingGuessesForSelf: publishJoinedQuery(hunt) failed in added()",
+                { error, hunt: huntId },
+              );
+              this.error(error);
             });
           }
         }
@@ -80,9 +87,15 @@ definePublication(pendingGuessesForSelf, {
           if (!huntGuessWatchers.has(huntId)) {
             const subSubscription = merger.newSub();
             huntGuessWatchers.set(huntId, subSubscription);
-            void publishJoinedQuery(subSubscription, huntGuessSpec, {
+            publishJoinedQuery(subSubscription, huntGuessSpec, {
               state: "pending",
               hunt: huntId,
+            }).catch((error) => {
+              Logger.error(
+                "pendingGuessesForSelf: publishJoinedQuery(hunt) failed in changed()",
+                { error, hunt: huntId },
+              );
+              this.error(error);
             });
           }
         }

--- a/imports/server/setup.ts
+++ b/imports/server/setup.ts
@@ -1,5 +1,6 @@
 import { Meteor } from "meteor/meteor";
 import { Random } from "meteor/random";
+import Logger from "../Logger";
 import isAdmin from "../lib/isAdmin";
 import MeteorUsers from "../lib/models/MeteorUsers";
 import type { SettingType } from "../lib/models/Settings";
@@ -120,23 +121,29 @@ Meteor.publish("googleScriptInfo", async function () {
   };
   const handle: Meteor.LiveQueryHandle = await cursor.observeAsync({
     added: (doc) => {
-      void (async () => {
+      (async () => {
         tracked = true;
         this.added(
           "googleScriptInfo",
           "googleScriptInfo",
           await formatDoc(doc),
         );
-      })();
+      })().catch((error) => {
+        Logger.error("googleScriptInfo added() failed", { error });
+        this.error(error);
+      });
     },
     changed: (newDoc) => {
-      void (async () => {
+      (async () => {
         this.changed(
           "googleScriptInfo",
           "googleScriptInfo",
           await formatDoc(newDoc),
         );
-      })();
+      })().catch((error) => {
+        Logger.error("googleScriptInfo changed() failed", { error });
+        this.error(error);
+      });
     },
     removed: () => {
       if (tracked) {

--- a/imports/server/users.ts
+++ b/imports/server/users.ts
@@ -3,6 +3,7 @@ import { check } from "meteor/check";
 import type { Subscription } from "meteor/meteor";
 import { Meteor } from "meteor/meteor";
 import type { Mongo } from "meteor/mongo";
+import Logger from "../Logger";
 import { GLOBAL_SCOPE } from "../lib/isAdmin";
 import Hunts from "../lib/models/Hunts";
 import MeteorUsers from "../lib/models/MeteorUsers";
@@ -61,7 +62,7 @@ const republishOnUserChange = async (
     projection,
   }).observeAsync({
     changed: (doc) => {
-      void (async () => {
+      (async () => {
         const newCursor = await makeCursor(doc);
         let newSub;
         if (newCursor) {
@@ -77,7 +78,13 @@ const republishOnUserChange = async (
           merger.removeSub(currentSub);
         }
         currentSub = newSub;
-      })();
+      })().catch((error) => {
+        Logger.error("Error republishing on user change", {
+          error,
+          user: sub.userId,
+        });
+        sub.error(error);
+      });
     },
   });
 

--- a/imports/server/withLock.ts
+++ b/imports/server/withLock.ts
@@ -97,7 +97,9 @@ export default async function withLock<T>(
           // Otherwise wait until expiration and then check again
           timeoutHandle = Meteor.setTimeout(waitForDeadline, timeout);
         };
-        void waitForDeadline();
+        waitForDeadline().catch((error) => {
+          Logger.error("withLock waitForDeadline() threw", { name, error });
+        });
       });
 
       // If we time out, then preempt


### PR DESCRIPTION
Since node 15, unhandled promise rejections have changed behavior: whereas they used to log an error to the console, now they cause the process to exit.

This is good for helping track down subtle incorrectness caused by rejecting promises, but we have a bunch of cases where we were `void`-ing promises when we couldn't do anything particularly useful if they were to fail.  While we don't see these promises reject often, we definitely don't want a situation where e.g. a mongo write for one workflow fails which proceeds to take down the entire backend.

To that end, we ensure that all promises that we had simply been ignoring that could reject are now caught.