### PR TITLE
Only apply makeHuntFilterTransform when the field hunts exists

### DIFF
--- a/imports/server/users.ts
+++ b/imports/server/users.ts
@@ -97,10 +97,13 @@ const makeHuntFilterTransform = (
 ): ((user: Partial<Meteor.User>) => Partial<Meteor.User>) => {
   const huntSet = new Set(hunts);
   return (u) => {
-    return {
-      ...u,
-      hunts: u.hunts?.filter((h) => huntSet.has(h)),
-    };
+    if (u.hunts) {
+      return {
+        ...u,
+        hunts: u.hunts?.filter((h) => huntSet.has(h)),
+      };
+    }
+    return u;
   };
 };
 


### PR DESCRIPTION
Per discussion in Discord, this addresses the buggy behavior:

I have two users A and B.
I open the hunt/<id>/hunters page as A.
In a separate browser I log in as B and modify something in profile (e.g. change display name).
In A's window, B disappears from the profile list until I do a refresh.

This is because only the field changing (in this case, "displayName") is getting published, i.e. 
```{ displayName: "newName" }```
 but we still apply the makeHuntFilterTransform on the change doc, so it becomes 
```{ displayName: "newName"; hunts: undefined; }```
so we think the user is not in any hunts and therefore remove it from the list.

So we should only filter `hunts` when the field exists to avoid accidentally overriding the value with undefined.