### PR TITLE
Make dark-mode muted/deafened icons black too

### DIFF
--- a/imports/client/theme.ts
+++ b/imports/client/theme.ts
@@ -199,7 +199,7 @@ export const darkTheme: Theme = {
     callStateIcon: "#f8d7da",
     mutedIconBorder: "#6fa8dc",
     deafenedIconBorder: "#6fa8dc",
-    mutedIconText: "white",
+    mutedIconText: "black",
     remoteMuteButtonHoverBackground: "rgb(200 200 200 / 50%)",
     remoteMuteButtonHoverText: "#ccc",
     chatterSectionBackground: "#333",


### PR DESCRIPTION
The intended design for these is the same in light and dark mode: tiny white background, black icon in foreground.

Before this patch, dark mode had white-on-white, which meant the indicator icons were invisible.

Before:
<img width="296" height="135" alt="Screenshot 2026-01-06 at 00 08 48" src="https://github.com/user-attachments/assets/85da5649-f736-40da-b8db-69f03bf7f52c" />

After:
<img width="299" height="130" alt="Screenshot 2026-01-06 at 00 09 21" src="https://github.com/user-attachments/assets/f1ee5dc9-a62f-41e4-b010-198bcba0d0cb" />
