### PR TITLE
Update bulk add hunt for better error reporting

### DIFF
--- a/imports/server/methods/bulkAddHuntUsers.ts
+++ b/imports/server/methods/bulkAddHuntUsers.ts
@@ -33,21 +33,19 @@ defineMethod(bulkAddHuntUsers, {
     }
 
     const errors: { email: string; error: any }[] = [];
-    await Promise.all(
-      emails.map(async (email) => {
-        try {
-          await addUserToHunt({ hunt, email, invitedBy: userId });
-        } catch (error) {
-          errors.push({ email, error });
-        }
-      }),
-    );
+    for (const email of emails) {
+      try {
+        await addUserToHunt({ hunt, email, invitedBy: userId });
+      } catch (error) {
+        errors.push({ email, error });
+      }
+    }
 
     if (errors.length > 0) {
       const message = errors
         .map(({ email, error }) => {
           const err = error.sanitizedError ?? error;
-          return `${email}: ${err.reason}`;
+          return `${email}: ${err}`;
         })
         .join("\n");
       throw new Meteor.Error(


### PR DESCRIPTION
Two changes:

- One, we previously attempted to add all users in parallel, which sounds like a great way to get rate limited by everything everywhere. So instead let's do it in serial.
- Two, we attempted to sanitize errors that we sent back to the client, but in practice the error "reason" was always unset, so just send the whole stringified error.

(This is a "let's make things strictly less worse" patch, not a "let's make things good" patch)

Related to #549 but goodness gracious does not come anywhere close to fixing it.