### PR TITLE
Reimplement TypedMethod and TypedPublication using zod

### DIFF
--- a/docs/assets.md
+++ b/docs/assets.md
@@ -7,7 +7,7 @@ files:
   - imports/server/lookupUrl.ts
   - imports/server/models/Blobs.ts
   - imports/server/publications/blobMappingsAll.ts
-updated: 2026-02-21
+updated: 2026-07-25
 ---
 
 # Custom Asset Pipeline

--- a/docs/google-drive.md
+++ b/docs/google-drive.md
@@ -35,7 +35,7 @@ files:
   - imports/server/setup.ts
   - private/google-script/cookie-test.html
   - private/google-script/main.js
-updated: 2026-07-20T20:48:16Z
+updated: 2026-07-25
 ---
 
 # Google Drive Integration

--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -334,7 +334,7 @@ const APIKeysSection = ({ apiKeys }: { apiKeys?: APIKeyType[] }) => {
   const [createError, setCreateError] = useState<string | undefined>(undefined);
   const createKey = useCallback(() => {
     setCreateState("requesting");
-    createAPIKey.call({}, (error, _newKey) => {
+    createAPIKey.call((error, _newKey) => {
       if (error) {
         setCreateState("error");
         setCreateError(error.message);

--- a/imports/client/hooks/useTypedSubscribe.ts
+++ b/imports/client/hooks/useTypedSubscribe.ts
@@ -1,11 +1,15 @@
 import { useSubscribe } from "meteor/react-meteor-data";
+import type z from "zod";
 import type TypedPublication from "../../lib/publications/TypedPublication";
-import type { TypedPublicationArgs } from "../../lib/publications/TypedPublication";
-import type { TypedMethodSubscribeArgs } from "../typedSubscribe";
+import type { ExactCallArgs } from "../../lib/ValidateShape";
 
-export default function useTypedSubscribe<T, Arg extends TypedPublicationArgs>(
-  publication: TypedPublication<Arg> | undefined,
-  ...args: TypedMethodSubscribeArgs<T, Arg>
+export default function useTypedSubscribe<
+  Args extends z.ZodTuple,
+  // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- T must remain independently inferred so ExactCallArgs can reject excess properties
+  T extends z.input<Args>,
+>(
+  publication: TypedPublication<Args> | undefined,
+  ...args: ExactCallArgs<T, z.input<Args>>
 ) {
   return useSubscribe(publication?.name ?? undefined, ...args);
 }

--- a/imports/client/typedSubscribe.ts
+++ b/imports/client/typedSubscribe.ts
@@ -1,23 +1,20 @@
 import { Meteor } from "meteor/meteor";
+import type z from "zod";
 import type TypedPublication from "../lib/publications/TypedPublication";
-import type { TypedPublicationArgs } from "../lib/publications/TypedPublication";
-import type ValidateShape from "../lib/ValidateShape";
+import type { ExactCallArgs } from "../lib/ValidateShape";
 
-export type TypedMethodSubscribeArgs<
-  T,
-  Arg extends TypedPublicationArgs,
-> = Arg extends void ? [] : [ValidateShape<T, Arg>];
-
-const typedSubscribe = <T, Args extends TypedPublicationArgs>(
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- T must remain independently inferred so ExactCallArgs can reject excess properties
+const typedSubscribe = <Args extends z.ZodTuple, T extends z.input<Args>>(
   publication: TypedPublication<Args>,
-  ...args: TypedMethodSubscribeArgs<T, Args>
+  ...args: ExactCallArgs<T, z.input<Args>>
 ) => {
   return Meteor.subscribe(publication.name, ...args);
 };
 
-typedSubscribe.async = <T, Args extends TypedPublicationArgs>(
+// oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- T must remain independently inferred so ExactCallArgs can reject excess properties
+typedSubscribe.async = <Args extends z.ZodTuple, T extends z.input<Args>>(
   publication: TypedPublication<Args>,
-  ...args: TypedMethodSubscribeArgs<T, Args>
+  ...args: ExactCallArgs<T, z.input<Args>>
 ) => {
   return new Promise<Meteor.SubscriptionHandle>((resolve, reject) => {
     const handle = Meteor.subscribe(publication.name, ...args, {

--- a/imports/lib/ValidateEJSONable.ts
+++ b/imports/lib/ValidateEJSONable.ts
@@ -1,0 +1,31 @@
+import type z from "zod";
+
+// Our own description of what EJSON can serialize. Meteor's EJSONable types
+// (from meteor/ejson) include `Object`, which TypeScript treats as "anything
+// that isn't null or undefined" (functions, Maps, and class instances all
+// qualify), so a constraint built on them accepts every schema and catches
+// nothing.
+export type EJSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | Date
+  | Uint8Array
+  | EJSONValue[]
+  | { [key: string]: EJSONValue };
+
+// Constrain a zod schema to one that describes EJSON-serializable values.
+// (Intersecting with `unknown` is a no-op, making the validator an identity
+// function; a string will have no overlap with a zod schema, resulting in a
+// type error.)
+export type ValidateEJSONableArgs<Schema extends z.ZodType> = Schema &
+  (z.input<Schema> extends EJSONValue
+    ? unknown
+    : "Schema input must be EJSON-serializable");
+
+export type ValidateEJSONableReturn<Schema extends z.ZodType> = Schema &
+  (z.output<Schema> extends void | EJSONValue
+    ? unknown
+    : "Schema output must be EJSON-serializable");

--- a/imports/lib/ValidateShape.ts
+++ b/imports/lib/ValidateShape.ts
@@ -1,5 +1,29 @@
-type ValidateShape<T, Shape> = Shape & {
-  [K in keyof T]: K extends keyof Shape ? T[K] : never;
-};
+type ValidateShape<T, Shape> = Shape extends undefined
+  ? undefined
+  : Shape & {
+      [K in keyof T]: K extends keyof Shape ? T[K] : never;
+    };
+
+// tuple mapped types expose fixed indices as string keys, so the first branch
+// converts a key like "2" back to the numeric index 2; the second branch handles
+// keys that are already numeric, including the unspecified `number` used for
+// rest elements.
+type TupleElement<
+  S extends readonly unknown[],
+  K,
+> = K extends `${infer N extends number}`
+  ? S[N]
+  : K extends number
+    ? S[K]
+    : never;
+
+// map over `T` (the supplied argument tuple) rather than `S` (the expected
+// argument tuple) so TypeScript infers each supplied element before applying
+// `ValidateShape`. Wrap and spread so that the result is interpreted as a tuple
+export type ExactCallArgs<T extends S, S extends readonly unknown[]> = [
+  ...{
+    [K in keyof T]: ValidateShape<T[K], TupleElement<S, K>>;
+  },
+];
 
 export default ValidateShape;

--- a/imports/lib/models/Hunts.ts
+++ b/imports/lib/models/Hunts.ts
@@ -1,4 +1,3 @@
-import { Match } from "meteor/check";
 import { z } from "zod";
 import { nonEmptyString, snowflake } from "../typedModel/customTypes";
 import type { ModelType } from "../typedModel/Model";
@@ -6,14 +5,14 @@ import { Url } from "../typedModel/regexes";
 import SoftDeletedModel from "../typedModel/SoftDeletedModel";
 import withCommon from "../typedModel/withCommon";
 
-export const SavedDiscordObjectFields = z.object({
+export const SavedDiscordObjectFields = z.strictObject({
   id: snowflake,
   name: nonEmptyString,
 });
 
 export type SavedDiscordObjectType = z.infer<typeof SavedDiscordObjectFields>;
 
-const EditableHunt = z.object({
+const BaseHunt = z.strictObject({
   name: nonEmptyString,
   // Everyone that joins the hunt will be added to these mailing lists
   mailingLists: nonEmptyString.array().default([]),
@@ -51,28 +50,15 @@ const EditableHunt = z.object({
   // profile will be added to this role.
   memberDiscordRole: SavedDiscordObjectFields.optional(),
 });
+// Fields with document-construction defaults stay required for RPC callers;
+// otherwise they would get re-set to their defaults when the update RPC parses
+// the input.
+export const EditableHunt = BaseHunt.required({
+  mailingLists: true,
+  openSignups: true,
+});
 export type EditableHuntType = z.infer<typeof EditableHunt>;
-const Hunt = withCommon(EditableHunt);
-
-const SavedDiscordObjectPattern = {
-  id: String,
-  name: String,
-};
-
-export const HuntPattern = {
-  name: String,
-  mailingLists: [String] as [StringConstructor],
-  signupMessage: Match.Optional(String),
-  openSignups: Boolean,
-  hasGuessQueue: Boolean,
-  termsOfUse: Match.Optional(String),
-  submitTemplate: Match.Optional(String),
-  homepageUrl: Match.Optional(String),
-  announcementDiscordChannel: Match.Optional(SavedDiscordObjectPattern),
-  puzzleHooksDiscordChannel: Match.Optional(SavedDiscordObjectPattern),
-  firehoseDiscordChannel: Match.Optional(SavedDiscordObjectPattern),
-  memberDiscordRole: Match.Optional(SavedDiscordObjectPattern),
-};
+const Hunt = withCommon(BaseHunt);
 
 const Hunts = new SoftDeletedModel("jr_hunts", Hunt);
 export type HuntType = ModelType<typeof Hunts>;

--- a/imports/lib/publications/TypedPublication.ts
+++ b/imports/lib/publications/TypedPublication.ts
@@ -1,25 +1,19 @@
-import type { EJSONable, EJSONableProperty } from "meteor/ejson";
+import type z from "zod";
+import type { ValidateEJSONableArgs } from "../ValidateEJSONable";
 
-type TypedPublicationParam = EJSONable | EJSONableProperty;
-export type TypedPublicationArgs = Record<string, TypedPublicationParam> | void;
-
-export class BaseTypedPublication<
-  Args extends TypedPublicationArgs,
-  Name extends string | (Args extends void ? null : never),
-> {
-  name: Name;
-
-  constructor(name: Name) {
-    this.name = name;
-  }
-}
-
-export class DefaultTypedPublication extends BaseTypedPublication<void, null> {
-  constructor() {
-    super(null);
-  }
-}
+export type PublicationName<Args extends z.ZodTuple> =
+  | string
+  | (z.output<Args> extends [] ? null : never);
 
 export default class TypedPublication<
-  Args extends TypedPublicationArgs,
-> extends BaseTypedPublication<Args, string> {}
+  Args extends z.ZodTuple,
+  Name extends PublicationName<Args> = string,
+> {
+  name: Name;
+  args: Args;
+
+  constructor(name: Name, args: ValidateEJSONableArgs<Args>) {
+    this.name = name;
+    this.args = args;
+  }
+}

--- a/imports/lib/publications/announcementsForAnnouncementsPage.ts
+++ b/imports/lib/publications/announcementsForAnnouncementsPage.ts
@@ -1,5 +1,7 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{ huntId: string }>(
+export default new TypedPublication(
   "Announcements.publications.forAnnouncementsPage",
+  z.tuple([z.strictObject({ huntId: z.string() })]),
 );

--- a/imports/lib/publications/apiKeysForSelf.ts
+++ b/imports/lib/publications/apiKeysForSelf.ts
@@ -1,3 +1,7 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<void>("APIKeys.publications.forSelf");
+export default new TypedPublication(
+  "APIKeys.publications.forSelf",
+  z.tuple([]),
+);

--- a/imports/lib/publications/blobMappingsAll.ts
+++ b/imports/lib/publications/blobMappingsAll.ts
@@ -1,6 +1,10 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
 // Note that this could be a default publication, but our client-side
 // implementation of `lookupUrl` wants to know when this has loaded, which means
 // we need an explicit subscription
-export default new TypedPublication<void>("BlobMappings.publications.all");
+export default new TypedPublication(
+  "BlobMappings.publications.all",
+  z.tuple([]),
+);

--- a/imports/lib/publications/bookmarkNotificationsForSelf.ts
+++ b/imports/lib/publications/bookmarkNotificationsForSelf.ts
@@ -1,5 +1,7 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<void>(
+export default new TypedPublication(
   "BookmarkNotifications.publications.forSelf",
+  z.tuple([]),
 );

--- a/imports/lib/publications/chatMessagesForFirehose.ts
+++ b/imports/lib/publications/chatMessagesForFirehose.ts
@@ -1,5 +1,11 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{ huntId: string }>(
+export default new TypedPublication(
   "ChatMessages.publications.forFirehose",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+    }),
+  ]),
 );

--- a/imports/lib/publications/chatMessagesForPuzzle.ts
+++ b/imports/lib/publications/chatMessagesForPuzzle.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{ puzzleId: string; huntId: string }>(
+export default new TypedPublication(
   "ChatMessages.publications.forPuzzle",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+      huntId: z.string(),
+    }),
+  ]),
 );

--- a/imports/lib/publications/discordChannelsForConfiguredGuild.ts
+++ b/imports/lib/publications/discordChannelsForConfiguredGuild.ts
@@ -1,5 +1,7 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<void>(
+export default new TypedPublication(
   "DiscordCache.publications.channelsForConfiguredGuild",
+  z.tuple([]),
 );

--- a/imports/lib/publications/discordGuildsAll.ts
+++ b/imports/lib/publications/discordGuildsAll.ts
@@ -1,5 +1,7 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<void>(
+export default new TypedPublication(
   "DiscordCache.publications.allGuilds",
+  z.tuple([]),
 );

--- a/imports/lib/publications/discordRolesForConfiguredGuild.ts
+++ b/imports/lib/publications/discordRolesForConfiguredGuild.ts
@@ -1,5 +1,7 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<void>(
+export default new TypedPublication(
   "DiscordCache.publications.rolesForConfiguredGuild",
+  z.tuple([]),
 );

--- a/imports/lib/publications/documentsForPuzzleDeleteModal.ts
+++ b/imports/lib/publications/documentsForPuzzleDeleteModal.ts
@@ -1,5 +1,11 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{ huntId: string }>(
+export default new TypedPublication(
   "Documents.publications.forPuzzleDeleteModal",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+    }),
+  ]),
 );

--- a/imports/lib/publications/featureFlagsAll.ts
+++ b/imports/lib/publications/featureFlagsAll.ts
@@ -1,4 +1,5 @@
-import { DefaultTypedPublication } from "./TypedPublication";
+import z from "zod";
+import TypedPublication from "./TypedPublication";
 
 // All feature flags are always available on the client
-export default new DefaultTypedPublication();
+export default new TypedPublication(null, z.tuple([]));

--- a/imports/lib/publications/guessesForGuessQueue.ts
+++ b/imports/lib/publications/guessesForGuessQueue.ts
@@ -1,5 +1,11 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{ huntId: string }>(
+export default new TypedPublication(
   "Guesses.publications.forGuessQueue",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+    }),
+  ]),
 );

--- a/imports/lib/publications/huntForHuntApp.ts
+++ b/imports/lib/publications/huntForHuntApp.ts
@@ -1,5 +1,11 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{ huntId: string }>(
+export default new TypedPublication(
   "Hunts.publications.forHuntApp",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+    }),
+  ]),
 );

--- a/imports/lib/publications/huntForInvitationCode.ts
+++ b/imports/lib/publications/huntForInvitationCode.ts
@@ -1,5 +1,11 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{ invitationCode: string }>(
+export default new TypedPublication(
   "Hunts.publications.forInvitationCode",
+  z.tuple([
+    z.strictObject({
+      invitationCode: z.string(),
+    }),
+  ]),
 );

--- a/imports/lib/publications/huntsAll.ts
+++ b/imports/lib/publications/huntsAll.ts
@@ -1,3 +1,4 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<void>("Hunts.publications.all");
+export default new TypedPublication("Hunts.publications.all", z.tuple([]));

--- a/imports/lib/publications/invitationCodesForHunt.ts
+++ b/imports/lib/publications/invitationCodesForHunt.ts
@@ -1,5 +1,11 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{ huntId: string }>(
+export default new TypedPublication(
   "InvitationCodes.publications.forHunt",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+    }),
+  ]),
 );

--- a/imports/lib/publications/jobForMerge.ts
+++ b/imports/lib/publications/jobForMerge.ts
@@ -1,5 +1,11 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{ jobId: string }>(
+export default new TypedPublication(
   "Jobs.publications.forMerge",
+  z.tuple([
+    z.strictObject({
+      jobId: z.string(),
+    }),
+  ]),
 );

--- a/imports/lib/publications/jobsAll.ts
+++ b/imports/lib/publications/jobsAll.ts
@@ -1,3 +1,4 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<void>("Jobs.publications.all");
+export default new TypedPublication("Jobs.publications.all", z.tuple([]));

--- a/imports/lib/publications/pendingAnnouncementsForSelf.ts
+++ b/imports/lib/publications/pendingAnnouncementsForSelf.ts
@@ -1,5 +1,7 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<void>(
+export default new TypedPublication(
   "PendingAnnouncements.publications.forSelf",
+  z.tuple([]),
 );

--- a/imports/lib/publications/pendingGuessesForSelf.ts
+++ b/imports/lib/publications/pendingGuessesForSelf.ts
@@ -1,3 +1,4 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
 // Publish pending guesses enriched with puzzle and hunt. This is a dedicated
@@ -12,6 +13,7 @@ import TypedPublication from "./TypedPublication";
 // subscription. Doing this on the client means we can make it a reactive
 // computation, whereas if we used a permissions check on the server to
 // short-circuit the sub, we could not.
-export default new TypedPublication<void>(
+export default new TypedPublication(
   "Guesses.publications.pendingForSelf",
+  z.tuple([]),
 );

--- a/imports/lib/publications/puzzleActivityForHunt.ts
+++ b/imports/lib/publications/puzzleActivityForHunt.ts
@@ -1,5 +1,11 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{ huntId: string }>(
+export default new TypedPublication(
   "PuzzleActivity.publications.forHunt",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+    }),
+  ]),
 );

--- a/imports/lib/publications/puzzleForPuzzlePage.ts
+++ b/imports/lib/publications/puzzleForPuzzlePage.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{ puzzleId: string; huntId: string }>(
+export default new TypedPublication(
   "Puzzles.publications.forPuzzlePage",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+      huntId: z.string(),
+    }),
+  ]),
 );

--- a/imports/lib/publications/puzzlesForHunt.ts
+++ b/imports/lib/publications/puzzlesForHunt.ts
@@ -1,6 +1,12 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{
-  huntId: string;
-  includeDeleted?: boolean;
-}>("Puzzles.publications.forHunt");
+export default new TypedPublication(
+  "Puzzles.publications.forHunt",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+      includeDeleted: z.boolean().optional(),
+    }),
+  ]),
+);

--- a/imports/lib/publications/puzzlesForPuzzleList.ts
+++ b/imports/lib/publications/puzzlesForPuzzleList.ts
@@ -1,6 +1,12 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{
-  huntId: string;
-  includeDeleted?: boolean;
-}>("Puzzles.publications.forPuzzleList");
+export default new TypedPublication(
+  "Puzzles.publications.forPuzzleList",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+      includeDeleted: z.boolean().optional(),
+    }),
+  ]),
+);

