### PR TITLE
Update copyright in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Evan Broder, Drew Fisher, Grant Elliott
+Copyright (c) 2018 Jolly Roger contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
When we originally open-sourced Jolly Roger, there were only three contributors, and so they were cited in the copyright notice. Since then, we have been lucky enough to have several more contributors as others on Death and Mayhem have contributed fixes and as other teams have adopted Jolly Roger. This commit updates the copyright notice to acknowledge all contributors.