### PR TITLE
Improve the docs linter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Fetch PR merge base
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags origin ${{ github.event.pull_request.base.sha }} --depth=1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:


### PR DESCRIPTION
In CI, this failed to pick up issues because CI was using a shallow clone of the repository, which meant that all files looked like they were created in the most recent commit (and thus equally up to date). Work around this by fetching the merge-base commit, so that we can tell if the files have been changed in the PR being reviewed.

In local execution, the script evaluated committed changes, but that meant that if you edited a file, it wouldn't cause the linter to fail until after you had committed it. To fix this, update the script to look at staged and unstaged changes. (If a source file change is staged, the docs update must also be staged; if source is changed in the working tree, the docs must also be changed in the working tree.)