--- a/imports/lib/publications/settingsAll.ts
+++ b/imports/lib/publications/settingsAll.ts
@@ -1,3 +1,4 @@
+import z from "zod";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<void>("Settings.publications.all");
+export default new TypedPublication("Settings.publications.all", z.tuple([]));

--- a/imports/lib/publications/settingsByName.ts
+++ b/imports/lib/publications/settingsByName.ts
@@ -1,6 +1,12 @@
-import type { SettingNameType } from "../models/Settings";
+import z from "zod";
+import { SettingNames } from "../models/Settings";
 import TypedPublication from "./TypedPublication";
 
-export default new TypedPublication<{ name: SettingNameType }>(
+export default new TypedPublication(
   "Settings.publications.byName",
+  z.tuple([
+    z.strictObject({
+      name: z.enum(SettingNames),
+    }),
+  ]),
 );

--- a/imports/lib/typedModel/validateSchema.ts
+++ b/imports/lib/typedModel/validateSchema.ts
@@ -49,15 +49,20 @@ function validateSchemaInner(raw: $ZodType) {
       validateSchemaInner(def.element);
       break;
 
-    case "object":
+    case "object": {
       for (const [, field] of Object.entries(def.shape)) {
         if (field === undefined) continue;
         validateSchemaInner(field);
       }
-      if (def.catchall) {
-        validateSchemaInner(def.catchall);
+      const { catchall } = def;
+      if (catchall && catchall._zod.def.type !== "never") {
+        // A never catchall (z.strictObject) serializes to
+        // additionalProperties: false rather than a value schema, so there is
+        // nothing further to validate.
+        validateSchemaInner(catchall);
       }
       break;
+    }
 
     case "record":
       validateSchemaInner(def.valueType);

--- a/imports/methods/TypedMethod.ts
+++ b/imports/methods/TypedMethod.ts
@@ -1,119 +1,106 @@
 import { check } from "meteor/check";
-import type { EJSONable, EJSONableProperty } from "meteor/ejson";
 import { EJSON } from "meteor/ejson";
 import { Meteor } from "meteor/meteor";
 import Bugsnag from "@bugsnag/js";
+import type z from "zod";
 import Logger from "../Logger";
-import type ValidateShape from "../lib/ValidateShape";
+import type {
+  ValidateEJSONableArgs,
+  ValidateEJSONableReturn,
+} from "../lib/ValidateEJSONable";
+import type { ExactCallArgs } from "../lib/ValidateShape";
 
-export type TypedMethodParam = EJSONable | EJSONableProperty;
-export type TypedMethodArgs = Record<string, TypedMethodParam> | void;
-type TypedMethodCallback<Return extends TypedMethodParam | void> =
-  Return extends void
-    ? (error?: Meteor.Error) => void
-    : <Error extends true | false>(
-        error: Error extends true ? Meteor.Error : undefined,
-        result: Error extends false ? Return : undefined,
+type TypedMethodCallback<Return extends z.ZodType> =
+  z.output<Return> extends void
+    ? (error: Meteor.Error | undefined) => void
+    : (
+        error: Meteor.Error | undefined,
+        result: z.output<Return> | undefined,
       ) => void;
-type TypedMethodCallArgs<
-  T,
-  Arg extends TypedMethodArgs,
-  Return extends TypedMethodParam | void,
-> = Arg extends void
-  ? [TypedMethodCallback<Return>] | []
-  :
-      | [ValidateShape<T, Arg>, TypedMethodCallback<Return>]
-      | [ValidateShape<T, Arg>];
-type TypedMethodCallPromiseArgs<
-  T,
-  Arg extends TypedMethodArgs,
-> = Arg extends void ? [] : [ValidateShape<T, Arg>];
 
-class TypedMethod<
-  Args extends TypedMethodArgs,
-  Return extends TypedMethodParam | void,
-> {
+// EJSON.stringify only accepts objects, so wrap rather than passing the array.
+const describeArgs = (args: unknown[]) => EJSON.stringify({ args });
+
+const severityFor = (error: unknown) =>
+  error instanceof Meteor.Error &&
+  typeof error.error === "number" &&
+  error.error >= 400 &&
+  error.error < 500
+    ? "info"
+    : "error";
+
+class TypedMethod<Args extends z.ZodTuple, Return extends z.ZodType> {
   name: string;
+  args: Args;
+  return: Return;
 
-  constructor(name: string) {
+  constructor(
+    name: string,
+    args: ValidateEJSONableArgs<Args>,
+    returnType: ValidateEJSONableReturn<Return>,
+  ) {
     check(name, String);
 
     this.name = name;
+    this.args = args;
+    this.return = returnType;
   }
 
-  call<T>(...args: TypedMethodCallArgs<T, Args, Return>): void {
+  private breadcrumb(args: unknown[]) {
+    if (Bugsnag.isStarted()) {
+      Bugsnag.leaveBreadcrumb(
+        "Meteor method call",
+        { method: this.name, arguments: describeArgs(args) },
+        "request",
+      );
+    }
+  }
+
+  private logError(error: unknown, args: unknown[]) {
+    Logger[severityFor(error)](`Meteor method call failed: ${this.name}`, {
+      error,
+      method: this.name,
+      arguments: describeArgs(args),
+    });
+  }
+
+  // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- T must remain independently inferred so ExactCallArgs can reject excess properties
+  call<T extends z.input<Args>>(
+    ...args: [
+      ...ExactCallArgs<T, z.input<Args>>,
+      callback?: TypedMethodCallback<Return>,
+    ]
+  ): void {
     let callback: TypedMethodCallback<Return> | undefined;
     if (typeof args.at(-1) === "function") {
       callback = args.pop() as TypedMethodCallback<Return>;
     }
 
-    if (Bugsnag.isStarted()) {
-      Bugsnag.leaveBreadcrumb(
-        "Meteor method call",
-        {
-          method: this.name,
-          arguments:
-            typeof args[0] === "object" ? EJSON.stringify(args[0]) : undefined,
-        },
-        "request",
-      );
-    }
+    this.breadcrumb(args);
 
-    Meteor.call(this.name, ...args, (error: Meteor.Error, result: Return) => {
-      if (error) {
-        const severity =
-          error instanceof Meteor.Error &&
-          typeof error.error === "number" &&
-          error.error >= 400 &&
-          error.error < 500
-            ? "info"
-            : "error";
-        Logger[severity](`Meteor method call failed: ${this.name}`, {
-          error,
-          method: this.name,
-          arguments:
-            typeof args[0] === "object" ? EJSON.stringify(args[0]) : undefined,
-        });
-      }
-      callback?.(error, result as any);
-    });
+    Meteor.call(
+      this.name,
+      ...args,
+      (error: Meteor.Error | undefined, result: z.output<Return>) => {
+        if (error) {
+          this.logError(error, args);
+        }
+        callback?.(error, result);
+      },
+    );
   }
 
-  async callPromise<T>(
-    ...args: TypedMethodCallPromiseArgs<T, Args>
-  ): Promise<Return> {
+  // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- T must remain independently inferred so ExactCallArgs can reject excess properties
+  async callPromise<T extends z.input<Args>>(
+    ...args: ExactCallArgs<T, z.input<Args>>
+  ): Promise<z.output<Return>> {
+    this.breadcrumb(args);
+
     try {
-      if (Bugsnag.isStarted()) {
-        Bugsnag.leaveBreadcrumb(
-          "Meteor method call",
-          {
-            method: this.name,
-            arguments:
-              typeof args[0] === "object"
-                ? EJSON.stringify(args[0])
-                : undefined,
-          },
-          "request",
-        );
-      }
       const result = await Meteor.callAsync(this.name, ...args);
-      return result as Return;
+      return result as z.output<Return>;
     } catch (error) {
-      if (error) {
-        const severity =
-          error instanceof Meteor.Error &&
-          typeof error.error === "number" &&
-          error.error >= 400 &&
-          error.error < 500
-            ? "info"
-            : "error";
-        Logger[severity](`Meteor method call failed: ${this.name}`, {
-          error,
-          method: this.name,
-          arguments:
-            typeof args[0] === "object" ? EJSON.stringify(args[0]) : undefined,
-        });
-      }
+      this.logError(error, args);
       throw error;
     }
   }

--- a/imports/methods/acceptHuntInvitationCode.ts
+++ b/imports/methods/acceptHuntInvitationCode.ts
@@ -1,6 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  { invitationCode: string; email?: string },
-  string
->("Hunts.methods.acceptHuntInvitationCode");
+export default new TypedMethod(
+  "Hunts.methods.acceptHuntInvitationCode",
+  z.tuple([
+    z.strictObject({
+      invitationCode: z.string(),
+      email: z.string().optional(),
+    }),
+  ]),
+  z.string(),
+);

--- a/imports/methods/acceptUserHuntTerms.ts
+++ b/imports/methods/acceptUserHuntTerms.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ huntId: string }, void>(
+export default new TypedMethod(
   "Users.methods.acceptHuntTerms",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/addHuntUser.ts
+++ b/imports/methods/addHuntUser.ts
@@ -1,5 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ huntId: string; email: string }, void>(
+export default new TypedMethod(
   "Hunts.methods.addUser",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+      email: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/addPuzzleAnswer.ts
+++ b/imports/methods/addPuzzleAnswer.ts
@@ -1,5 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ puzzleId: string; answer: string }, void>(
+export default new TypedMethod(
   "Puzzles.methods.addAnswer",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+      answer: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/addPuzzleTag.ts
+++ b/imports/methods/addPuzzleTag.ts
@@ -1,7 +1,15 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
 // addPuzzleTag takes a tag name, rather than a tag ID, so we can avoid doing
 // two round-trips for tag creation.
-export default new TypedMethod<{ puzzleId: string; tagName: string }, void>(
+export default new TypedMethod(
   "Puzzles.methods.addTag",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+      tagName: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/addUserAccountEmail.ts
+++ b/imports/methods/addUserAccountEmail.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ email: string }, void>(
+export default new TypedMethod(
   "Users.methods.addUserAccountEmail",
+  z.tuple([
+    z.strictObject({
+      email: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/bookmarkPuzzle.ts
+++ b/imports/methods/bookmarkPuzzle.ts
@@ -1,5 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ puzzleId: string; bookmark: boolean }, void>(
+export default new TypedMethod(
   "Puzzles.methods.bookmark",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+      bookmark: z.boolean(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/bulkAddHuntUsers.ts
+++ b/imports/methods/bulkAddHuntUsers.ts
@@ -1,5 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ huntId: string; emails: string[] }, void>(
+export default new TypedMethod(
   "Hunts.methods.bulkAddUsers",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+      emails: z.string().array(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/clearHuntInvitationCode.ts
+++ b/imports/methods/clearHuntInvitationCode.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ huntId: string }, void>(
+export default new TypedMethod(
   "Hunts.methods.clearHuntInvitationCode",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/configureClearGdriveCreds.ts
+++ b/imports/methods/configureClearGdriveCreds.ts
@@ -1,3 +1,8 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<void, void>("Settings.methods.clearGdriveCreds");
+export default new TypedMethod(
+  "Settings.methods.clearGdriveCreds",
+  z.tuple([]),
+  z.void(),
+);

--- a/imports/methods/configureCollectGoogleAccountIds.ts
+++ b/imports/methods/configureCollectGoogleAccountIds.ts
@@ -1,5 +1,8 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<void, void>(
+export default new TypedMethod(
   "Settings.methods.collectGoogleAccountIds",
+  z.tuple([]),
+  z.void(),
 );

--- a/imports/methods/configureDiscordBot.ts
+++ b/imports/methods/configureDiscordBot.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ token?: string }, void>(
+export default new TypedMethod(
   "Setup.methods.configureDiscordBot",
+  z.tuple([
+    z.strictObject({
+      token: z.string().optional(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/configureDiscordBotGuild.ts
+++ b/imports/methods/configureDiscordBotGuild.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ guild?: { id: string; name: string } }, void>(
+export default new TypedMethod(
   "Setup.methods.configureDiscordBotGuild",
+  z.tuple([
+    z.strictObject({
+      guild: z.strictObject({ id: z.string(), name: z.string() }).optional(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/configureDiscordOAuthClient.ts
+++ b/imports/methods/configureDiscordOAuthClient.ts
@@ -1,6 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  { clientId?: string; clientSecret?: string },
-  void
->("Setup.methods.configureDiscordOAuthClient");
+export default new TypedMethod(
+  "Setup.methods.configureDiscordOAuthClient",
+  z.tuple([
+    z.strictObject({
+      clientId: z.string().optional(),
+      clientSecret: z.string().optional(),
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/configureEmailBranding.ts
+++ b/imports/methods/configureEmailBranding.ts
@@ -1,12 +1,16 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  {
-    from?: string;
-    enrollSubject?: string;
-    enrollMessage?: string;
-    joinSubject?: string;
-    joinMessage?: string;
-  },
-  void
->("Setup.methods.configureEmailBranding");
+export default new TypedMethod(
+  "Setup.methods.configureEmailBranding",
+  z.tuple([
+    z.strictObject({
+      from: z.string().optional(),
+      enrollSubject: z.string().optional(),
+      enrollMessage: z.string().optional(),
+      joinSubject: z.string().optional(),
+      joinMessage: z.string().optional(),
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/configureEnsureGoogleScript.ts
+++ b/imports/methods/configureEnsureGoogleScript.ts
@@ -1,3 +1,8 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<void, void>("Setup.methods.ensureGoogleScript");
+export default new TypedMethod(
+  "Setup.methods.ensureGoogleScript",
+  z.tuple([]),
+  z.void(),
+);

--- a/imports/methods/configureGdriveCreds.ts
+++ b/imports/methods/configureGdriveCreds.ts
@@ -1,5 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ key: string; secret: string }, void>(
+export default new TypedMethod(
   "Setup.methods.configureGdriveCreds",
+  z.tuple([
+    z.strictObject({
+      key: z.string(),
+      secret: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/configureGdriveRoot.ts
+++ b/imports/methods/configureGdriveRoot.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ root?: string | undefined }, void>(
+export default new TypedMethod(
   "Setup.methods.configureGdriveRoot",
+  z.tuple([
+    z.strictObject({
+      root: z.string().optional(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/configureGdriveTemplates.ts
+++ b/imports/methods/configureGdriveTemplates.ts
@@ -1,6 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  { spreadsheetTemplate?: string; documentTemplate?: string },
-  void
->("Setup.methods.configureGdriveTemplates");
+export default new TypedMethod(
+  "Setup.methods.configureGdriveTemplates",
+  z.tuple([
+    z.strictObject({
+      spreadsheetTemplate: z.string().optional(),
+      documentTemplate: z.string().optional(),
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/configureGoogleOAuthClient.ts
+++ b/imports/methods/configureGoogleOAuthClient.ts
@@ -1,5 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ clientId?: string; secret?: string }, void>(
+export default new TypedMethod(
   "Setup.methods.configureGoogleOAuthClient",
+  z.tuple([
+    z.strictObject({
+      clientId: z.string().optional(),
+      secret: z.string().optional(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/configureGoogleScriptUrl.ts
+++ b/imports/methods/configureGoogleScriptUrl.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ url?: string }, void>(
+export default new TypedMethod(
   "Setup.methods.configureGoogleScriptUrl",
+  z.tuple([
+    z.strictObject({
+      url: z.string().optional(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/configureListS3Buckets.ts
+++ b/imports/methods/configureListS3Buckets.ts
@@ -1,3 +1,8 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<void, string[]>("Setup.methods.listS3Buckets");
+export default new TypedMethod(
+  "Setup.methods.listS3Buckets",
+  z.tuple([]),
+  z.string().array(),
+);

--- a/imports/methods/configureOrganizeGoogleDrive.ts
+++ b/imports/methods/configureOrganizeGoogleDrive.ts
@@ -1,5 +1,8 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<void, void>(
+export default new TypedMethod(
   "Settings.methods.organizeGoogleDrive",
+  z.tuple([]),
+  z.void(),
 );

--- a/imports/methods/configureS3ImageBucket.ts
+++ b/imports/methods/configureS3ImageBucket.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ bucketName: string | undefined }, void>(
+export default new TypedMethod(
   "Setup.methods.configureS3ImageBucket",
+  z.tuple([
+    z.strictObject({
+      bucketName: z.string().optional(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/configureServerLanguage.ts
+++ b/imports/methods/configureServerLanguage.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ language: string }, void>(
+export default new TypedMethod(
   "Setup.methods.configureServerLanguage",
+  z.tuple([
+    z.strictObject({
+      language: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/configureTeamName.ts
+++ b/imports/methods/configureTeamName.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ teamName?: string }, void>(
+export default new TypedMethod(
   "Setup.methods.configureTeamName",
+  z.tuple([
+    z.strictObject({
+      teamName: z.string().optional(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/confirmUserMerge.ts
+++ b/imports/methods/confirmUserMerge.ts
@@ -1,6 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  { sourceUser: string; targetUser: string },
-  string
->("Users.methods.confirmMerge");
+export default new TypedMethod(
+  "Users.methods.confirmMerge",
+  z.tuple([
+    z.strictObject({
+      sourceUser: z.string(),
+      targetUser: z.string(),
+    }),
+  ]),
+  z.string(),
+);

--- a/imports/methods/createAPIKey.ts
+++ b/imports/methods/createAPIKey.ts
@@ -1,5 +1,8 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<Record<string, never>, string>(
+export default new TypedMethod(
   "APIKeys.method.create",
+  z.tuple([]),
+  z.string(),
 );

--- a/imports/methods/createChatImageUpload.ts
+++ b/imports/methods/createChatImageUpload.ts
@@ -1,7 +1,19 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  { puzzleId: string; mimeType: string },
-  | { publicUrl: string; uploadUrl: string; fields: Record<string, string> }
-  | undefined
->("ChatMessages.methods.createImageUpload");
+export default new TypedMethod(
+  "ChatMessages.methods.createImageUpload",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+      mimeType: z.string(),
+    }),
+  ]),
+  z
+    .object({
+      publicUrl: z.string(),
+      uploadUrl: z.string(),
+      fields: z.record(z.string(), z.string()),
+    })
+    .optional(),
+);

--- a/imports/methods/createDocumentImageUpload.ts
+++ b/imports/methods/createDocumentImageUpload.ts
@@ -1,7 +1,20 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  { documentId: string; filename: string; mimeType: string },
-  | { publicUrl: string; uploadUrl: string; fields: Record<string, string> }
-  | undefined
->("Documents.methods.createImageUpload");
+export default new TypedMethod(
+  "Documents.methods.createImageUpload",
+  z.tuple([
+    z.strictObject({
+      documentId: z.string(),
+      filename: z.string(),
+      mimeType: z.string(),
+    }),
+  ]),
+  z
+    .object({
+      publicUrl: z.string(),
+      uploadUrl: z.string(),
+      fields: z.record(z.string(), z.string()),
+    })
+    .optional(),
+);

--- a/imports/methods/createFixtureHunt.ts
+++ b/imports/methods/createFixtureHunt.ts
@@ -1,3 +1,8 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<void, void>("Hunts.methods.createFixture");
+export default new TypedMethod(
+  "Hunts.methods.createFixture",
+  z.tuple([]),
+  z.void(),
+);

--- a/imports/methods/createGuess.ts
+++ b/imports/methods/createGuess.ts
@@ -1,11 +1,15 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  {
-    puzzleId: string;
-    guess: string;
-    direction: number;
-    confidence: number;
-  },
-  string
->("Guesses.method.create");
+export default new TypedMethod(
+  "Guesses.method.create",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+      guess: z.string(),
+      direction: z.number(),
+      confidence: z.number(),
+    }),
+  ]),
+  z.string(),
+);

--- a/imports/methods/createHunt.ts
+++ b/imports/methods/createHunt.ts
@@ -1,6 +1,9 @@
-import type { EditableHuntType } from "../lib/models/Hunts";
+import z from "zod";
+import { EditableHunt } from "../lib/models/Hunts";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<EditableHuntType, string>(
+export default new TypedMethod(
   "Hunts.methods.create",
+  z.tuple([EditableHunt]),
+  z.string(),
 );

--- a/imports/methods/createPuzzle.ts
+++ b/imports/methods/createPuzzle.ts
@@ -1,16 +1,22 @@
-import type { GdriveMimeTypesType } from "../lib/GdriveMimeTypes";
+import z from "zod";
+import GdriveMimeTypes from "../lib/GdriveMimeTypes";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  {
-    huntId: string;
-    title: string;
-    url?: string;
-    tags: string[];
-    expectedAnswerCount: number;
-    docType: GdriveMimeTypesType;
-    allowDuplicateUrls?: boolean;
-    completedWithNoAnswer?: boolean;
-  },
-  string
->("Puzzles.methods.create");
+export default new TypedMethod(
+  "Puzzles.methods.create",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+      title: z.string(),
+      url: z.string().optional(),
+      tags: z.string().array(),
+      expectedAnswerCount: z.number(),
+      docType: z.enum(
+        Object.keys(GdriveMimeTypes) as (keyof typeof GdriveMimeTypes)[],
+      ),
+      allowDuplicateUrls: z.boolean().optional(),
+      completedWithNoAnswer: z.boolean().optional(),
+    }),
+  ]),
+  z.string(),
+);

--- a/imports/methods/demoteOperator.ts
+++ b/imports/methods/demoteOperator.ts
@@ -1,5 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ targetUserId: string; huntId: string }, void>(
+export default new TypedMethod(
   "Users.method.demoteOperator",
+  z.tuple([
+    z.strictObject({
+      targetUserId: z.string(),
+      huntId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/destroyAPIKey.ts
+++ b/imports/methods/destroyAPIKey.ts
@@ -1,9 +1,15 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  {
-    apiKeyId: string; // the _id, not the key itself
-    forUser?: string; // If provided, the user who owns the API key
-  },
-  void
->("APIKeys.method.destroy");
+export default new TypedMethod(
+  "APIKeys.method.destroy",
+  z.tuple([
+    z.strictObject({
+      // the _id, not the key itself
+      apiKeyId: z.string(),
+      // If provided, the user who owns the API key
+      forUser: z.string().optional(),
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/destroyHunt.ts
+++ b/imports/methods/destroyHunt.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ huntId: string }, void>(
+export default new TypedMethod(
   "Hunts.methods.destroy",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/destroyPuzzle.ts
+++ b/imports/methods/destroyPuzzle.ts
@@ -1,10 +1,14 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  {
-    puzzleId: string;
-    replacedBy?: string;
-    copySheetsToReplacement: boolean;
-  },
-  void
->("Puzzles.methods.destroy");
+export default new TypedMethod(
+  "Puzzles.methods.destroy",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+      replacedBy: z.string().optional(),
+      copySheetsToReplacement: z.boolean(),
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/dismissBookmarkNotification.ts
+++ b/imports/methods/dismissBookmarkNotification.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ bookmarkNotificationId: string }, void>(
+export default new TypedMethod(
   "BookmarkNotifications.methods.dismiss",
+  z.tuple([
+    z.strictObject({
+      bookmarkNotificationId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/dismissChatNotification.ts
+++ b/imports/methods/dismissChatNotification.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ chatNotificationId: string }, void>(
+export default new TypedMethod(
   "ChatNotifications.methods.dismiss",
+  z.tuple([
+    z.strictObject({
+      chatNotificationId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/dismissPendingAnnouncement.ts
+++ b/imports/methods/dismissPendingAnnouncement.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ pendingAnnouncementId: string }, void>(
+export default new TypedMethod(
   "PendingAnnouncements.methods.dismiss",
+  z.tuple([
+    z.strictObject({
+      pendingAnnouncementId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/ensurePuzzleDocument.ts
+++ b/imports/methods/ensurePuzzleDocument.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ puzzleId: string }, void>(
+export default new TypedMethod(
   "Puzzles.methods.ensureDocument",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/generateHuntInvitationCode.ts
+++ b/imports/methods/generateHuntInvitationCode.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ huntId: string }, string>(
+export default new TypedMethod(
   "Hunts.methods.generateHuntInvitationCode",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+    }),
+  ]),
+  z.string(),
 );

--- a/imports/methods/generateUploadToken.ts
+++ b/imports/methods/generateUploadToken.ts
@@ -1,6 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  { assetName: string; assetMimeType: string },
-  string
->("UploadTokens.methods.generate");
+export default new TypedMethod(
+  "UploadTokens.methods.generate",
+  z.tuple([
+    z.strictObject({
+      assetName: z.string(),
+      assetMimeType: z.string(),
+    }),
+  ]),
+  z.string(),
+);

--- a/imports/methods/insertDocumentImage.ts
+++ b/imports/methods/insertDocumentImage.ts
@@ -1,19 +1,29 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-type UploadImageSource = {
-  source: "upload";
-  filename: string;
-  contents: string /* base64-encoded data url */;
-};
+const UploadImageSource = z.strictObject({
+  source: z.literal("upload"),
+  filename: z.string(),
+  // base64-encoded data url
+  contents: z.string(),
+});
 
-type LinkImageSource = {
-  source: "link";
-  url: string;
-};
+const LinkImageSource = z.strictObject({
+  source: z.literal("link"),
+  url: z.string(),
+});
 
-export type ImageSource = UploadImageSource | LinkImageSource;
+const ImageSource = z.union([UploadImageSource, LinkImageSource]);
+export type ImageSource = z.infer<typeof ImageSource>;
 
-export default new TypedMethod<
-  { documentId: string; sheetId: number; image: ImageSource },
-  void
->("Documents.methods.insertImage");
+export default new TypedMethod(
+  "Documents.methods.insertImage",
+  z.tuple([
+    z.strictObject({
+      documentId: z.string(),
+      sheetId: z.number(),
+      image: ImageSource,
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/linkUserDiscordAccount.ts
+++ b/imports/methods/linkUserDiscordAccount.ts
@@ -1,5 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ key: string; secret: string }, void>(
+export default new TypedMethod(
   "Users.methods.linkDiscordAccount",
+  z.tuple([
+    z.strictObject({
+      key: z.string(),
+      secret: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/linkUserGoogleAccount.ts
+++ b/imports/methods/linkUserGoogleAccount.ts
@@ -1,5 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ key: string; secret: string }, void>(
+export default new TypedMethod(
   "Users.methods.linkGoogleAccount",
+  z.tuple([
+    z.strictObject({
+      key: z.string(),
+      secret: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/listDocumentSheets.ts
+++ b/imports/methods/listDocumentSheets.ts
@@ -1,10 +1,18 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export type Sheet = {
-  name: string;
-  id: number;
-};
+const Sheet = z.object({
+  name: z.string(),
+  id: z.number(),
+});
+export type Sheet = z.infer<typeof Sheet>;
 
-export default new TypedMethod<{ documentId: string }, Sheet[]>(
+export default new TypedMethod(
   "Documents.methods.listSheets",
+  z.tuple([
+    z.strictObject({
+      documentId: z.string(),
+    }),
+  ]),
+  Sheet.array(),
 );

--- a/imports/methods/makeUserEmailPrimary.ts
+++ b/imports/methods/makeUserEmailPrimary.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ email: string }, void>(
+export default new TypedMethod(
   "Users.methods.makeUserEmailPrimary",
+  z.tuple([
+    z.strictObject({
+      email: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/mediasoupAckConsumer.ts
+++ b/imports/methods/mediasoupAckConsumer.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ consumerId: string }, void>(
+export default new TypedMethod(
   "Mediasoup.Consumers.methods.ack",
+  z.tuple([
+    z.strictObject({
+      consumerId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/mediasoupAckPeerRemoteMute.ts
+++ b/imports/methods/mediasoupAckPeerRemoteMute.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ peerId: string }, void>(
+export default new TypedMethod(
   "Mediasoup.Peers.methods.ackRemoteMute",
+  z.tuple([
+    z.strictObject({
+      peerId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/mediasoupConnectTransport.ts
+++ b/imports/methods/mediasoupConnectTransport.ts
@@ -1,6 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  { transportId: string; dtlsParameters: string },
-  void
->("Mediasoup.Transports.methods.connect");
+export default new TypedMethod(
+  "Mediasoup.Transports.methods.connect",
+  z.tuple([
+    z.strictObject({
+      transportId: z.string(),
+      dtlsParameters: z.string(),
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/mediasoupRemoteMutePeer.ts
+++ b/imports/methods/mediasoupRemoteMutePeer.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ peerId: string }, void>(
+export default new TypedMethod(
   "Mediasoup.Peers.methods.remoteMute",
+  z.tuple([
+    z.strictObject({
+      peerId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/mediasoupSetPeerState.ts
+++ b/imports/methods/mediasoupSetPeerState.ts
@@ -1,3 +1,4 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
 // The three participant states permitted by setMediasoupPeerState fan out to two
@@ -11,7 +12,13 @@ import TypedMethod from "./TypedMethod";
 // --------+--------+-------+----------+
 export const ALLOWED_STATES = ["active", "muted", "deafened"] as const;
 
-export default new TypedMethod<
-  { peerId: string; state: (typeof ALLOWED_STATES)[number] },
-  void
->("Mediasoup.Peers.methods.setState");
+export default new TypedMethod(
+  "Mediasoup.Peers.methods.setState",
+  z.tuple([
+    z.strictObject({
+      peerId: z.string(),
+      state: z.enum(ALLOWED_STATES),
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/mediasoupSetProducerPaused.ts
+++ b/imports/methods/mediasoupSetProducerPaused.ts
@@ -1,6 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  { mediasoupProducerId: string; paused: boolean },
-  void
->("Mediasoup.ProducerClients.methods.setPaused");
+export default new TypedMethod(
+  "Mediasoup.ProducerClients.methods.setPaused",
+  z.tuple([
+    z.strictObject({
+      mediasoupProducerId: z.string(),
+      paused: z.boolean(),
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/postAnnouncement.ts
+++ b/imports/methods/postAnnouncement.ts
@@ -1,5 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ huntId: string; message: string }, void>(
+export default new TypedMethod(
   "Announcements.methods.post",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+      message: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/promoteOperator.ts
+++ b/imports/methods/promoteOperator.ts
@@ -1,5 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ targetUserId: string; huntId: string }, void>(
+export default new TypedMethod(
   "Users.method.promoteOperator",
+  z.tuple([
+    z.strictObject({
+      targetUserId: z.string(),
+      huntId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/provisionFirstUser.ts
+++ b/imports/methods/provisionFirstUser.ts
@@ -1,9 +1,17 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
 // Allow creating the first user and making them an admin by virtue of being the
 // first to show up at the server and call this method.  Assume that if someone
 // else beats you to this on your own infra, you'll burn it to the ground and
 // try again.
-export default new TypedMethod<{ email: string; password: string }, void>(
+export default new TypedMethod(
   "Users.methods.provisionFirst",
+  z.tuple([
+    z.strictObject({
+      email: z.string(),
+      password: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/provisionScreenshotData.ts
+++ b/imports/methods/provisionScreenshotData.ts
@@ -1,3 +1,8 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<void, void>("Screenshots.methods.provisionData");
+export default new TypedMethod(
+  "Screenshots.methods.provisionData",
+  z.tuple([]),
+  z.void(),
+);

--- a/imports/methods/purgeHunt.ts
+++ b/imports/methods/purgeHunt.ts
@@ -1,3 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ huntId: string }, void>("Hunts.methods.purge");
+export default new TypedMethod(
+  "Hunts.methods.purge",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/removePuzzleAnswer.ts
+++ b/imports/methods/removePuzzleAnswer.ts
@@ -1,5 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ puzzleId: string; guessId: string }, void>(
+export default new TypedMethod(
   "Puzzles.methods.removeAnswer",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+      guessId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/removePuzzleTag.ts
+++ b/imports/methods/removePuzzleTag.ts
@@ -1,7 +1,15 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
 // Note that removePuzzleTag takes a tagId rather than a tag name, since the
 // client should already know the tagId.
-export default new TypedMethod<{ puzzleId: string; tagId: string }, void>(
+export default new TypedMethod(
   "Puzzles.methods.removeTag",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+      tagId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/removeUserAccountEmail.ts
+++ b/imports/methods/removeUserAccountEmail.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ email: string }, void>(
+export default new TypedMethod(
   "Users.methods.removeUserAccountEmail",
+  z.tuple([
+    z.strictObject({
+      email: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/renameTag.ts
+++ b/imports/methods/renameTag.ts
@@ -1,5 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ tagId: string; name: string }, void>(
+export default new TypedMethod(
   "Tags.methods.rename",
+  z.tuple([
+    z.strictObject({
+      tagId: z.string(),
+      name: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/sendChatMessage.ts
+++ b/imports/methods/sendChatMessage.ts
@@ -1,9 +1,13 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  {
-    puzzleId: string;
-    content: string;
-  },
-  void
->("ChatMessages.methods.send");
+export default new TypedMethod(
+  "ChatMessages.methods.send",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+      content: z.string(),
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/sendUserVerificationEmail.ts
+++ b/imports/methods/sendUserVerificationEmail.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ email: string }, void>(
+export default new TypedMethod(
   "Users.methods.sendUserVerificationEmail",
+  z.tuple([
+    z.strictObject({
+      email: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/setFeatureFlag.ts
+++ b/imports/methods/setFeatureFlag.ts
@@ -1,11 +1,14 @@
-import type { FlagNames } from "../lib/models/FeatureFlags";
+import z from "zod";
+import { FlagNames } from "../lib/models/FeatureFlags";
 import TypedMethod from "./TypedMethod";
 
-type SetFeatureFlagArgs = {
-  name: (typeof FlagNames)[number];
-  type: "on" | "off";
-};
-
-export default new TypedMethod<SetFeatureFlagArgs, void>(
+export default new TypedMethod(
   "FeatureFlags.methods.set",
+  z.tuple([
+    z.strictObject({
+      name: z.enum(FlagNames),
+      type: z.enum(["off", "on"]),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/setGuessState.ts
+++ b/imports/methods/setGuessState.ts
@@ -1,11 +1,15 @@
-import type { GuessType } from "../lib/models/Guesses";
+import z from "zod";
+import { GuessStates } from "../lib/models/Guesses";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  {
-    guessId: string;
-    state: GuessType["state"];
-    additionalNotes?: string;
-  },
-  void
->("Guesses.methods.setState");
+export default new TypedMethod(
+  "Guesses.methods.setState",
+  z.tuple([
+    z.strictObject({
+      guessId: z.string(),
+      state: GuessStates,
+      additionalNotes: z.string().optional(),
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/syncHuntDiscordRole.ts
+++ b/imports/methods/syncHuntDiscordRole.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ huntId: string }, void>(
+export default new TypedMethod(
   "Hunts.methods.syncDiscordRole",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/undestroyHunt.ts
+++ b/imports/methods/undestroyHunt.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ huntId: string }, void>(
+export default new TypedMethod(
   "Hunts.methods.undestroy",
+  z.tuple([
+    z.strictObject({
+      huntId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/undestroyPuzzle.ts
+++ b/imports/methods/undestroyPuzzle.ts
@@ -1,5 +1,12 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<{ puzzleId: string }, void>(
+export default new TypedMethod(
   "Puzzles.methods.undestroy",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+    }),
+  ]),
+  z.void(),
 );

--- a/imports/methods/unlinkUserDiscordAccount.ts
+++ b/imports/methods/unlinkUserDiscordAccount.ts
@@ -1,5 +1,8 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<void, void>(
+export default new TypedMethod(
   "Users.methods.unlinkDiscordAccount",
+  z.tuple([]),
+  z.void(),
 );

--- a/imports/methods/unlinkUserGoogleAccount.ts
+++ b/imports/methods/unlinkUserGoogleAccount.ts
@@ -1,3 +1,8 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<void, void>("Users.methods.unlinkGoogleAccount");
+export default new TypedMethod(
+  "Users.methods.unlinkGoogleAccount",
+  z.tuple([]),
+  z.void(),
+);

--- a/imports/methods/updateHunt.ts
+++ b/imports/methods/updateHunt.ts
@@ -1,7 +1,9 @@
-import type { EditableHuntType } from "../lib/models/Hunts";
+import z from "zod";
+import { EditableHunt } from "../lib/models/Hunts";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  { huntId: string; value: EditableHuntType },
-  void
->("Hunts.methods.update");
+export default new TypedMethod(
+  "Hunts.methods.update",
+  z.tuple([z.strictObject({ huntId: z.string(), value: EditableHunt })]),
+  z.void(),
+);

--- a/imports/methods/updateProfile.ts
+++ b/imports/methods/updateProfile.ts
@@ -1,15 +1,19 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  {
-    displayName: string;
-    phoneNumber?: string;
-    dingwords: string[];
-    // If provided, identifies the user by enrollment token instead of
-    // requiring a logged-in session. This allows updateProfile to be called
-    // before Accounts.resetPassword consumes the token, making the
-    // enrollment flow resilient to method retries on connection drops.
-    enrollmentToken?: string;
-  },
-  void
->("Users.methods.updateProfile");
+export default new TypedMethod(
+  "Users.methods.updateProfile",
+  z.tuple([
+    z.strictObject({
+      displayName: z.string(),
+      phoneNumber: z.string().optional(),
+      dingwords: z.string().array(),
+      // If provided, identifies the user by enrollment token instead of
+      // requiring a logged-in session. This allows updateProfile to be called
+      // before Accounts.resetPassword consumes the token, making the
+      // enrollment flow resilient to method retries on connection drops.
+      enrollmentToken: z.string().optional(),
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/updatePuzzle.ts
+++ b/imports/methods/updatePuzzle.ts
@@ -1,14 +1,21 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export default new TypedMethod<
-  {
-    puzzleId: string;
-    title: string;
-    url?: string;
-    tags: string[];
-    expectedAnswerCount: number;
-    allowDuplicateUrls?: boolean;
-    completedWithNoAnswer?: boolean;
-  },
-  void
->("Puzzles.methods.update");
+export default new TypedMethod(
+  "Puzzles.methods.update",
+  z.tuple([
+    z.strictObject({
+      puzzleId: z.string(),
+      title: z.string(),
+      url: z.string().optional(),
+      tags: z.string().array(),
+      expectedAnswerCount: z.number(),
+      // We accept this argument since it's provided by the form, but it's not
+      // checked here - only during puzzle creation, to avoid duplicates when
+      // creating new puzzles.
+      allowDuplicateUrls: z.boolean().optional(),
+      completedWithNoAnswer: z.boolean().optional(),
+    }),
+  ]),
+  z.void(),
+);

--- a/imports/methods/userLoginOptions.ts
+++ b/imports/methods/userLoginOptions.ts
@@ -1,11 +1,19 @@
+import z from "zod";
 import TypedMethod from "./TypedMethod";
 
-export type UserLoginOptionsResult = {
-  exists: boolean;
-  loginMethods?: string[];
-};
+const UserLoginOptionsResult = z.object({
+  exists: z.boolean(),
+  loginMethods: z.string().array().optional(),
+});
+export type UserLoginOptionsResult = z.infer<typeof UserLoginOptionsResult>;
 
-export default new TypedMethod<
-  { email: string; invitationCode: string },
-  UserLoginOptionsResult
->("Users.methods.loginOptions");
+export default new TypedMethod(
+  "Users.methods.loginOptions",
+  z.tuple([
+    z.strictObject({
+      email: z.string(),
+      invitationCode: z.string(),
+    }),
+  ]),
+  UserLoginOptionsResult,
+);

--- a/imports/server/assertStrictSchema.ts
+++ b/imports/server/assertStrictSchema.ts
@@ -1,0 +1,116 @@
+import type { $ZodType, $ZodTypes } from "zod/v4/core";
+
+// Zod's default object schema (z.object) silently discards unrecognized keys,
+// which would hide client bugs like misspelled argument names. We require all
+// objects to have a catchall (probably by using strictObject, but another
+// validator would theoretically be fine).
+export default function assertStrictSchema(schema: $ZodType, context: string) {
+  const visited = new Set<$ZodType>();
+
+  const walk = (raw: $ZodType, path: string) => {
+    if (visited.has(raw)) return;
+    visited.add(raw);
+
+    // This is the documented way to traverse a schema
+    const node = raw as unknown as $ZodTypes;
+    const { def } = node._zod;
+
+    switch (def.type) {
+      case "object":
+        if (def.catchall === undefined) {
+          throw new Error(
+            `${context}: non-strict object schema at ${path}; use z.strictObject`,
+          );
+        }
+        for (const [key, field] of Object.entries(def.shape)) {
+          walk(field, `${path}.${key}`);
+        }
+        walk(def.catchall, `${path}[catchall]`);
+        break;
+
+      case "tuple":
+        def.items.forEach((item, index) => walk(item, `${path}[${index}]`));
+        if (def.rest) {
+          walk(def.rest, `${path}[rest]`);
+        }
+        break;
+
+      case "array":
+        walk(def.element, `${path}[]`);
+        break;
+
+      case "union":
+        def.options.forEach((option, index) =>
+          walk(option, `${path}[option ${index}]`),
+        );
+        break;
+
+      case "intersection":
+        walk(def.left, `${path}[left]`);
+        walk(def.right, `${path}[right]`);
+        break;
+
+      case "record":
+      case "map":
+        walk(def.keyType, `${path}[key]`);
+        walk(def.valueType, `${path}[value]`);
+        break;
+
+      case "set":
+        walk(def.valueType, `${path}[value]`);
+        break;
+
+      case "optional":
+      case "nullable":
+      case "default":
+      case "prefault":
+      case "nonoptional":
+      case "readonly":
+      case "catch":
+      case "success":
+      case "promise":
+        walk(def.innerType, path);
+        break;
+
+      case "lazy":
+        walk(def.getter(), path);
+        break;
+
+      case "pipe":
+        walk(def.in, `${path}[in]`);
+        walk(def.out, `${path}[out]`);
+        break;
+
+      // Leaf types that can't contain an object schema
+      case "string":
+      case "number":
+      case "bigint":
+      case "boolean":
+      case "date":
+      case "symbol":
+      case "null":
+      case "undefined":
+      case "void":
+      case "never":
+      case "any":
+      case "unknown":
+      case "nan":
+      case "enum":
+      case "literal":
+      case "template_literal":
+      case "file":
+      case "transform":
+      case "custom":
+        break;
+
+      default:
+        // Fail loud rather than silently skipping a schema type (a future
+        // wrapper could hide a strip-mode object from this audit).
+        throw new Error(
+          `${context}: unrecognized schema type ${def.type} at ${path}`,
+        );
+    }
+  };
+
+  walk(schema, "args");
+}

--- a/imports/server/methods/acceptHuntInvitationCode.ts
+++ b/imports/server/methods/acceptHuntInvitationCode.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Hunts from "../../lib/models/Hunts";
 import InvitationCodes from "../../lib/models/InvitationCodes";
@@ -9,14 +9,6 @@ import addUserToHunt from "../addUserToHunt";
 import defineMethod from "./defineMethod";
 
 defineMethod(acceptHuntInvitationCode, {
-  validate(arg) {
-    check(arg, {
-      invitationCode: String,
-      email: Match.Optional(String),
-    });
-    return arg;
-  },
-
   async run({ invitationCode, email }): Promise<string> {
     // Note: this method can be called either by a logged-in user without the `email` arg,
     // or by a logged-out user to use the invitation code to send themselves an invite via email.

--- a/imports/server/methods/acceptUserHuntTerms.ts
+++ b/imports/server/methods/acceptUserHuntTerms.ts
@@ -4,12 +4,6 @@ import acceptUserHuntTerms from "../../methods/acceptUserHuntTerms";
 import defineMethod from "./defineMethod";
 
 defineMethod(acceptUserHuntTerms, {
-  validate(arg) {
-    check(arg, { huntId: String });
-
-    return arg;
-  },
-
   async run({ huntId }) {
     check(this.userId, String);
     await MeteorUsers.updateAsync(this.userId, {

--- a/imports/server/methods/addHuntUser.ts
+++ b/imports/server/methods/addHuntUser.ts
@@ -8,14 +8,6 @@ import addUserToHunt from "../addUserToHunt";
 import defineMethod from "./defineMethod";
 
 defineMethod(addHuntUser, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-      email: String,
-    });
-    return arg;
-  },
-
   async run({ huntId, email }) {
     check(this.userId, String);
 

--- a/imports/server/methods/addPuzzleAnswer.ts
+++ b/imports/server/methods/addPuzzleAnswer.ts
@@ -14,14 +14,6 @@ import sendChatMessageInternal from "../sendChatMessageInternal";
 import defineMethod from "./defineMethod";
 
 defineMethod(addPuzzleAnswer, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-      answer: String,
-    });
-    return arg;
-  },
-
   async run({ puzzleId, answer: rawAnswer }) {
     check(this.userId, String);
 

--- a/imports/server/methods/addPuzzleTag.ts
+++ b/imports/server/methods/addPuzzleTag.ts
@@ -7,15 +7,6 @@ import getOrCreateTagByName from "../getOrCreateTagByName";
 import defineMethod from "./defineMethod";
 
 defineMethod(addPuzzleTag, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-      tagName: String,
-    });
-
-    return arg;
-  },
-
   async run({ puzzleId, tagName }) {
     check(this.userId, String);
 

--- a/imports/server/methods/addUserAccountEmail.ts
+++ b/imports/server/methods/addUserAccountEmail.ts
@@ -8,11 +8,6 @@ import checkVerificationEmailCooldown from "../checkVerificationEmailCooldown";
 import defineMethod from "./defineMethod";
 
 defineMethod(addUserAccountEmail, {
-  validate(arg) {
-    check(arg, { email: String });
-    return arg;
-  },
-
   async run({ email }) {
     check(this.userId, String);
 

--- a/imports/server/methods/bookmarkPuzzle.ts
+++ b/imports/server/methods/bookmarkPuzzle.ts
@@ -7,14 +7,6 @@ import ignoringDuplicateKeyErrors from "../ignoringDuplicateKeyErrors";
 import defineMethod from "./defineMethod";
 
 defineMethod(bookmarkPuzzle, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-      bookmark: Boolean,
-    });
-    return arg;
-  },
-
   async run({ puzzleId, bookmark }) {
     check(this.userId, String);
 

--- a/imports/server/methods/bulkAddHuntUsers.ts
+++ b/imports/server/methods/bulkAddHuntUsers.ts
@@ -8,14 +8,6 @@ import addUserToHunt from "../addUserToHunt";
 import defineMethod from "./defineMethod";
 
 defineMethod(bulkAddHuntUsers, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-      emails: [String],
-    });
-    return arg;
-  },
-
   async run({ huntId, emails }) {
     const { userId } = this;
     check(userId, String);

--- a/imports/server/methods/clearHuntInvitationCode.ts
+++ b/imports/server/methods/clearHuntInvitationCode.ts
@@ -10,13 +10,6 @@ import defineMethod from "./defineMethod";
 
 // Clear the invitation code for the given hunt.
 defineMethod(clearHuntInvitationCode, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-    });
-    return arg;
-  },
-
   async run({ huntId }) {
     check(this.userId, String);
 

--- a/imports/server/methods/configureDiscordBot.ts
+++ b/imports/server/methods/configureDiscordBot.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Logger from "../../Logger";
 import MeteorUsers from "../../lib/models/MeteorUsers";
@@ -8,13 +8,6 @@ import configureDiscordBot from "../../methods/configureDiscordBot";
 import defineMethod from "./defineMethod";
 
 defineMethod(configureDiscordBot, {
-  validate(arg) {
-    check(arg, {
-      token: Match.Optional(String),
-    });
-    return arg;
-  },
-
   async run({ token }) {
     check(this.userId, String);
 

--- a/imports/server/methods/configureDiscordBotGuild.ts
+++ b/imports/server/methods/configureDiscordBotGuild.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Logger from "../../Logger";
 import MeteorUsers from "../../lib/models/MeteorUsers";
@@ -8,16 +8,6 @@ import configureDiscordBotGuild from "../../methods/configureDiscordBotGuild";
 import defineMethod from "./defineMethod";
 
 defineMethod(configureDiscordBotGuild, {
-  validate(arg) {
-    check(arg, {
-      guild: Match.Optional({
-        id: String,
-        name: String,
-      }),
-    });
-    return arg;
-  },
-
   async run({ guild }) {
     check(this.userId, String);
 

--- a/imports/server/methods/configureDiscordOAuthClient.ts
+++ b/imports/server/methods/configureDiscordOAuthClient.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import { ServiceConfiguration } from "meteor/service-configuration";
 import Logger from "../../Logger";
@@ -9,14 +9,6 @@ import configureDiscordOAuthClient from "../../methods/configureDiscordOAuthClie
 import defineMethod from "./defineMethod";
 
 defineMethod(configureDiscordOAuthClient, {
-  validate(arg) {
-    check(arg, {
-      clientId: Match.Optional(String),
-      clientSecret: Match.Optional(String),
-    });
-    return arg;
-  },
-
   async run({ clientId, clientSecret }) {
     check(this.userId, String);
 

--- a/imports/server/methods/configureEmailBranding.ts
+++ b/imports/server/methods/configureEmailBranding.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import Settings from "../../lib/models/Settings";
@@ -7,17 +7,6 @@ import configureEmailBranding from "../../methods/configureEmailBranding";
 import defineMethod from "./defineMethod";
 
 defineMethod(configureEmailBranding, {
-  validate(arg) {
-    check(arg, {
-      from: Match.Optional(String),
-      enrollSubject: Match.Optional(String),
-      enrollMessage: Match.Optional(String),
-      joinSubject: Match.Optional(String),
-      joinMessage: Match.Optional(String),
-    });
-    return arg;
-  },
-
   async run({ from, enrollSubject, enrollMessage, joinSubject, joinMessage }) {
     check(this.userId, String);
     if (

--- a/imports/server/methods/configureGdriveCreds.ts
+++ b/imports/server/methods/configureGdriveCreds.ts
@@ -9,14 +9,6 @@ import configureGdriveCreds from "../../methods/configureGdriveCreds";
 import defineMethod from "./defineMethod";
 
 defineMethod(configureGdriveCreds, {
-  validate(arg) {
-    check(arg, {
-      key: String,
-      secret: String,
-    });
-    return arg;
-  },
-
   async run({ key, secret }) {
     check(this.userId, String);
 

--- a/imports/server/methods/configureGdriveRoot.ts
+++ b/imports/server/methods/configureGdriveRoot.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import Settings from "../../lib/models/Settings";
@@ -7,13 +7,6 @@ import configureGdriveRoot from "../../methods/configureGdriveRoot";
 import defineMethod from "./defineMethod";
 
 defineMethod(configureGdriveRoot, {
-  validate(arg) {
-    check(arg, {
-      root: Match.Optional(String),
-    });
-    return arg;
-  },
-
   async run({ root }) {
     check(this.userId, String);
 

--- a/imports/server/methods/configureGdriveTemplates.ts
+++ b/imports/server/methods/configureGdriveTemplates.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import Settings from "../../lib/models/Settings";
@@ -7,14 +7,6 @@ import configureGdriveTemplates from "../../methods/configureGdriveTemplates";
 import defineMethod from "./defineMethod";
 
 defineMethod(configureGdriveTemplates, {
-  validate(arg) {
-    check(arg, {
-      spreadsheetTemplate: Match.Optional(String),
-      documentTemplate: Match.Optional(String),
-    });
-    return arg;
-  },
-
   async run({ spreadsheetTemplate, documentTemplate }) {
     check(this.userId, String);
 

--- a/imports/server/methods/configureGoogleOAuthClient.ts
+++ b/imports/server/methods/configureGoogleOAuthClient.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import { ServiceConfiguration } from "meteor/service-configuration";
 import Logger from "../../Logger";
@@ -8,14 +8,6 @@ import configureGoogleOAuthClient from "../../methods/configureGoogleOAuthClient
 import defineMethod from "./defineMethod";
 
 defineMethod(configureGoogleOAuthClient, {
-  validate(arg) {
-    check(arg, {
-      clientId: Match.Optional(String),
-      secret: Match.Optional(String),
-    });
-    return arg;
-  },
-
   async run({ clientId, secret }) {
     check(this.userId, String);
 

--- a/imports/server/methods/configureGoogleScriptUrl.ts
+++ b/imports/server/methods/configureGoogleScriptUrl.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Logger from "../../Logger";
 import MeteorUsers from "../../lib/models/MeteorUsers";
@@ -8,13 +8,6 @@ import configureGoogleScriptUrl from "../../methods/configureGoogleScriptUrl";
 import defineMethod from "./defineMethod";
 
 defineMethod(configureGoogleScriptUrl, {
-  validate(arg) {
-    check(arg, {
-      url: Match.Optional(String),
-    });
-    return arg;
-  },
-
   async run({ url }) {
     check(this.userId, String);
     checkAdmin(await MeteorUsers.findOneAsync(this.userId));

--- a/imports/server/methods/configureListS3Buckets.ts
+++ b/imports/server/methods/configureListS3Buckets.ts
@@ -18,7 +18,9 @@ defineMethod(configureListS3Buckets, {
     try {
       const s3 = new S3Client();
       const buckets = await s3.send(new ListBucketsCommand({}));
-      return buckets.Buckets?.map((b) => b.Name) ?? [];
+      return (
+        buckets.Buckets?.map((b) => b.Name).filter((n) => n !== undefined) ?? []
+      );
     } catch (e) {
       // This probably means something is wrong with our AWS credentials
       Logger.warn("Unable to list S3 buckets", { error: e });

--- a/imports/server/methods/configureS3ImageBucket.ts
+++ b/imports/server/methods/configureS3ImageBucket.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import { Random } from "meteor/random";
 import {
@@ -14,13 +14,6 @@ import configureS3ImageBucket from "../../methods/configureS3ImageBucket";
 import defineMethod from "./defineMethod";
 
 defineMethod(configureS3ImageBucket, {
-  validate(arg) {
-    check(arg, {
-      bucketName: Match.Optional(String),
-    });
-    return arg;
-  },
-
   async run({ bucketName }) {
     check(this.userId, String);
 

--- a/imports/server/methods/configureServerLanguage.ts
+++ b/imports/server/methods/configureServerLanguage.ts
@@ -7,13 +7,6 @@ import configureServerLanguage from "../../methods/configureServerLanguage";
 import defineMethod from "./defineMethod";
 
 defineMethod(configureServerLanguage, {
-  validate(arg) {
-    check(arg, {
-      language: String,
-    });
-    return arg;
-  },
-
   async run({ language }) {
     check(this.userId, String);
     if (

--- a/imports/server/methods/configureTeamName.ts
+++ b/imports/server/methods/configureTeamName.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import Settings from "../../lib/models/Settings";
@@ -7,13 +7,6 @@ import configureTeamName from "../../methods/configureTeamName";
 import defineMethod from "./defineMethod";
 
 defineMethod(configureTeamName, {
-  validate(arg) {
-    check(arg, {
-      teamName: Match.Optional(String),
-    });
-    return arg;
-  },
-
   async run({ teamName }) {
     check(this.userId, String);
     if (

--- a/imports/server/methods/confirmUserMerge.ts
+++ b/imports/server/methods/confirmUserMerge.ts
@@ -9,14 +9,6 @@ import enqueueJob from "../jobs/framework/enqueueJob";
 import defineMethod from "./defineMethod";
 
 defineMethod(confirmUserMerge, {
-  validate(arg) {
-    check(arg, {
-      sourceUser: String,
-      targetUser: String,
-    });
-    return arg;
-  },
-
   async run({ sourceUser, targetUser }) {
     check(this.userId, String);
 

--- a/imports/server/methods/createAPIKey.ts
+++ b/imports/server/methods/createAPIKey.ts
@@ -5,11 +5,6 @@ import createAPIKey from "../../methods/createAPIKey";
 import defineMethod from "./defineMethod";
 
 defineMethod(createAPIKey, {
-  validate(arg) {
-    check(arg, {});
-    return arg;
-  },
-
   async run() {
     check(this.userId, String);
 

--- a/imports/server/methods/createChatImageUpload.ts
+++ b/imports/server/methods/createChatImageUpload.ts
@@ -8,15 +8,6 @@ import getS3UploadParams from "../getS3UploadParams";
 import defineMethod from "./defineMethod";
 
 defineMethod(createChatImageUpload, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-      mimeType: String,
-    });
-
-    return arg;
-  },
-
   async run({ puzzleId, mimeType }) {
     check(this.userId, String);
 

--- a/imports/server/methods/createDocumentImageUpload.ts
+++ b/imports/server/methods/createDocumentImageUpload.ts
@@ -8,16 +8,6 @@ import getS3UploadParams from "../getS3UploadParams";
 import defineMethod from "./defineMethod";
 
 defineMethod(createDocumentImageUpload, {
-  validate(arg) {
-    check(arg, {
-      documentId: String,
-      filename: String,
-      mimeType: String,
-    });
-
-    return arg;
-  },
-
   async run({ documentId, filename, mimeType }) {
     check(this.userId, String);
     const user = (await MeteorUsers.findOneAsync(this.userId))!;

--- a/imports/server/methods/createGuess.ts
+++ b/imports/server/methods/createGuess.ts
@@ -10,16 +10,6 @@ import sendChatMessageInternal from "../sendChatMessageInternal";
 import defineMethod from "./defineMethod";
 
 defineMethod(createGuess, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-      guess: String,
-      direction: Number,
-      confidence: Number,
-    });
-    return arg;
-  },
-
   async run({ puzzleId, guess: rawGuess, direction, confidence }) {
     check(this.userId, String);
 

--- a/imports/server/methods/createHunt.ts
+++ b/imports/server/methods/createHunt.ts
@@ -1,7 +1,7 @@
 import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Logger from "../../Logger";
-import Hunts, { HuntPattern } from "../../lib/models/Hunts";
+import Hunts from "../../lib/models/Hunts";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import { addUserToRole, checkAdmin } from "../../lib/permission_stubs";
 import createHunt from "../../methods/createHunt";
@@ -24,11 +24,6 @@ const DEFAULT_TAGS = [
 ];
 
 defineMethod(createHunt, {
-  validate(arg) {
-    check(arg, HuntPattern);
-    return arg;
-  },
-
   async run(arg) {
     check(this.userId, String);
     checkAdmin(await MeteorUsers.findOneAsync(this.userId));

--- a/imports/server/methods/createPuzzle.ts
+++ b/imports/server/methods/createPuzzle.ts
@@ -1,27 +1,9 @@
-import { check, Match } from "meteor/check";
-import type { GdriveMimeTypesType } from "../../lib/GdriveMimeTypes";
-import GdriveMimeTypes from "../../lib/GdriveMimeTypes";
+import { check } from "meteor/check";
 import createPuzzle from "../../methods/createPuzzle";
 import addPuzzle from "../addPuzzle";
 import defineMethod from "./defineMethod";
 
 defineMethod(createPuzzle, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-      title: String,
-      url: Match.Optional(String),
-      tags: [String],
-      expectedAnswerCount: Number,
-      docType: Match.OneOf(
-        ...(Object.keys(GdriveMimeTypes) as GdriveMimeTypesType[]),
-      ),
-      allowDuplicateUrls: Match.Optional(Boolean),
-      completedWithNoAnswer: Match.Optional(Boolean),
-    });
-    return arg;
-  },
-
   run({
     huntId,
     title,

--- a/imports/server/methods/defineMethod.ts
+++ b/imports/server/methods/defineMethod.ts
@@ -1,64 +1,52 @@
+import { check, Match } from "meteor/check";
 import { EJSON } from "meteor/ejson";
 import { Meteor } from "meteor/meteor";
 import Bugsnag from "@bugsnag/js";
+import type z from "zod";
+import { ZodError } from "zod";
 import type TypedMethod from "../../methods/TypedMethod";
-import type {
-  TypedMethodArgs,
-  TypedMethodParam,
-} from "../../methods/TypedMethod";
+import assertStrictSchema from "../assertStrictSchema";
 
-type TypedMethodValidator<Arg extends TypedMethodArgs> = (
-  this: Meteor.MethodThisType,
-  arg0: unknown,
-) => Arg;
-type TypedMethodRun<
-  Arg extends TypedMethodArgs,
-  Return extends TypedMethodParam | void,
-> = Arg extends void
-  ? (this: Meteor.MethodThisType) => Return | Promise<Return>
-  : (this: Meteor.MethodThisType, arg0: Arg) => Return | Promise<Return>;
-
-const voidValidator = () => {
-  /* noop */
-};
-
-// Supporting methods with no (void) arguments is a bit messy, but comes up
-// often enough that it's worth doing properly. With no arguments, the type
-// system doesn't accept a validator. However, there's no way to access type
-// information at runtime, so when no validator is provided, we substitute
-// `voidValidator` at runtime (which explicitly discards any arguments, ensuring
-// that they aren't passed through to the `run` implementation).
-//
-// Ideally we'd declare the `validate` method in a way that it is absent for
-// void and present for non-void and subsequently check for the presence/absence
-// to hint to the type system whether or not we were dealing with a void method,
-// but I wasn't able to get the type system to make inference in that direction
-// (that the absence of a validate method implied void arguments), which just
-// made everything more awkward.
 export default function defineMethod<
-  Args extends TypedMethodArgs,
-  Return extends TypedMethodParam | void,
+  Args extends z.ZodTuple,
+  Return extends z.ZodType,
 >(
   method: TypedMethod<Args, Return>,
   {
-    validate,
     run,
   }: {
-    run: TypedMethodRun<Args, Return>;
-  } & (Args extends void
-    ? { validate?: undefined }
-    : { validate: TypedMethodValidator<Args> }),
+    run: (
+      this: Meteor.MethodThisType,
+      ...args: z.output<Args>
+    ) => z.input<Return> | Promise<z.input<Return>>;
+  },
 ) {
-  const validator = (validate ?? voidValidator) as TypedMethodValidator<Args>;
+  assertStrictSchema(method.args, `Method ${method.name}`);
 
   Meteor.methods({
-    async [method.name](arg0: Args) {
+    async [method.name](...args: unknown[]) {
+      // Silence audit-argument-checks; we'll do our own validation below.
+      check(args, [Match.Any]);
+
       try {
-        // In the case of no arguments, the type system will track the return
-        // value from `validate` as `void`, but because it's a function that
-        // doesn't return anything, it will in practice be `undefined`.
-        const validatedArgs = validator.bind(this)(arg0) as any;
-        return await run.bind(this)(validatedArgs);
+        const validatedArgs = await method.args
+          .parseAsync(args)
+          .catch((error: unknown) => {
+            // Attach a sanitized error to get serialized over DDP, but keep the
+            // original error for server-side reporting.
+            if (error instanceof ZodError) {
+              (
+                error as ZodError & { sanitizedError?: Meteor.Error }
+              ).sanitizedError = new Meteor.Error(
+                400,
+                `Invalid arguments to method ${method.name}`,
+              );
+            }
+            throw error;
+          });
+        const result = await run.apply(this, validatedArgs);
+        // (Don't sanitize - a badly formatted return value is a server bug)
+        return await method.return.parseAsync(result);
       } catch (error) {
         if (error instanceof Error && Bugsnag.isStarted()) {
           // Attempt to classify severity based on the following rules:
@@ -80,7 +68,7 @@ export default function defineMethod<
             event.context = method.name;
             event.severity = severity;
             event.addMetadata("method", {
-              arguments: EJSON.stringify(arg0 ?? {}),
+              arguments: EJSON.stringify({ args }),
             });
           });
         }

--- a/imports/server/methods/demoteOperator.ts
+++ b/imports/server/methods/demoteOperator.ts
@@ -11,14 +11,6 @@ import demoteOperator from "../../methods/demoteOperator";
 import defineMethod from "./defineMethod";
 
 defineMethod(demoteOperator, {
-  validate(arg) {
-    check(arg, {
-      targetUserId: String,
-      huntId: String,
-    });
-    return arg;
-  },
-
   async run({ targetUserId, huntId }) {
     check(this.userId, String);
 

--- a/imports/server/methods/destroyAPIKey.ts
+++ b/imports/server/methods/destroyAPIKey.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import APIKeys from "../../lib/models/APIKeys";
 import destroyAPIKey from "../../methods/destroyAPIKey";
@@ -6,11 +6,6 @@ import userForKeyOperation from "../userForKeyOperation";
 import defineMethod from "./defineMethod";
 
 defineMethod(destroyAPIKey, {
-  validate(arg) {
-    check(arg, { apiKeyId: String, forUser: Match.Optional(String) });
-    return arg;
-  },
-
   async run({ apiKeyId, forUser }) {
     check(this.userId, String);
 

--- a/imports/server/methods/destroyAPIKey.ts
+++ b/imports/server/methods/destroyAPIKey.ts
@@ -1,4 +1,4 @@
-import { check } from "meteor/check";
+import { check, Match } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import APIKeys from "../../lib/models/APIKeys";
 import destroyAPIKey from "../../methods/destroyAPIKey";
@@ -7,7 +7,7 @@ import defineMethod from "./defineMethod";
 
 defineMethod(destroyAPIKey, {
   validate(arg) {
-    check(arg, { apiKeyId: String });
+    check(arg, { apiKeyId: String, forUser: Match.Optional(String) });
     return arg;
   },
 

--- a/imports/server/methods/destroyHunt.ts
+++ b/imports/server/methods/destroyHunt.ts
@@ -6,11 +6,6 @@ import destroyHunt from "../../methods/destroyHunt";
 import defineMethod from "./defineMethod";
 
 defineMethod(destroyHunt, {
-  validate(arg) {
-    check(arg, { huntId: String });
-    return arg;
-  },
-
   async run({ huntId }) {
     check(this.userId, String);
     checkAdmin(await MeteorUsers.findOneAsync(this.userId));

--- a/imports/server/methods/destroyPuzzle.ts
+++ b/imports/server/methods/destroyPuzzle.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Flags from "../../Flags";
 import Documents from "../../lib/models/Documents";
@@ -11,15 +11,6 @@ import { copySheets, makeReadOnly } from "../gdrive";
 import defineMethod from "./defineMethod";
 
 defineMethod(destroyPuzzle, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-      replacedBy: Match.Optional(String),
-      copySheetsToReplacement: Boolean,
-    });
-    return arg;
-  },
-
   async run({ puzzleId, replacedBy, copySheetsToReplacement }) {
     check(this.userId, String);
 

--- a/imports/server/methods/dismissBookmarkNotification.ts
+++ b/imports/server/methods/dismissBookmarkNotification.ts
@@ -4,12 +4,6 @@ import dismissBookmarkNotification from "../../methods/dismissBookmarkNotificati
 import defineMethod from "./defineMethod";
 
 defineMethod(dismissBookmarkNotification, {
-  validate(arg) {
-    check(arg, { bookmarkNotificationId: String });
-
-    return arg;
-  },
-
   async run({ bookmarkNotificationId }) {
     check(this.userId, String);
 

--- a/imports/server/methods/dismissChatNotification.ts
+++ b/imports/server/methods/dismissChatNotification.ts
@@ -4,12 +4,6 @@ import dismissChatNotification from "../../methods/dismissChatNotification";
 import defineMethod from "./defineMethod";
 
 defineMethod(dismissChatNotification, {
-  validate(arg) {
-    check(arg, { chatNotificationId: String });
-
-    return arg;
-  },
-
   async run({ chatNotificationId }) {
     check(this.userId, String);
 

--- a/imports/server/methods/dismissPendingAnnouncement.ts
+++ b/imports/server/methods/dismissPendingAnnouncement.ts
@@ -4,12 +4,6 @@ import dismissPendingAnnouncement from "../../methods/dismissPendingAnnouncement
 import defineMethod from "./defineMethod";
 
 defineMethod(dismissPendingAnnouncement, {
-  validate(arg) {
-    check(arg, { pendingAnnouncementId: String });
-
-    return arg;
-  },
-
   async run({ pendingAnnouncementId }) {
     check(this.userId, String);
 

--- a/imports/server/methods/ensurePuzzleDocument.ts
+++ b/imports/server/methods/ensurePuzzleDocument.ts
@@ -8,13 +8,6 @@ import { ensureDocument, ensureHuntFolderPermission } from "../gdrive";
 import defineMethod from "./defineMethod";
 
 defineMethod(ensurePuzzleDocument, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-    });
-    return arg;
-  },
-
   async run({ puzzleId }) {
     check(this.userId, String);
 

--- a/imports/server/methods/generateHuntInvitationCode.ts
+++ b/imports/server/methods/generateHuntInvitationCode.ts
@@ -11,13 +11,6 @@ import defineMethod from "./defineMethod";
 
 // Generate (or regenerate) an invitation code for the given hunt.
 defineMethod(generateHuntInvitationCode, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-    });
-    return arg;
-  },
-
   async run({ huntId }) {
     check(this.userId, String);
 

--- a/imports/server/methods/generateUploadToken.ts
+++ b/imports/server/methods/generateUploadToken.ts
@@ -7,14 +7,6 @@ import UploadTokens from "../models/UploadTokens";
 import defineMethod from "./defineMethod";
 
 defineMethod(generateUploadToken, {
-  validate(arg) {
-    check(arg, {
-      assetName: String,
-      assetMimeType: String,
-    });
-    return arg;
-  },
-
   async run({ assetName, assetMimeType }) {
     check(this.userId, String);
     if (!userMayConfigureAssets(await MeteorUsers.findOneAsync(this.userId))) {

--- a/imports/server/methods/insertDocumentImage.ts
+++ b/imports/server/methods/insertDocumentImage.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { fetch } from "meteor/fetch";
 import { Meteor } from "meteor/meteor";
 import Documents from "../../lib/models/Documents";
@@ -38,26 +38,6 @@ async function validateImageLink(link: string) {
 }
 
 defineMethod(insertDocumentImage, {
-  validate(arg) {
-    check(arg, {
-      documentId: String,
-      sheetId: Number,
-      image: Match.OneOf(
-        {
-          source: Match.OneOf("upload"),
-          filename: String,
-          contents: String,
-        },
-        {
-          source: Match.OneOf("link"),
-          url: String,
-        },
-      ),
-    });
-
-    return arg;
-  },
-
   async run({ documentId, sheetId, image }) {
     check(this.userId, String);
 

--- a/imports/server/methods/linkUserDiscordAccount.ts
+++ b/imports/server/methods/linkUserDiscordAccount.ts
@@ -10,14 +10,6 @@ import { DiscordAPIClient, DiscordBot } from "../discord";
 import defineMethod from "./defineMethod";
 
 defineMethod(linkUserDiscordAccount, {
-  validate(arg) {
-    check(arg, {
-      key: String,
-      secret: String,
-    });
-    return arg;
-  },
-
   async run({ key, secret }) {
     check(this.userId, String);
 

--- a/imports/server/methods/linkUserGoogleAccount.ts
+++ b/imports/server/methods/linkUserGoogleAccount.ts
@@ -9,14 +9,6 @@ import { ensureHuntFolderPermission } from "../gdrive";
 import defineMethod from "./defineMethod";
 
 defineMethod(linkUserGoogleAccount, {
-  validate(arg) {
-    check(arg, {
-      key: String,
-      secret: String,
-    });
-    return arg;
-  },
-
   async run({ key, secret }) {
     check(this.userId, String);
 

--- a/imports/server/methods/listDocumentSheets.ts
+++ b/imports/server/methods/listDocumentSheets.ts
@@ -7,13 +7,6 @@ import listDocumentSheets from "../../methods/listDocumentSheets";
 import defineMethod from "./defineMethod";
 
 defineMethod(listDocumentSheets, {
-  validate(arg) {
-    check(arg, {
-      documentId: String,
-    });
-    return arg;
-  },
-
   async run({ documentId }) {
     check(this.userId, String);
 

--- a/imports/server/methods/makeUserEmailPrimary.ts
+++ b/imports/server/methods/makeUserEmailPrimary.ts
@@ -6,11 +6,6 @@ import makeUserEmailPrimary from "../../methods/makeUserEmailPrimary";
 import defineMethod from "./defineMethod";
 
 defineMethod(makeUserEmailPrimary, {
-  validate(arg) {
-    check(arg, { email: String });
-    return arg;
-  },
-
   async run({ email }) {
     check(this.userId, String);
 

--- a/imports/server/methods/mediasoupAckConsumer.ts
+++ b/imports/server/methods/mediasoupAckConsumer.ts
@@ -1,4 +1,3 @@
-import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Flags from "../../Flags";
 import ConsumerAcks from "../../lib/models/mediasoup/ConsumerAcks";
@@ -8,13 +7,6 @@ import serverId from "../serverId";
 import defineMethod from "./defineMethod";
 
 defineMethod(mediasoupAckConsumer, {
-  validate(arg) {
-    check(arg, {
-      consumerId: String,
-    });
-    return arg;
-  },
-
   async run({ consumerId }) {
     if (!this.userId) {
       throw new Meteor.Error(401, "Not logged in");

--- a/imports/server/methods/mediasoupAckPeerRemoteMute.ts
+++ b/imports/server/methods/mediasoupAckPeerRemoteMute.ts
@@ -1,4 +1,3 @@
-import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Flags from "../../Flags";
 import Peers from "../../lib/models/mediasoup/Peers";
@@ -6,13 +5,6 @@ import mediasoupAckPeerRemoteMute from "../../methods/mediasoupAckPeerRemoteMute
 import defineMethod from "./defineMethod";
 
 defineMethod(mediasoupAckPeerRemoteMute, {
-  validate(arg) {
-    check(arg, {
-      peerId: String,
-    });
-    return arg;
-  },
-
   async run({ peerId }) {
     if (!this.userId) {
       throw new Meteor.Error(401, "Not logged in");

--- a/imports/server/methods/mediasoupConnectTransport.ts
+++ b/imports/server/methods/mediasoupConnectTransport.ts
@@ -1,4 +1,3 @@
-import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Flags from "../../Flags";
 import ConnectRequests from "../../lib/models/mediasoup/ConnectRequests";
@@ -8,14 +7,6 @@ import serverId from "../serverId";
 import defineMethod from "./defineMethod";
 
 defineMethod(mediasoupConnectTransport, {
-  validate(arg) {
-    check(arg, {
-      transportId: String,
-      dtlsParameters: String,
-    });
-    return arg;
-  },
-
   async run({ transportId, dtlsParameters }) {
     if (!this.userId) {
       throw new Meteor.Error(401, "Not logged in");

--- a/imports/server/methods/mediasoupRemoteMutePeer.ts
+++ b/imports/server/methods/mediasoupRemoteMutePeer.ts
@@ -1,4 +1,3 @@
-import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Flags from "../../Flags";
 import PeerRemoteMutes from "../../lib/models/mediasoup/PeerRemoteMutes";
@@ -8,13 +7,6 @@ import mediasoupRemoteMutePeer from "../../methods/mediasoupRemoteMutePeer";
 import defineMethod from "./defineMethod";
 
 defineMethod(mediasoupRemoteMutePeer, {
-  validate(arg) {
-    check(arg, {
-      peerId: String,
-    });
-    return arg;
-  },
-
   async run({ peerId }) {
     if (!this.userId) {
       throw new Meteor.Error(401, "Not logged in");

--- a/imports/server/methods/mediasoupSetPeerState.ts
+++ b/imports/server/methods/mediasoupSetPeerState.ts
@@ -1,22 +1,10 @@
-import { check, Match } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Flags from "../../Flags";
 import Peers from "../../lib/models/mediasoup/Peers";
-import mediasoupSetPeerState, {
-  ALLOWED_STATES,
-} from "../../methods/mediasoupSetPeerState";
+import mediasoupSetPeerState from "../../methods/mediasoupSetPeerState";
 import defineMethod from "./defineMethod";
 
 defineMethod(mediasoupSetPeerState, {
-  validate(arg) {
-    check(arg, {
-      peerId: String,
-      state: Match.OneOf(...ALLOWED_STATES),
-    });
-
-    return arg;
-  },
-
   async run({ peerId, state }) {
     if (!this.userId) {
       throw new Meteor.Error(401, "Not logged in");

--- a/imports/server/methods/mediasoupSetProducerPaused.ts
+++ b/imports/server/methods/mediasoupSetProducerPaused.ts
@@ -1,4 +1,3 @@
-import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Flags from "../../Flags";
 import Peers from "../../lib/models/mediasoup/Peers";
@@ -8,14 +7,6 @@ import mediasoupSetProducerPaused from "../../methods/mediasoupSetProducerPaused
 import defineMethod from "./defineMethod";
 
 defineMethod(mediasoupSetProducerPaused, {
-  validate(arg) {
-    check(arg, {
-      mediasoupProducerId: String,
-      paused: Boolean,
-    });
-    return arg;
-  },
-
   async run({ mediasoupProducerId, paused }) {
     if (!this.userId) {
       throw new Meteor.Error(401, "Not logged in");

--- a/imports/server/methods/postAnnouncement.ts
+++ b/imports/server/methods/postAnnouncement.ts
@@ -11,15 +11,6 @@ import GlobalHooks from "../GlobalHooks";
 import defineMethod from "./defineMethod";
 
 defineMethod(postAnnouncement, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-      message: String,
-    });
-
-    return arg;
-  },
-
   async run({ huntId, message }) {
     check(this.userId, String);
 

--- a/imports/server/methods/promoteOperator.ts
+++ b/imports/server/methods/promoteOperator.ts
@@ -11,14 +11,6 @@ import promoteOperator from "../../methods/promoteOperator";
 import defineMethod from "./defineMethod";
 
 defineMethod(promoteOperator, {
-  validate(arg) {
-    check(arg, {
-      targetUserId: String,
-      huntId: String,
-    });
-    return arg;
-  },
-
   async run({ targetUserId, huntId }) {
     check(this.userId, String);
 

--- a/imports/server/methods/provisionFirstUser.ts
+++ b/imports/server/methods/provisionFirstUser.ts
@@ -1,5 +1,4 @@
 import { Accounts } from "meteor/accounts-base";
-import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import { GLOBAL_SCOPE } from "../../lib/isAdmin";
 import MeteorUsers from "../../lib/models/MeteorUsers";
@@ -8,14 +7,6 @@ import provisionFirstUser from "../../methods/provisionFirstUser";
 import defineMethod from "./defineMethod";
 
 defineMethod(provisionFirstUser, {
-  validate(args) {
-    check(args, {
-      email: String,
-      password: String,
-    });
-    return args;
-  },
-
   async run({ email, password }) {
     // Refuse to create the user if any users already exist
     // This is theoretically racy but is probably fine in practice

--- a/imports/server/methods/purgeHunt.ts
+++ b/imports/server/methods/purgeHunt.ts
@@ -7,11 +7,6 @@ import enqueueJob from "../jobs/framework/enqueueJob";
 import defineMethod from "./defineMethod";
 
 defineMethod(purgeHuntMethod, {
-  validate(arg) {
-    check(arg, { huntId: String });
-    return arg;
-  },
-
   async run({ huntId }) {
     check(this.userId, String);
     checkAdmin(await MeteorUsers.findOneAsync(this.userId));

--- a/imports/server/methods/removePuzzleAnswer.ts
+++ b/imports/server/methods/removePuzzleAnswer.ts
@@ -8,14 +8,6 @@ import transitionGuess from "../transitionGuess";
 import defineMethod from "./defineMethod";
 
 defineMethod(removePuzzleAnswer, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-      guessId: String,
-    });
-    return arg;
-  },
-
   async run({ puzzleId, guessId }) {
     check(this.userId, String);
 

--- a/imports/server/methods/removePuzzleTag.ts
+++ b/imports/server/methods/removePuzzleTag.ts
@@ -5,15 +5,6 @@ import removePuzzleTag from "../../methods/removePuzzleTag";
 import defineMethod from "./defineMethod";
 
 defineMethod(removePuzzleTag, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-      tagId: String,
-    });
-
-    return arg;
-  },
-
   async run({ puzzleId, tagId }) {
     check(this.userId, String);
 

--- a/imports/server/methods/removeUserAccountEmail.ts
+++ b/imports/server/methods/removeUserAccountEmail.ts
@@ -7,11 +7,6 @@ import removeUserAccountEmail from "../../methods/removeUserAccountEmail";
 import defineMethod from "./defineMethod";
 
 defineMethod(removeUserAccountEmail, {
-  validate(arg) {
-    check(arg, { email: String });
-    return arg;
-  },
-
   async run({ email }) {
     check(this.userId, String);
 

--- a/imports/server/methods/renameTag.ts
+++ b/imports/server/methods/renameTag.ts
@@ -5,15 +5,6 @@ import renameTag from "../../methods/renameTag";
 import defineMethod from "./defineMethod";
 
 defineMethod(renameTag, {
-  validate(arg) {
-    check(arg, {
-      tagId: String,
-      name: String,
-    });
-
-    return arg;
-  },
-
   async run({ tagId, name }) {
     check(this.userId, String);
 

--- a/imports/server/methods/sendChatMessage.ts
+++ b/imports/server/methods/sendChatMessage.ts
@@ -4,15 +4,6 @@ import sendChatMessageInternal from "../sendChatMessageInternal";
 import defineMethod from "./defineMethod";
 
 defineMethod(sendChatMessage, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-      content: String,
-    });
-
-    return arg;
-  },
-
   async run({ puzzleId, content }: { puzzleId: string; content: string }) {
     check(this.userId, String);
     const contentObj = JSON.parse(content);

--- a/imports/server/methods/sendUserVerificationEmail.ts
+++ b/imports/server/methods/sendUserVerificationEmail.ts
@@ -6,11 +6,6 @@ import checkVerificationEmailCooldown from "../checkVerificationEmailCooldown";
 import defineMethod from "./defineMethod";
 
 defineMethod(sendUserVerificationEmail, {
-  validate(arg) {
-    check(arg, { email: String });
-    return arg;
-  },
-
   async run({ email }) {
     check(this.userId, String);
 

--- a/imports/server/methods/setFeatureFlag.ts
+++ b/imports/server/methods/setFeatureFlag.ts
@@ -1,20 +1,11 @@
-import { check, Match } from "meteor/check";
-import FeatureFlags, { FlagNames } from "../../lib/models/FeatureFlags";
+import { check } from "meteor/check";
+import FeatureFlags from "../../lib/models/FeatureFlags";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import { checkAdmin } from "../../lib/permission_stubs";
 import setFeatureFlag from "../../methods/setFeatureFlag";
 import defineMethod from "./defineMethod";
 
 defineMethod(setFeatureFlag, {
-  validate(arg) {
-    check(arg, {
-      name: Match.OneOf(...FlagNames),
-      type: Match.OneOf("off", "on"),
-    });
-
-    return arg;
-  },
-
   async run({ name, type }) {
     // Feature flags may only be updated by admins
     check(this.userId, String);

--- a/imports/server/methods/setGuessState.ts
+++ b/imports/server/methods/setGuessState.ts
@@ -1,7 +1,7 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Logger from "../../Logger";
-import Guesses, { GuessStates } from "../../lib/models/Guesses";
+import Guesses from "../../lib/models/Guesses";
 import Hunts from "../../lib/models/Hunts";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import Puzzles from "../../lib/models/Puzzles";
@@ -11,15 +11,6 @@ import transitionGuess from "../transitionGuess";
 import defineMethod from "./defineMethod";
 
 defineMethod(setGuessState, {
-  validate(arg) {
-    check(arg, {
-      guessId: String,
-      state: Match.OneOf(...GuessStates.options),
-      additionalNotes: Match.Optional(String),
-    });
-    return arg;
-  },
-
   async run({ guessId, state, additionalNotes }) {
     check(this.userId, String);
 

--- a/imports/server/methods/syncHuntDiscordRole.ts
+++ b/imports/server/methods/syncHuntDiscordRole.ts
@@ -7,11 +7,6 @@ import addUsersToDiscordRole from "../addUsersToDiscordRole";
 import defineMethod from "./defineMethod";
 
 defineMethod(syncHuntDiscordRole, {
-  validate(arg) {
-    check(arg, { huntId: String });
-    return arg;
-  },
-
   async run({ huntId }) {
     check(this.userId, String);
 

--- a/imports/server/methods/undestroyHunt.ts
+++ b/imports/server/methods/undestroyHunt.ts
@@ -6,13 +6,6 @@ import undestroyHunt from "../../methods/undestroyHunt";
 import defineMethod from "./defineMethod";
 
 defineMethod(undestroyHunt, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-    });
-    return arg;
-  },
-
   async run({ huntId }) {
     check(this.userId, String);
     checkAdmin(await MeteorUsers.findOneAsync(this.userId));

--- a/imports/server/methods/undestroyPuzzle.ts
+++ b/imports/server/methods/undestroyPuzzle.ts
@@ -11,13 +11,6 @@ import { makeReadWrite } from "../gdrive";
 import defineMethod from "./defineMethod";
 
 defineMethod(undestroyPuzzle, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-    });
-    return arg;
-  },
-
   async run({ puzzleId }) {
     check(this.userId, String);
 

--- a/imports/server/methods/updateHunt.ts
+++ b/imports/server/methods/updateHunt.ts
@@ -2,7 +2,7 @@ import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Logger from "../../Logger";
 import type { HuntType } from "../../lib/models/Hunts";
-import Hunts, { HuntPattern } from "../../lib/models/Hunts";
+import Hunts, { EditableHunt } from "../../lib/models/Hunts";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import { checkAdmin } from "../../lib/permission_stubs";
 import updateHunt from "../../methods/updateHunt";
@@ -11,11 +11,6 @@ import { ensureHuntFolder, huntFolderName, renameDocument } from "../gdrive";
 import defineMethod from "./defineMethod";
 
 defineMethod(updateHunt, {
-  validate(arg) {
-    check(arg, { huntId: String, value: HuntPattern });
-    return arg;
-  },
-
   async run({ huntId, value }) {
     check(this.userId, String);
     checkAdmin(await MeteorUsers.findOneAsync(this.userId));
@@ -32,8 +27,8 @@ defineMethod(updateHunt, {
     // unset to achieve the desired final state.
     const toSet: { [key in keyof HuntType]?: any } = {};
     const toUnset: { [key in keyof HuntType]?: "" } = {};
-    Object.keys(HuntPattern).forEach((key: string) => {
-      const typedKey = key as keyof typeof HuntPattern;
+    Object.keys(EditableHunt.shape).forEach((key: string) => {
+      const typedKey = key as keyof typeof EditableHunt.shape;
       if (value[typedKey] === undefined) {
         toUnset[typedKey] = "";
       } else {

--- a/imports/server/methods/updateProfile.ts
+++ b/imports/server/methods/updateProfile.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import Logger from "../../Logger";
 import MeteorUsers from "../../lib/models/MeteorUsers";
@@ -6,17 +6,6 @@ import updateProfile from "../../methods/updateProfile";
 import defineMethod from "./defineMethod";
 
 defineMethod(updateProfile, {
-  validate(arg) {
-    check(arg, {
-      displayName: String,
-      phoneNumber: Match.Optional(String),
-      dingwords: [String],
-      enrollmentToken: Match.Optional(String),
-    });
-
-    return arg;
-  },
-
   async run({ displayName, phoneNumber, dingwords, enrollmentToken }) {
     let userId: string;
     if (enrollmentToken) {

--- a/imports/server/methods/updatePuzzle.ts
+++ b/imports/server/methods/updatePuzzle.ts
@@ -1,4 +1,4 @@
-import { check, Match } from "meteor/check";
+import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import type { Mongo } from "meteor/mongo";
 import Logger from "../../Logger";
@@ -15,22 +15,6 @@ import getTeamName from "../getTeamName";
 import defineMethod from "./defineMethod";
 
 defineMethod(updatePuzzle, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-      title: String,
-      url: Match.Optional(String),
-      tags: [String],
-      expectedAnswerCount: Number,
-      // We accept this argument since it's provided by the form, but it's not checked here - only
-      // during puzzle creation, to avoid duplicates when creating new puzzles.
-      allowDuplicateUrls: Match.Optional(Boolean),
-      completedWithNoAnswer: Match.Optional(Boolean),
-    });
-
-    return arg;
-  },
-
   async run({
     puzzleId,
     title,

--- a/imports/server/methods/userLoginOptions.ts
+++ b/imports/server/methods/userLoginOptions.ts
@@ -1,5 +1,4 @@
 import { Accounts } from "meteor/accounts-base";
-import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import InvitationCodes from "../../lib/models/InvitationCodes";
 import type { UserLoginOptionsResult } from "../../methods/userLoginOptions";
@@ -7,14 +6,6 @@ import userLoginOptions from "../../methods/userLoginOptions";
 import defineMethod from "./defineMethod";
 
 defineMethod(userLoginOptions, {
-  validate(arg) {
-    check(arg, {
-      email: String,
-      invitationCode: String,
-    });
-    return arg;
-  },
-
   async run({ email, invitationCode }): Promise<UserLoginOptionsResult> {
     // We *do not* require a logged-in user to make this query, as it is intended to assist users who are not logged in figure out how to best do so.
     // We *do* require a valid invitation code that we intend to redeem.

--- a/imports/server/publications/announcementsForAnnouncementsPage.ts
+++ b/imports/server/publications/announcementsForAnnouncementsPage.ts
@@ -1,4 +1,3 @@
-import { check } from "meteor/check";
 import Announcements from "../../lib/models/Announcements";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import announcementsForAnnouncementsPage from "../../lib/publications/announcementsForAnnouncementsPage";
@@ -6,13 +5,6 @@ import publishJoinedQuery from "../publishJoinedQuery";
 import definePublication from "./definePublication";
 
 definePublication(announcementsForAnnouncementsPage, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-    });
-    return arg;
-  },
-
   async run({ huntId }) {
     if (!this.userId) {
       return [];

--- a/imports/server/publications/chatMessagesForFirehose.ts
+++ b/imports/server/publications/chatMessagesForFirehose.ts
@@ -1,4 +1,3 @@
-import { check } from "meteor/check";
 import ChatMessages from "../../lib/models/ChatMessages";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import Puzzles from "../../lib/models/Puzzles";
@@ -6,13 +5,6 @@ import chatMessagesForFirehose from "../../lib/publications/chatMessagesForFireh
 import definePublication from "./definePublication";
 
 definePublication(chatMessagesForFirehose, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-    });
-    return arg;
-  },
-
   async run({ huntId }) {
     if (!this.userId) {
       return [];

--- a/imports/server/publications/chatMessagesForPuzzle.ts
+++ b/imports/server/publications/chatMessagesForPuzzle.ts
@@ -1,18 +1,9 @@
-import { check } from "meteor/check";
 import ChatMessages from "../../lib/models/ChatMessages";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import chatMessagesForPuzzle from "../../lib/publications/chatMessagesForPuzzle";
 import definePublication from "./definePublication";
 
 definePublication(chatMessagesForPuzzle, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-      huntId: String,
-    });
-    return arg;
-  },
-
   async run({ puzzleId, huntId }) {
     if (!this.userId) {
       return [];

--- a/imports/server/publications/definePublication.ts
+++ b/imports/server/publications/definePublication.ts
@@ -1,63 +1,68 @@
+import { check, Match } from "meteor/check";
 import type { Subscription } from "meteor/meteor";
 import { Meteor } from "meteor/meteor";
 import type { Mongo } from "meteor/mongo";
 import Bugsnag from "@bugsnag/js";
+import type z from "zod";
+import { ZodError } from "zod";
 import Logger from "../../Logger";
 import type TypedPublication from "../../lib/publications/TypedPublication";
-import type {
-  DefaultTypedPublication,
-  TypedPublicationArgs,
-} from "../../lib/publications/TypedPublication";
+import type { PublicationName } from "../../lib/publications/TypedPublication";
+import assertStrictSchema from "../assertStrictSchema";
 
 type TypedPublicationReturn =
   | undefined
   | Mongo.Cursor<any>
   | Mongo.Cursor<any>[]
   | Promise<undefined | Mongo.Cursor<any> | Mongo.Cursor<any>[]>;
-type TypedPublicationValidator<Arg extends TypedPublicationArgs> = (
-  arg0: unknown,
-) => Arg;
-type TypedPublicationRun<Arg extends TypedPublicationArgs> = Arg extends void
-  ? (this: Subscription) => TypedPublicationReturn
-  : (this: Subscription, arg0: Arg) => TypedPublicationReturn;
 
-const voidValidator = () => {
-  /* noop */
-};
-
-// Supporting publications with void arguments is a bit messy, but as with
-// TypedMethods, worth doing. See TypedMethod for an explanation of the
-// shenanigans required, which are basically the same here
 export default function definePublication<
-  Publication extends TypedPublication<any> | DefaultTypedPublication,
-  Args extends TypedPublicationArgs = Publication extends TypedPublication<
-    infer A
-  >
-    ? A
-    : void,
+  Args extends z.ZodTuple,
+  Name extends PublicationName<Args>,
 >(
-  publication: Publication,
+  publication: TypedPublication<Args, Name>,
   {
-    validate,
     run,
   }: {
-    run: TypedPublicationRun<Args>;
-  } & (Args extends void
-    ? { validate?: undefined }
-    : { validate: TypedPublicationValidator<Args> }),
-) {
-  const validator = (validate ??
-    voidValidator) as TypedPublicationValidator<Args>;
+    run: (
+      this: Subscription,
+      ...args: z.output<Args>
+    ) => TypedPublicationReturn | Promise<TypedPublicationReturn>;
+  },
+): void {
+  assertStrictSchema(
+    publication.args,
+    publication.name === null
+      ? "Default publication"
+      : `Publication ${publication.name}`,
+  );
 
-  Meteor.publish(publication.name, async function (arg0: Args) {
+  Meteor.publish(publication.name, async function (...args: unknown[]) {
+    // Silence audit-argument-checks; we'll do our own validation below.
+    check(args, [Match.Any]);
+
     try {
-      const validatedArg0 = validator.bind(this)(arg0) as any;
-      return await run.bind(this)(validatedArg0);
+      const validatedArgs = await publication.args
+        .parseAsync(args)
+        .catch((error: unknown) => {
+          // Attach a sanitized error to get serialized over DDP, but keep the
+          // original error for server-side reporting.
+          if (error instanceof ZodError) {
+            (
+              error as ZodError & { sanitizedError?: Meteor.Error }
+            ).sanitizedError = new Meteor.Error(
+              400,
+              `Invalid arguments to publication ${publication.name}`,
+            );
+          }
+          throw error;
+        });
+      return await run.apply(this, validatedArgs);
     } catch (error) {
       Logger.info("Error in publication", {
         name: publication.name,
         user: this.userId,
-        arguments: arg0,
+        arguments: args,
         error: error instanceof Error ? error.message : error,
       });
       if (error instanceof Error && Bugsnag.isStarted()) {

--- a/imports/server/publications/documentsForPuzzleDeleteModal.ts
+++ b/imports/server/publications/documentsForPuzzleDeleteModal.ts
@@ -1,17 +1,9 @@
-import { check } from "meteor/check";
 import Documents from "../../lib/models/Documents";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import documentsForPuzzleDeleteModal from "../../lib/publications/documentsForPuzzleDeleteModal";
 import definePublication from "./definePublication";
 
 definePublication(documentsForPuzzleDeleteModal, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-    });
-    return arg;
-  },
-
   async run({ huntId }) {
     if (!this.userId) {
       return [];

--- a/imports/server/publications/guessesForGuessQueue.ts
+++ b/imports/server/publications/guessesForGuessQueue.ts
@@ -1,4 +1,3 @@
-import { check } from "meteor/check";
 import Guesses from "../../lib/models/Guesses";
 import Hunts from "../../lib/models/Hunts";
 import MeteorUsers from "../../lib/models/MeteorUsers";
@@ -8,13 +7,6 @@ import publishJoinedQuery from "../publishJoinedQuery";
 import definePublication from "./definePublication";
 
 definePublication(guessesForGuessQueue, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-    });
-    return arg;
-  },
-
   async run({ huntId }) {
     if (!this.userId) {
       return [];

--- a/imports/server/publications/huntForHuntApp.ts
+++ b/imports/server/publications/huntForHuntApp.ts
@@ -1,16 +1,8 @@
-import { check } from "meteor/check";
 import Hunts from "../../lib/models/Hunts";
 import huntForHuntApp from "../../lib/publications/huntForHuntApp";
 import definePublication from "./definePublication";
 
 definePublication(huntForHuntApp, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-    });
-    return arg;
-  },
-
   run({ huntId }) {
     if (!this.userId) {
       return [];

--- a/imports/server/publications/huntForInvitationCode.ts
+++ b/imports/server/publications/huntForInvitationCode.ts
@@ -1,4 +1,3 @@
-import { check } from "meteor/check";
 import Hunts from "../../lib/models/Hunts";
 import InvitationCodes from "../../lib/models/InvitationCodes";
 import huntForInvitationCode from "../../lib/publications/huntForInvitationCode";
@@ -6,12 +5,6 @@ import publishJoinedQuery from "../publishJoinedQuery";
 import definePublication from "./definePublication";
 
 definePublication(huntForInvitationCode, {
-  validate(arg) {
-    check(arg, {
-      invitationCode: String,
-    });
-    return arg;
-  },
   async run({ invitationCode }) {
     await publishJoinedQuery(
       this,

--- a/imports/server/publications/invitationCodesForHunt.ts
+++ b/imports/server/publications/invitationCodesForHunt.ts
@@ -1,4 +1,3 @@
-import { check } from "meteor/check";
 import Hunts from "../../lib/models/Hunts";
 import InvitationCodes from "../../lib/models/InvitationCodes";
 import MeteorUsers from "../../lib/models/MeteorUsers";
@@ -7,13 +6,6 @@ import invitationCodesForHunt from "../../lib/publications/invitationCodesForHun
 import definePublication from "./definePublication";
 
 definePublication(invitationCodesForHunt, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-    });
-    return arg;
-  },
-
   async run({ huntId }) {
     if (!this.userId) {
       return [];

--- a/imports/server/publications/jobForMerge.ts
+++ b/imports/server/publications/jobForMerge.ts
@@ -1,4 +1,3 @@
-import { check } from "meteor/check";
 import isAdmin from "../../lib/isAdmin";
 import Jobs from "../../lib/models/Jobs";
 import MeteorUsers from "../../lib/models/MeteorUsers";
@@ -6,11 +5,6 @@ import jobForMerge from "../../lib/publications/jobForMerge";
 import definePublication from "./definePublication";
 
 definePublication(jobForMerge, {
-  validate(arg) {
-    check(arg, { jobId: String });
-    return arg;
-  },
-
   async run({ jobId }) {
     if (!this.userId) {
       return [];

--- a/imports/server/publications/puzzleActivityForHunt.ts
+++ b/imports/server/publications/puzzleActivityForHunt.ts
@@ -1,4 +1,3 @@
-import { check } from "meteor/check";
 import type { Subscription } from "meteor/meteor";
 import { Meteor } from "meteor/meteor";
 import type { PublishedBucket } from "../../lib/config/activityTracking";
@@ -270,11 +269,6 @@ class HuntActivityAggregator {
 }
 
 definePublication(puzzleActivityForHunt, {
-  validate(arg) {
-    check(arg, { huntId: String });
-    return arg;
-  },
-
   async run({ huntId }) {
     const aggregator = await HuntActivityAggregator.get(huntId);
     aggregator.addSubscription(this);

--- a/imports/server/publications/puzzleForPuzzlePage.ts
+++ b/imports/server/publications/puzzleForPuzzlePage.ts
@@ -1,4 +1,3 @@
-import { check } from "meteor/check";
 import Bookmarks from "../../lib/models/Bookmarks";
 import Documents from "../../lib/models/Documents";
 import Guesses from "../../lib/models/Guesses";
@@ -12,14 +11,6 @@ import definePublication from "./definePublication";
 import publishCursor from "./publishCursor";
 
 definePublication(puzzleForPuzzlePage, {
-  validate(arg) {
-    check(arg, {
-      puzzleId: String,
-      huntId: String,
-    });
-    return arg;
-  },
-
   async run({ puzzleId, huntId }) {
     if (!this.userId) {
       return [];

--- a/imports/server/publications/puzzlesForHunt.ts
+++ b/imports/server/publications/puzzlesForHunt.ts
@@ -1,18 +1,9 @@
-import { check, Match } from "meteor/check";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import Puzzles from "../../lib/models/Puzzles";
 import puzzlesForHunt from "../../lib/publications/puzzlesForHunt";
 import definePublication from "./definePublication";
 
 definePublication(puzzlesForHunt, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-      includeDeleted: Match.Optional(Boolean),
-    });
-    return arg;
-  },
-
   async run({ huntId, includeDeleted = false }) {
     if (!this.userId) {
       return [];

--- a/imports/server/publications/puzzlesForPuzzleList.ts
+++ b/imports/server/publications/puzzlesForPuzzleList.ts
@@ -1,4 +1,3 @@
-import { check, Match } from "meteor/check";
 import Bookmarks from "../../lib/models/Bookmarks";
 import MeteorUsers from "../../lib/models/MeteorUsers";
 import Puzzles from "../../lib/models/Puzzles";
@@ -7,14 +6,6 @@ import puzzlesForPuzzleList from "../../lib/publications/puzzlesForPuzzleList";
 import definePublication from "./definePublication";
 
 definePublication(puzzlesForPuzzleList, {
-  validate(arg) {
-    check(arg, {
-      huntId: String,
-      includeDeleted: Match.Optional(Boolean),
-    });
-    return arg;
-  },
-
   async run({ huntId, includeDeleted = false }) {
     if (!this.userId) {
       return [];

--- a/imports/server/publications/settingsByName.ts
+++ b/imports/server/publications/settingsByName.ts
@@ -1,16 +1,10 @@
-import { check, Match } from "meteor/check";
 import isAdmin from "../../lib/isAdmin";
 import MeteorUsers from "../../lib/models/MeteorUsers";
-import Settings, { SettingNames } from "../../lib/models/Settings";
+import Settings from "../../lib/models/Settings";
 import settingsByName from "../../lib/publications/settingsByName";
 import definePublication from "./definePublication";
 
 definePublication(settingsByName, {
-  validate(arg) {
-    check(arg, { name: Match.OneOf(...SettingNames) });
-    return arg;
-  },
-
   async run({ name }) {
     // Only allow admins to pull down Settings.
     if (!this.userId || !isAdmin(await MeteorUsers.findOneAsync(this.userId))) {

--- a/tests/acceptance/emails.ts
+++ b/tests/acceptance/emails.ts
@@ -1,8 +1,8 @@
 import { promisify } from "node:util";
 import { Accounts } from "meteor/accounts-base";
-import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import { assert } from "chai";
+import z from "zod";
 import Hunts from "../../imports/lib/models/Hunts";
 import MeteorUsers from "../../imports/lib/models/MeteorUsers";
 import addUserAccountEmail from "../../imports/methods/addUserAccountEmail";
@@ -14,31 +14,38 @@ import resetDatabase from "../lib/resetDatabase";
 import { subscribeAsync } from "./lib";
 
 // Test-only helper methods
-const createUser = new TypedMethod<
-  { email: string; password: string; displayName: string },
-  string
->("test.methods.emails.createUser");
-const createHunt = new TypedMethod<{ name: string }, string>(
+const createUser = new TypedMethod(
+  "test.methods.emails.createUser",
+  z.tuple([
+    z.strictObject({
+      email: z.string(),
+      password: z.string(),
+      displayName: z.string(),
+    }),
+  ]),
+  z.string(),
+);
+const createHunt = new TypedMethod(
   "test.methods.emails.createHunt",
+  z.tuple([z.strictObject({ name: z.string() })]),
+  z.string(),
 );
-const joinHunt = new TypedMethod<{ huntId: string; userId: string }, void>(
+const joinHunt = new TypedMethod(
   "test.methods.emails.joinHunt",
+  z.tuple([z.strictObject({ huntId: z.string(), userId: z.string() })]),
+  z.void(),
 );
-const verifyUserEmail = new TypedMethod<
-  { userId: string; email: string },
-  void
->("test.methods.emails.verifyUserEmail");
+const verifyUserEmail = new TypedMethod(
+  "test.methods.emails.verifyUserEmail",
+  z.tuple([z.strictObject({ userId: z.string(), email: z.string() })]),
+  z.void(),
+);
 
 if (Meteor.isServer) {
   const defineMethod: typeof import("../../imports/server/methods/defineMethod").default =
     require("../../imports/server/methods/defineMethod").default;
 
   defineMethod(createUser, {
-    validate(arg: unknown) {
-      check(arg, { email: String, password: String, displayName: String });
-      return arg;
-    },
-
     async run({ email, password, displayName }) {
       if (!Meteor.isAppTest) {
         throw new Meteor.Error(500, "This code must not run in production");
@@ -51,11 +58,6 @@ if (Meteor.isServer) {
   });
 
   defineMethod(createHunt, {
-    validate(arg: unknown) {
-      check(arg, { name: String });
-      return arg;
-    },
-
     async run({ name }) {
       if (!Meteor.isAppTest) {
         throw new Meteor.Error(500, "This code must not run in production");
@@ -71,11 +73,6 @@ if (Meteor.isServer) {
   });
 
   defineMethod(joinHunt, {
-    validate(arg: unknown) {
-      check(arg, { huntId: String, userId: String });
-      return arg;
-    },
-
     async run({ huntId, userId }) {
       if (!Meteor.isAppTest) {
         throw new Meteor.Error(500, "This code must not run in production");
@@ -88,11 +85,6 @@ if (Meteor.isServer) {
   });
 
   defineMethod(verifyUserEmail, {
-    validate(arg: unknown) {
-      check(arg, { userId: String, email: String });
-      return arg;
-    },
-
     async run({ userId, email }) {
       if (!Meteor.isAppTest) {
         throw new Meteor.Error(500, "This code must not run in production");

--- a/tests/acceptance/profiles.tsx
+++ b/tests/acceptance/profiles.tsx
@@ -1,8 +1,8 @@
 import { promisify } from "node:util";
 import { Accounts } from "meteor/accounts-base";
-import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import { assert } from "chai";
+import z from "zod";
 import Hunts from "../../imports/lib/models/Hunts";
 import MeteorUsers from "../../imports/lib/models/MeteorUsers";
 import {
@@ -15,19 +15,33 @@ import { stabilize, subscribeAsync } from "./lib";
 
 // To make these tests easier to setup, use these methods to punch through most
 // of our normal permissions. They don't even require that you be logged in.
-const createUser = new TypedMethod<
-  { email: string; password: string; displayName: string },
-  string
->("test.methods.profiles.createUser");
-const addUserToRole = new TypedMethod<
-  { userId: string; scope: string; role: string },
-  void
->("test.methods.profiles.addUserToRole");
-const createHunt = new TypedMethod<{ name: string }, string>(
-  "test.methods.profiles.createHunt",
+const createUser = new TypedMethod(
+  "test.methods.profiles.createUser",
+  z.tuple([
+    z.strictObject({
+      email: z.string(),
+      password: z.string(),
+      displayName: z.string(),
+    }),
+  ]),
+  z.string(),
 );
-const joinHunt = new TypedMethod<{ huntId: string; userId: string }, void>(
+const addUserToRole = new TypedMethod(
+  "test.methods.profiles.addUserToRole",
+  z.tuple([
+    z.strictObject({ userId: z.string(), scope: z.string(), role: z.string() }),
+  ]),
+  z.void(),
+);
+const createHunt = new TypedMethod(
+  "test.methods.profiles.createHunt",
+  z.tuple([z.strictObject({ name: z.string() })]),
+  z.string(),
+);
+const joinHunt = new TypedMethod(
   "test.methods.profiles.joinHunt",
+  z.tuple([z.strictObject({ huntId: z.string(), userId: z.string() })]),
+  z.void(),
 );
 
 if (Meteor.isServer) {
@@ -35,16 +49,6 @@ if (Meteor.isServer) {
     require("../../imports/server/methods/defineMethod").default;
 
   defineMethod(createUser, {
-    validate(arg: unknown) {
-      check(arg, {
-        email: String,
-        password: String,
-        displayName: String,
-      });
-
-      return arg;
-    },
-
     async run({ email, password, displayName }) {
       if (!Meteor.isAppTest) {
         throw new Meteor.Error(500, "This code must not run in production");
@@ -57,16 +61,6 @@ if (Meteor.isServer) {
   });
 
   defineMethod(addUserToRole, {
-    validate(arg: unknown) {
-      check(arg, {
-        userId: String,
-        scope: String,
-        role: String,
-      });
-
-      return arg;
-    },
-
     async run({ userId, scope, role }) {
       if (!Meteor.isAppTest) {
         throw new Meteor.Error(500, "This code must not run in production");
@@ -77,14 +71,6 @@ if (Meteor.isServer) {
   });
 
   defineMethod(createHunt, {
-    validate(arg: unknown) {
-      check(arg, {
-        name: String,
-      });
-
-      return arg;
-    },
-
     async run({ name }) {
       if (!Meteor.isAppTest) {
         throw new Meteor.Error(500, "This code must not run in production");
@@ -101,15 +87,6 @@ if (Meteor.isServer) {
   });
 
   defineMethod(joinHunt, {
-    validate(arg: unknown) {
-      check(arg, {
-        huntId: String,
-        userId: String,
-      });
-
-      return arg;
-    },
-
     async run({ huntId, userId }) {
       await MeteorUsers.updateAsync(userId, {
         $addToSet: { hunts: { $each: [huntId] } },

--- a/tests/acceptance/typedMethods.ts
+++ b/tests/acceptance/typedMethods.ts
@@ -1,0 +1,94 @@
+import { Meteor } from "meteor/meteor";
+import { assert } from "chai";
+import z from "zod";
+import TypedMethod from "../../imports/methods/TypedMethod";
+
+// Test-only methods
+const echoName = new TypedMethod(
+  "test.methods.typedMethods.echoName",
+  z.tuple([z.strictObject({ name: z.string() })]),
+  z.object({ name: z.string() }),
+);
+const misbehavedReturn = new TypedMethod(
+  "test.methods.typedMethods.misbehavedReturn",
+  z.tuple([]),
+  z.string(),
+);
+
+if (Meteor.isServer) {
+  const defineMethod: typeof import("../../imports/server/methods/defineMethod").default =
+    require("../../imports/server/methods/defineMethod").default;
+
+  defineMethod(echoName, {
+    run({ name }) {
+      if (!Meteor.isAppTest) {
+        throw new Meteor.Error(500, "This code must not run in production");
+      }
+
+      // Intentionally include an extra field so we can prove it gets stripped over the wire
+      return { name, secret: "do not leak" };
+    },
+  });
+
+  defineMethod(misbehavedReturn, {
+    // @ts-expect-error deliberately malformed; the client should see an
+    // opaque 500
+    run() {
+      if (!Meteor.isAppTest) {
+        throw new Meteor.Error(500, "This code must not run in production");
+      }
+
+      return 42;
+    },
+  });
+}
+
+if (Meteor.isClient) {
+  describe("TypedMethod wire contract", function () {
+    it("rejects extra argument properties with a sanitized 400", async function () {
+      let error: Meteor.Error | undefined;
+      try {
+        // @ts-expect-error intentional extra property to test validation
+        await echoName.callPromise({ name: "x", extra: 1 });
+      } catch (e) {
+        error = e as Meteor.Error;
+      }
+      assert.isDefined(error);
+      assert.equal(error.error, 400);
+      assert.equal(
+        error.reason,
+        "Invalid arguments to method test.methods.typedMethods.echoName",
+      );
+      // zod's issue details must not survive sanitization
+      assert.notMatch(JSON.stringify(error), /unrecognized_keys|issues/);
+    });
+
+    it("rejects extra arguments with a sanitized 400", async function () {
+      let error: Meteor.Error | undefined;
+      try {
+        await Meteor.callAsync(echoName.name, { name: "x" }, 2);
+      } catch (e) {
+        error = e as Meteor.Error;
+      }
+      assert.isDefined(error);
+      assert.equal(error.error, 400);
+    });
+
+    it("converts a malformed return value into an opaque 500", async function () {
+      let error: Meteor.Error | undefined;
+      try {
+        await misbehavedReturn.callPromise();
+      } catch (e) {
+        error = e as Meteor.Error;
+      }
+      assert.isDefined(error);
+      assert.equal(error.error, 500);
+      assert.equal(error.reason, "Internal server error");
+    });
+
+    it("strips undeclared fields from return values", async function () {
+      const result = await echoName.callPromise({ name: "x" });
+      assert.deepEqual(result, { name: "x" });
+    });
+  });
+}

--- a/tests/client-main.ts
+++ b/tests/client-main.ts
@@ -6,6 +6,7 @@ chai.use(chaiAsPromised);
 import "./unit/imports/lib/calendarTimeFormat";
 import "./unit/imports/lib/puzzle-sort-and-group";
 import "./unit/imports/lib/relativeTimeFormat";
+import "./unit/imports/lib/TypedPublication";
 import "./unit/imports/lib/ValidateShape";
 
 import "./acceptance/authentication";

--- a/tests/client-main.ts
+++ b/tests/client-main.ts
@@ -13,4 +13,5 @@ import "./acceptance/authentication";
 import "./acceptance/chatHooks";
 import "./acceptance/emails";
 import "./acceptance/profiles";
+import "./acceptance/typedMethods";
 import "./acceptance/smoke";

--- a/tests/lib/resetDatabase.ts
+++ b/tests/lib/resetDatabase.ts
@@ -1,11 +1,13 @@
 import { promisify } from "node:util";
-import { check } from "meteor/check";
 import { Meteor } from "meteor/meteor";
 import { MongoInternals } from "meteor/mongo";
+import z from "zod";
 import TypedMethod from "../../imports/methods/TypedMethod";
 
-const resetDatabaseMethod = new TypedMethod<{ testName: string }, void>(
+const resetDatabaseMethod = new TypedMethod(
   "test.methods.resetDatabase",
+  z.tuple([z.strictObject({ testName: z.string() })]),
+  z.void(),
 );
 
 let resetDatabase: (testName: string) => Promise<void>;
@@ -67,11 +69,6 @@ if (Meteor.isServer) {
   };
 
   defineMethod(resetDatabaseMethod, {
-    validate(arg: unknown) {
-      check(arg, { testName: String });
-
-      return arg;
-    },
     run({ testName }) {
       return resetDatabase(testName);
     },

--- a/tests/server-main.ts
+++ b/tests/server-main.ts
@@ -29,4 +29,5 @@ import "./acceptance/authentication";
 import "./acceptance/chatHooks";
 import "./acceptance/emails";
 import "./acceptance/profiles";
+import "./acceptance/typedMethods";
 import "./acceptance/smoke";

--- a/tests/server-main.ts
+++ b/tests/server-main.ts
@@ -8,6 +8,7 @@ chai.use(chaiAsPromised);
 import "./unit/imports/lib/calendarTimeFormat";
 import "./unit/imports/lib/puzzle-sort-and-group";
 import "./unit/imports/lib/relativeTimeFormat";
+import "./unit/imports/lib/TypedPublication";
 import "./unit/imports/lib/ValidateShape";
 
 // Disable rate limiting

--- a/tests/unit/imports/lib/TypedPublication.ts
+++ b/tests/unit/imports/lib/TypedPublication.ts
@@ -1,0 +1,29 @@
+import z from "zod";
+import typedSubscribe from "../../../../imports/client/typedSubscribe";
+import TypedPublication from "../../../../imports/lib/publications/TypedPublication";
+
+describe("TypedPublication", () => {
+  // The arrow below is never invoked: we only need the compiler to check
+  // these declarations and calls.
+  it("constrains default publications to empty argument tuples", () => {
+    void (() => {
+      const namedWithoutArgs = new TypedPublication("named", z.tuple([]));
+      const namedWithArgs = new TypedPublication(
+        "named",
+        z.tuple([z.string()]),
+      );
+      const defaultPublication = new TypedPublication(null, z.tuple([]));
+
+      typedSubscribe(namedWithoutArgs);
+      typedSubscribe(namedWithArgs, "argument");
+
+      // @ts-expect-error default publications cannot accept arguments
+      void new TypedPublication(null, z.tuple([z.string()]));
+
+      // @ts-expect-error default publications cannot be subscribed to by name
+      typedSubscribe(defaultPublication);
+      // @ts-expect-error default publications cannot be subscribed to by name
+      void typedSubscribe.async(defaultPublication);
+    });
+  });
+});

--- a/tests/unit/imports/lib/ValidateShape.ts
+++ b/tests/unit/imports/lib/ValidateShape.ts
@@ -1,47 +1,126 @@
-import type ValidateShape from "../../../../imports/lib/ValidateShape";
+/* eslint jolly-roger/no-disallowed-sync-methods: "off" -- we are deliberately exercising the .call() signature */
+import { assert } from "chai";
+import z from "zod";
+import TypedMethod from "../../../../imports/methods/TypedMethod";
 
-function validatedCall<T>(
-  _arg: ValidateShape<
-    T,
-    {
-      a: number;
-      b: number;
-      c?: number;
-    }
-  >,
-): void {
-  /* dummy function for type checking */
-}
+const testMethod = new TypedMethod(
+  "Test.methods.validateShape",
+  z.tuple([
+    z.strictObject({
+      a: z.number(),
+      b: z.number(),
+      c: z.number().optional(),
+    }),
+  ]),
+  z.void(),
+);
+
+const zeroArgMethod = new TypedMethod(
+  "Test.methods.validateShapeZeroArgs",
+  z.tuple([]),
+  z.void(),
+);
+
+const multiArgMethod = new TypedMethod(
+  "Test.methods.validateShapeMultiArgs",
+  z.tuple([
+    z.strictObject({ id: z.string() }),
+    z.strictObject({ enabled: z.boolean() }).optional(),
+  ]),
+  z.void(),
+);
+
+const restArgMethod = new TypedMethod(
+  "Test.methods.validateShapeRestArgs",
+  z.tuple(
+    [z.strictObject({ id: z.string() })],
+    z.strictObject({ value: z.number() }),
+  ),
+  z.void(),
+);
 
 describe("ValidateShape", () => {
+  // The arrows below are never invoked: we only need the compiler to check
+  // these calls (and reject the @ts-expect-error ones), and running them
+  // would issue actual Meteor method calls.
   it("rejects extra parameters", () => {
-    const arg = {
-      a: 1,
-      b: 2,
-      c: 3,
-      d: 4,
-    };
-    // @ts-expect-error extra parameter
-    validatedCall(arg);
-    const arg2 = {
-      a: 1,
-      b: 2,
-      d: 3,
-    };
-    // @ts-expect-error extra parameter
-    validatedCall(arg2);
+    void (() => {
+      const arg = { a: 1, b: 2, c: 3, d: 4 };
+      // @ts-expect-error extra parameter
+      void testMethod.callPromise(arg);
+
+      const arg2 = { a: 1, b: 2, d: 3 };
+      // @ts-expect-error extra parameter
+      void testMethod.callPromise(arg2);
+
+      // @ts-expect-error extra parameter via spread
+      void testMethod.callPromise({ ...arg2 });
+
+      // @ts-expect-error extra parameter alongside a callback
+      testMethod.call(arg2, (error) => {
+        assert.isUndefined(error);
+      });
+
+      void multiArgMethod.callPromise(
+        { id: "test" },
+        // @ts-expect-error extra parameter in a second tuple element
+        { enabled: true, extra: true },
+      );
+
+      void restArgMethod.callPromise(
+        { id: "test" },
+        { value: 1 },
+        // @ts-expect-error extra parameter in a rest tuple element
+        { value: 2, extra: true },
+      );
+    });
   });
 
   it("rejects missing parameters", () => {
-    const arg = { a: 1 };
-    // @ts-expect-error missing parameter
-    validatedCall(arg);
+    void (() => {
+      const arg = { a: 1 };
+      // @ts-expect-error missing parameter
+      void testMethod.callPromise(arg);
+    });
   });
 
   it("accepts valid parameters", () => {
-    const arg = { a: 1, b: 2 };
-    validatedCall(arg);
-    const arg2 = { a: 1, b: 2, c: 3 };
-    validatedCall(arg2);
+    void (() => {
+      void testMethod.callPromise({ a: 1, b: 2 });
+      void testMethod.callPromise({ a: 1, b: 2, c: 3 });
+
+      const arg = { a: 1, b: 2 };
+      void testMethod.callPromise(arg);
+      const arg2 = { a: 1, b: 2, c: 3 };
+      void testMethod.callPromise(arg2);
+
+      testMethod.call({ a: 1, b: 2 });
+      testMethod.call(arg, (error) => {
+        assert.isUndefined(error);
+      });
+
+      void zeroArgMethod.callPromise();
+      zeroArgMethod.call();
+      zeroArgMethod.call((error) => {
+        assert.isUndefined(error);
+      });
+
+      void multiArgMethod.callPromise({ id: "test" });
+      void multiArgMethod.callPromise({ id: "test" }, { enabled: true });
+      void multiArgMethod.callPromise({ id: "test" }, undefined);
+      multiArgMethod.call({ id: "test" }, { enabled: true }, (error) => {
+        assert.isUndefined(error);
+      });
+
+      void restArgMethod.callPromise({ id: "test" });
+      void restArgMethod.callPromise(
+        { id: "test" },
+        { value: 1 },
+        { value: 2 },
+      );
+      restArgMethod.call({ id: "test" }, { value: 1 }, (error) => {
+        assert.isUndefined(error);
+      });
+    });
   });
 });


### PR DESCRIPTION
I would probably recommend looking at just the new implementation rather than the diff.

Our existing Typed* systems built on top of `check` are fine I guess, but zod is great for putting (a) type declarations (b) type validations in the same place, which is one less set of code that we need to write when adding a method. I especially like the simplification this offers for `createHunt` and `updateHunt`, where we previously had to maintain basically two versions of the same complex validation. (Although I still would need to deal with `Object.keys(HuntPattern)` and replace that with some zod probing.

I'll proceed with conversion if this seems sufficiently interesting. (After Mystery Hunt, of course)