### PR TITLE
Fix two issues with haproxy config

### DIFF
--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -728,7 +728,6 @@ Resources:
 
                     backend nginx
                     server nginx localhost:8443 send-proxy
-                    mode http
 
                     backend nginx-http2
                     server nginx-http2 localhost:8444 send-proxy
@@ -904,7 +903,7 @@ Resources:
               SingleInstanceCertReference: !If
                 - HaveLoadBalancing
                 - ""
-                - ssl crt /usr/local/etc/haproxy/certs/
+                - ssl crt /usr/local/etc/haproxy/certs/ alpn h2,http/1.1
 
   AppInstancePublicIp:
     Type: AWS::EC2::EIP


### PR DESCRIPTION
First, add the alpn configuration to allow negotiating HTTP/2 traffic. This would likely be the default behavior if we were running in HTTP mode instead of TCP mode, but since we're in TCP mode we need to specify it explicitly.

Second, don't try and connect to the HTTP/1 nginx backend in HTTP mode. When nginx is re-populating its asset cache from the jolly-roger backend, it sends the reply using HTTP/1.1 chunked encoding, and if HAProxy tries to parse and relay that, something weird seems to happen causing connections to fail. Since we don't actually need HAProxy to *do* anything with the HTTP content, we can just leave it in TCP mode.

This seems to fix the intermittent hangs when first attempting to load Jolly Roger.

For the record, I don't entirely understand *why* HAProxy is struggling so hard with chunked encoding, but mostly I can't be bothered to care. We weren't really getting any utility out of having it run in http mode anyway

In any case, as part of validating that this works, I've already deployed this to our instance.

cc @jpd236 since I think you're the only other person using our CFN config.