### PR TITLE
Work around issue with device selection

### DIFF
--- a/imports/client/getAudioStream.ts
+++ b/imports/client/getAudioStream.ts
@@ -1,0 +1,42 @@
+/**
+ * Attempt to capture an audio stream, trying the preferred device first and
+ * falling back to the system default if it is unavailable.
+ */
+export default async function getAudioStream(
+  preferredDeviceId?: string,
+): Promise<MediaStream> {
+  const audioConstraints = {
+    echoCancellation: { ideal: true },
+    autoGainControl: { ideal: true },
+    noiseSuppression: { ideal: true },
+  };
+  if (preferredDeviceId) {
+    try {
+      return await navigator.mediaDevices.getUserMedia({
+        audio: { ...audioConstraints, deviceId: { exact: preferredDeviceId } },
+      });
+    } catch (e) {
+      if ((e as Error).name !== "OverconstrainedError") {
+        throw e;
+      }
+    }
+  }
+
+  // Try Chrome's "default" pseudo-device, which correctly tracks the OS
+  // default. Without this, Chrome may pick the first device instead.
+  // This throws OverconstrainedError on Firefox/Safari where "default"
+  // doesn't exist, so we fall through to an unconstrained call.
+  try {
+    return await navigator.mediaDevices.getUserMedia({
+      audio: { ...audioConstraints, deviceId: { exact: "default" } },
+    });
+  } catch (e) {
+    if ((e as Error).name !== "OverconstrainedError") {
+      throw e;
+    }
+  }
+
+  return await navigator.mediaDevices.getUserMedia({
+    audio: audioConstraints,
+  });
+}

--- a/imports/client/hooks/useCallState.ts
+++ b/imports/client/hooks/useCallState.ts
@@ -27,6 +27,7 @@ import mediasoupConnectTransport from "../../methods/mediasoupConnectTransport";
 import mediasoupSetPeerState from "../../methods/mediasoupSetPeerState";
 import mediasoupSetProducerPaused from "../../methods/mediasoupSetProducerPaused";
 import { PREFERRED_AUDIO_DEVICE_STORAGE_KEY } from "../components/AudioConfig";
+import getAudioStream from "../getAudioStream";
 import { trace } from "../tracing";
 import useBlockUpdate from "./useBlockUpdate";
 
@@ -1181,22 +1182,10 @@ const useCallState = ({
         dispatch({ type: "request-capture" });
         const preferredAudioDeviceId =
           localStorage.getItem(PREFERRED_AUDIO_DEVICE_STORAGE_KEY) ?? undefined;
-        // Get the user media stream.
-        const mediaStreamConstraints = {
-          audio: {
-            echoCancellation: { ideal: true },
-            autoGainControl: { ideal: true },
-            noiseSuppression: { ideal: true },
-            deviceId: preferredAudioDeviceId,
-          },
-          // TODO: conditionally allow video if enabled by feature flag?
-        };
 
         let mediaSource: MediaStream;
         try {
-          mediaSource = await navigator.mediaDevices.getUserMedia(
-            mediaStreamConstraints,
-          );
+          mediaSource = await getAudioStream(preferredAudioDeviceId);
         } catch (e) {
           dispatch({ type: "capture-error", error: e as Error });
           return;


### PR DESCRIPTION
Strangely, getUserMedia doesn't seem to always respect the provided deviceId unless it's constrained with the "exact" keyword. In particular, I regularly observed that even with a valid deviceId, Chrome would sometimes prefer the *first* available audio input device (which, annoyingly, happened to be my iPhone in Continuity Camera mode).

So instead, require the exact deviceId, and since it's possible that device is no longer available, fall back to the "default" device (which should match the OS default) before aborting.