### PR TITLE
Take advantage of some modern Node promise functions

### DIFF
--- a/imports/server/addUsersToDiscordRole.ts
+++ b/imports/server/addUsersToDiscordRole.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from "node:timers/promises";
 import Flags from "../Flags";
 import Logger from "../Logger";
 import DiscordRoleGrants from "../lib/models/DiscordRoleGrants";
@@ -97,9 +98,7 @@ export default async (
 
       // Discord seems to start rate limiting at around 20 requests per second;
       // to be safe, we'll limit to 2 per second
-      await new Promise((r) => {
-        setTimeout(r, 500);
-      });
+      await setTimeout(500);
     } catch (error) {
       Logger.warn("Error while adding user to Discord role", {
         error,

--- a/tests/unit/imports/server/Flags.ts
+++ b/tests/unit/imports/server/Flags.ts
@@ -1,5 +1,5 @@
+import { setImmediate } from "node:timers/promises";
 import { Accounts } from "meteor/accounts-base";
-import { Meteor } from "meteor/meteor";
 import { MongoInternals } from "meteor/mongo";
 import { assert } from "chai";
 import Flags from "../../../../imports/Flags";
@@ -25,7 +25,7 @@ async function waitUntilOplogCaughtUp() {
   await oplogHandle.waitUntilCaughtUp();
 
   // Wait an extra tick to ensure any observers have fired
-  await new Promise((resolve) => Meteor.defer(resolve));
+  await setImmediate();
 }
 
 describe("Flags", function () {

--- a/tests/unit/imports/server/publishJoinedQuery.ts
+++ b/tests/unit/imports/server/publishJoinedQuery.ts
@@ -1,4 +1,5 @@
-import { Meteor, type Subscription } from "meteor/meteor";
+import { setImmediate } from "node:timers/promises";
+import type { Meteor, Subscription } from "meteor/meteor";
 import { Random } from "meteor/random";
 import { assert } from "chai";
 import Guesses from "../../../../imports/lib/models/Guesses";
@@ -204,9 +205,7 @@ describe("publishJoinedQuery", function () {
     // testing, this generally completes within 10 turns and 2ms.
     for (let i = 0; i < 1000; i++) {
       // console.log(`tick ${i}`);
-      await new Promise<void>((r) => {
-        Meteor.defer(r);
-      });
+      await setImmediate();
       // Exit early if condition is satisfied
       const observed = [...tagCollection.keys()];
       const newSortedTagIds = newTagIds.toSorted();


### PR DESCRIPTION
There are a handful of cases where we're wrapping things in promises when in fact Node already has native ways of doing this.

(This is mostly a "I think this is cool syntax" thing and maybe a little of a "leave good examples in the codebase for copy-pasting" thing)