### PR TITLE
Make Google account linking and enrollment idempotent

### DIFF
--- a/docs/google-drive.md
+++ b/docs/google-drive.md
@@ -32,7 +32,7 @@ files:
   - imports/server/models/DriveActivityLatests.ts
   - imports/server/setup.ts
   - private/google-script/main.js
-updated: 2026-02-02
+updated: 2026-02-12
 ---
 
 # Google Drive Integration

--- a/imports/methods/updateProfile.ts
+++ b/imports/methods/updateProfile.ts
@@ -5,6 +5,11 @@ export default new TypedMethod<
     displayName: string;
     phoneNumber?: string;
     dingwords: string[];
+    // If provided, identifies the user by enrollment token instead of
+    // requiring a logged-in session. This allows updateProfile to be called
+    // before Accounts.resetPassword consumes the token, making the
+    // enrollment flow resilient to method retries on connection drops.
+    enrollmentToken?: string;
   },
   void
 >("Users.methods.updateProfile");


### PR DESCRIPTION
linkUserGoogleAccount: handle the case where Google.retrieveCredential returns undefined because the pending credential was already consumed by a Meteor method retry. If the user already has a Google account linked, treat it as a no-op. Fixes #1945.

updateProfile: accept an optional enrollmentToken that identifies the user by their enrollment token instead of requiring a logged-in session. EnrollForm now calls updateProfile (with the token) before Accounts.resetPassword, so the profile is saved while the token is still valid. If resetPassword's response is lost and Meteor retries it, the profile is already persisted. Fixes #1946.

(Hat-tip to Claude for coming up with pretty cromulent workarounds for these issues when I could not)