### PR TITLE
Puzzles API: also allow completedWithNoAnswer

### DIFF
--- a/imports/server/api/resources/hunts.ts
+++ b/imports/server/api/resources/hunts.ts
@@ -81,12 +81,13 @@ hunts.post(
         ...(Object.keys(GdriveMimeTypes) as GdriveMimeTypesType[]),
       ),
       allowDuplicateUrls: Match.Optional(Boolean),
+      completedWithNoAnswer: Match.Optional(Boolean),
     });
 
     try {
       const id = await addPuzzle({
-        huntId: req.params.huntId,
         ...req.body,
+        huntId: req.params.huntId,
       });
       res.json({
         id,


### PR DESCRIPTION
I added this field in relative haste to the Puzzle model, but we should presumably also surface it in the API.

While we're here, it's not a security bug since we don't allow a huntId to be specified in the request body, but I always get a little nervous about object spreads possibly clobbering fields.  Last in the list wins; since we did access controls checks on huntId, we probably want to be sure that it carries the day, so I'm placing it last in the assignment list.