### PR TITLE
Add option to mark 0-answer puzzles "solved" instead of "noAnswer"

### DIFF
--- a/imports/lib/models/Puzzles.ts
+++ b/imports/lib/models/Puzzles.ts
@@ -23,6 +23,7 @@ const Puzzle = withCommon(
     url: z.string().url().optional(),
     answers: answer.array(),
     expectedAnswerCount: z.number().int().nonnegative(),
+    completedWithNoAnswer: z.boolean().optional(),
     replacedBy: foreignKey.optional(),
   }),
 );

--- a/imports/lib/solvedness.ts
+++ b/imports/lib/solvedness.ts
@@ -3,7 +3,7 @@ import type { PuzzleType } from "./models/Puzzles";
 export type Solvedness = "noAnswers" | "solved" | "unsolved";
 export const computeSolvedness = (puzzle: PuzzleType): Solvedness => {
   if (puzzle.expectedAnswerCount === 0) {
-    return "noAnswers";
+    return puzzle.completedWithNoAnswer ? "solved" : "noAnswers";
   } else if (puzzle.answers.length < puzzle.expectedAnswerCount) {
     return "unsolved";
   } else {

--- a/imports/methods/createPuzzle.ts
+++ b/imports/methods/createPuzzle.ts
@@ -10,6 +10,7 @@ export default new TypedMethod<
     expectedAnswerCount: number;
     docType: GdriveMimeTypesType;
     allowDuplicateUrls?: boolean;
+    completedWithNoAnswer?: boolean;
   },
   string
 >("Puzzles.methods.create");

--- a/imports/methods/updatePuzzle.ts
+++ b/imports/methods/updatePuzzle.ts
@@ -8,6 +8,7 @@ export default new TypedMethod<
     tags: string[];
     expectedAnswerCount: number;
     allowDuplicateUrls?: boolean;
+    completedWithNoAnswer?: boolean;
   },
   void
 >("Puzzles.methods.update");

--- a/imports/server/addPuzzle.ts
+++ b/imports/server/addPuzzle.ts
@@ -32,6 +32,7 @@ async function createDocumentAndInsertPuzzle(
   tags: string[],
   url: string | undefined,
   docType: GdriveMimeTypesType,
+  completedWithNoAnswer: boolean | undefined,
 ): Promise<string> {
   // Look up each tag by name and map them to tag IDs.
   const tagIds = await Promise.all(
@@ -48,6 +49,7 @@ async function createDocumentAndInsertPuzzle(
     tags: [...new Set(tagIds)],
     answers: [],
     url,
+    completedWithNoAnswer,
   };
 
   // By creating the document before we save the puzzle, we make sure nobody
@@ -70,6 +72,7 @@ export default async function addPuzzle({
   docType,
   url,
   allowDuplicateUrls,
+  completedWithNoAnswer,
 }: {
   huntId: string;
   title: string;
@@ -78,6 +81,7 @@ export default async function addPuzzle({
   expectedAnswerCount: number;
   docType: GdriveMimeTypesType;
   allowDuplicateUrls?: boolean;
+  completedWithNoAnswer?: boolean;
 }) {
   const userId = Meteor.userId();
 
@@ -91,6 +95,7 @@ export default async function addPuzzle({
     Match.OneOf(...(Object.keys(GdriveMimeTypes) as GdriveMimeTypesType[])),
   );
   check(allowDuplicateUrls, Match.Optional(Boolean));
+  check(completedWithNoAnswer, Match.Optional(Boolean));
 
   const hunt = await Hunts.findOneAsync(huntId);
   if (!hunt) {
@@ -128,6 +133,7 @@ export default async function addPuzzle({
       tags,
       url,
       docType,
+      completedWithNoAnswer,
     );
   } else {
     // With a lock, look for a puzzle with the same URL. If present, we reject the insertion
@@ -143,6 +149,7 @@ export default async function addPuzzle({
         tags,
         url,
         docType,
+        completedWithNoAnswer,
       );
     });
   }

--- a/imports/server/methods/createPuzzle.ts
+++ b/imports/server/methods/createPuzzle.ts
@@ -17,6 +17,7 @@ defineMethod(createPuzzle, {
         ...(Object.keys(GdriveMimeTypes) as GdriveMimeTypesType[]),
       ),
       allowDuplicateUrls: Match.Optional(Boolean),
+      completedWithNoAnswer: Match.Optional(Boolean),
     });
     return arg;
   },
@@ -29,6 +30,7 @@ defineMethod(createPuzzle, {
     docType,
     url,
     allowDuplicateUrls,
+    completedWithNoAnswer,
   }) {
     check(this.userId, String);
     return addPuzzle({
@@ -39,6 +41,7 @@ defineMethod(createPuzzle, {
       docType,
       url,
       allowDuplicateUrls,
+      completedWithNoAnswer,
     });
   },
 });

--- a/imports/server/methods/updatePuzzle.ts
+++ b/imports/server/methods/updatePuzzle.ts
@@ -25,12 +25,20 @@ defineMethod(updatePuzzle, {
       // We accept this argument since it's provided by the form, but it's not checked here - only
       // during puzzle creation, to avoid duplicates when creating new puzzles.
       allowDuplicateUrls: Match.Optional(Boolean),
+      completedWithNoAnswer: Match.Optional(Boolean),
     });
 
     return arg;
   },
 
-  async run({ puzzleId, title, url, tags, expectedAnswerCount }) {
+  async run({
+    puzzleId,
+    title,
+    url,
+    tags,
+    expectedAnswerCount,
+    completedWithNoAnswer,
+  }) {
     check(this.userId, String);
 
     const oldPuzzle = await Puzzles.findOneAllowingDeletedAsync(puzzleId);
@@ -62,6 +70,7 @@ defineMethod(updatePuzzle, {
       puzzle: puzzleId,
       title,
       expectedAnswerCount,
+      completedWithNoAnswer,
     });
 
     const update: Mongo.Modifier<PuzzleType> = {
@@ -75,6 +84,11 @@ defineMethod(updatePuzzle, {
       update.$set = { ...update.$set, url };
     } else {
       update.$unset = { url: "" };
+    }
+    if (completedWithNoAnswer) {
+      update.$set = { ...update.$set, completedWithNoAnswer };
+    } else {
+      update.$unset = { completedWithNoAnswer: "" };
     }
     await Puzzles.updateAsync(puzzleId, update);
 


### PR DESCRIPTION
This makes it easier to track "task" shaped work -- tasks can be marked as 0-answer and solved when they are completed and yield no answer, and then they'll be filtered out of the "show only unsolved" view (and displayed in green, and so on).

We can probably do a second pass on the graphic design when it's not Hunt.