### PR TITLE
Fix SshUsers parameter changes not propagating to instances

### DIFF
--- a/cloudformation/jolly-roger.yaml
+++ b/cloudformation/jolly-roger.yaml
@@ -192,16 +192,12 @@ Resources:
       Runtime: nodejs22.x
       Handler: "index.main"
       Role: !GetAtt LambdaExecutionRole.Arn
-      Environment:
-        Variables:
-          sshUsers:
-            Ref: SshUsers
       Code:
         ZipFile: |
           const response = require('cfn-response');
 
           exports.main = function (event, context) {
-            const sshUsers = process.env.sshUsers.split(',');
+            const sshUsers = event.ResourceProperties.SshUsers.split(',');
             var output = 'users:\n'
             sshUsers.forEach((sshUser) => {
                 const parts = sshUser.split('=');
@@ -217,11 +213,7 @@ Resources:
     Condition: HaveServing
     Properties:
       ServiceToken: !GetAtt SshUsersParsingFunction.Arn
-      Suite: jammy
-      Region: !Ref "AWS::Region"
-      InstanceType: ebs-ssd
-      Architecture: amd64
-      VirtualizationType: hvm
+      SshUsers: !Ref SshUsers
 
   VPC:
     Type: AWS::EC2::VPC


### PR DESCRIPTION
The SshUsersParsing custom resource's properties didn't reference the SshUsers parameter, so CloudFormation wouldn't re-invoke the Lambda when it changed. Pass SshUsers as a resource property (and read it from event.ResourceProperties instead of process.env) so changes are detected. Also remove unused copy-pasted properties from an old AMI lookup resource.

Fixes #2424