### PR TITLE
PuzzlePage link to the puzzle should be 'puzzle' rather than puzzle title

### DIFF
--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -1130,8 +1130,7 @@ const PuzzlePageMetadata = ({
       target="_blank"
       rel="noreferrer noopener"
     >
-      <FontAwesomeIcon fixedWidth icon={faPuzzlePiece} />{" "}
-      <span>{puzzle.title}</span>
+      <FontAwesomeIcon fixedWidth icon={faPuzzlePiece} /> <span>Puzzle</span>
     </PuzzleMetadataExternalLink>
   ) : null;
 


### PR DESCRIPTION
Accidentally merged it with the i18n change.