### PR TITLE
Throw on abort in discordSyncRole instead of returning

### DIFF
--- a/imports/server/jobs/discordSyncRole.ts
+++ b/imports/server/jobs/discordSyncRole.ts
@@ -65,7 +65,7 @@ const discordSyncRoleJob = defineJob(
       const discord = new DiscordBot(botToken);
 
       for (const userId of args.userIds) {
-        if (signal.aborted) return;
+        signal.throwIfAborted();
 
         const user = await MeteorUsers.findOneAsync(userId);
         if (!user?.discordAccount) {


### PR DESCRIPTION
A normal return causes the job worker to mark the job as completed, even though it may not have processed all users. Throwing lets the worker re-queue it for retry.