### PR TITLE
Prevent Google Sheets from stealing focus on load

### DIFF
--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -1990,6 +1990,7 @@ const PuzzlePageMultiplayerDocument = React.memo(
     if (document) {
       inner = (
         <DocumentDisplay
+          key={document._id}
           document={document}
           displayMode="embed"
           user={selfUser}


### PR DESCRIPTION
When a spreadsheet iframe is embedded, Google Sheets aggressively grabs focus during initialization, interrupting chat input or other interactions. Add a focus guard overlay that polls activeElement and restores focus while the guard is up. The user clicks the overlay to dismiss it and allow normal sheet interaction.

We use requestAnimationFrame polling rather than window blur/focusout events because browsers do not reliably fire blur on the parent window when focus moves into a cross-origin iframe via script.

Key the DocumentDisplay on document._id so the guard resets on puzzle navigation.

Fixes #2283