### PR TITLE
Implement hunt purging

### DIFF
--- a/docs/google-drive.md
+++ b/docs/google-drive.md
@@ -32,7 +32,7 @@ files:
   - imports/server/models/DriveActivityLatests.ts
   - imports/server/setup.ts
   - private/google-script/main.js
-updated: 2026-02-02
+updated: 2026-02-12
 ---
 
 # Google Drive Integration

--- a/imports/client/components/HuntPurgeModal.tsx
+++ b/imports/client/components/HuntPurgeModal.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useId, useState } from "react";
+import Alert from "react-bootstrap/Alert";
+import FormControl from "react-bootstrap/FormControl";
+import FormGroup from "react-bootstrap/FormGroup";
+import FormLabel from "react-bootstrap/FormLabel";
+import { Trans, useTranslation } from "react-i18next";
+import type { HuntType } from "../../lib/models/Hunts";
+import purgeHunt from "../../methods/purgeHunt";
+import ModalForm, { type ModalFormHandle } from "./ModalForm";
+
+const HuntPurgeModal = ({
+  ref,
+  hunt,
+}: {
+  ref: React.RefObject<ModalFormHandle | null>;
+  hunt: HuntType;
+}) => {
+  const [confirmText, setConfirmText] = useState<string>("");
+  const idPrefix = useId();
+  const { t } = useTranslation();
+
+  const onConfirmTextChanged = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setConfirmText(e.target.value);
+    },
+    [],
+  );
+
+  const onPurge = useCallback(
+    (callback: () => void) => {
+      purgeHunt.call({ huntId: hunt._id }, callback);
+    },
+    [hunt._id],
+  );
+
+  return (
+    <ModalForm
+      ref={ref}
+      title={t("huntList.purge.confirm.title", "Purge hunt")}
+      submitLabel={t("huntList.purge.confirm.submit", "Purge")}
+      submitStyle="danger"
+      onSubmit={onPurge}
+      closeDisabled={false}
+      submitDisabled={confirmText !== hunt.name}
+    >
+      <div>
+        {t(
+          "huntList.purge.confirm.text",
+          'Are you sure you want to purge all content from "{{huntName}}"? This will additionally delete all puzzles and associated state, including Google documents and files associated with this hunt stored in S3.',
+          { huntName: hunt.name },
+        )}
+        <Alert variant="danger">
+          {t("huntList.purge.confirm.warning", "This action cannot be undone.")}
+        </Alert>
+        <FormGroup controlId={`${idPrefix}-confirm`}>
+          <FormLabel>
+            <Trans
+              i18nKey="huntList.purge.confirm.instructions"
+              t={t}
+              defaults={"Type <code>{{huntName}}</code> below to confirm"}
+              components={{
+                code: <code />,
+              }}
+              values={{ huntName: hunt.name }}
+            />
+          </FormLabel>
+          <FormControl
+            type="text"
+            value={confirmText}
+            onChange={onConfirmTextChanged}
+            placeholder={hunt.name}
+          />
+        </FormGroup>
+      </div>
+    </ModalForm>
+  );
+};
+
+export default HuntPurgeModal;

--- a/imports/client/components/ModalForm.tsx
+++ b/imports/client/components/ModalForm.tsx
@@ -30,6 +30,7 @@ const ModalForm = (props: {
   submitLabel?: string;
   submitStyle?: string;
   submitDisabled?: boolean;
+  closeDisabled?: boolean;
   onSubmit: (callback: () => void) => void;
   children: React.ReactNode;
   ref: React.Ref<ModalFormHandle>;
@@ -88,7 +89,7 @@ const ModalForm = (props: {
           <Button
             variant="light"
             onClick={hide}
-            disabled={props.submitDisabled}
+            disabled={props.closeDisabled ?? props.submitDisabled}
           >
             {t("common.close", "Close")}
           </Button>

--- a/imports/lib/models/Announcements.ts
+++ b/imports/lib/models/Announcements.ts
@@ -15,6 +15,7 @@ const Announcement = withCommon(
 
 const Announcements = new SoftDeletedModel("jr_announcements", Announcement);
 Announcements.addIndex({ deleted: 1, hunt: 1, createdAt: -1 });
+Announcements.addIndex({ hunt: 1 });
 export type AnnouncementType = ModelType<typeof Announcements>;
 
 export default Announcements;

--- a/imports/lib/models/BookmarkNotifications.ts
+++ b/imports/lib/models/BookmarkNotifications.ts
@@ -32,6 +32,7 @@ const BookmarkNotifications = new SoftDeletedModel(
   BookmarkNotification,
 );
 BookmarkNotifications.addIndex({ deleted: 1, user: 1 });
+BookmarkNotifications.addIndex({ hunt: 1 });
 export type BookmarkNotificationType = ModelType<typeof BookmarkNotifications>;
 
 export default BookmarkNotifications;

--- a/imports/lib/models/Bookmarks.ts
+++ b/imports/lib/models/Bookmarks.ts
@@ -17,6 +17,7 @@ const Bookmark = withCommon(
 const Bookmarks = new SoftDeletedModel("jr_bookmarks", Bookmark);
 Bookmarks.addIndex({ user: 1, hunt: 1, puzzle: 1 }, { unique: true });
 Bookmarks.addIndex({ puzzle: 1 });
+Bookmarks.addIndex({ hunt: 1 });
 export type BookmarkType = ModelType<typeof Bookmarks>;
 
 export default Bookmarks;

--- a/imports/lib/models/ChatNotifications.ts
+++ b/imports/lib/models/ChatNotifications.ts
@@ -31,6 +31,7 @@ const ChatNotifications = new SoftDeletedModel(
   ChatNotification,
 );
 ChatNotifications.addIndex({ deleted: 1, user: 1 });
+ChatNotifications.addIndex({ hunt: 1 });
 export type ChatNotificationType = ModelType<typeof ChatNotifications>;
 
 export default ChatNotifications;

--- a/imports/lib/models/Documents.ts
+++ b/imports/lib/models/Documents.ts
@@ -27,6 +27,7 @@ const DocumentSchema = withCommon(
 const Documents = new SoftDeletedModel("jr_documents", DocumentSchema);
 Documents.addIndex({ deleted: 1, puzzle: 1 });
 Documents.addIndex({ "value.id": 1 });
+Documents.addIndex({ hunt: 1 });
 export type DocumentType = ModelType<typeof Documents>;
 
 export default Documents;

--- a/imports/lib/models/Guesses.ts
+++ b/imports/lib/models/Guesses.ts
@@ -45,6 +45,7 @@ const Guess = withCommon(
 const Guesses = new SoftDeletedModel("jr_guesses", Guess);
 Guesses.addIndex({ deleted: 1, hunt: 1, puzzle: 1 });
 Guesses.addIndex({ deleted: 1, state: 1 });
+Guesses.addIndex({ hunt: 1 });
 export type GuessType = ModelType<typeof Guesses>;
 
 export default Guesses;

--- a/imports/lib/models/PendingAnnouncements.ts
+++ b/imports/lib/models/PendingAnnouncements.ts
@@ -19,6 +19,7 @@ const PendingAnnouncements = new SoftDeletedModel(
   PendingAnnouncement,
 );
 PendingAnnouncements.addIndex({ user: 1 });
+PendingAnnouncements.addIndex({ hunt: 1 });
 export type PendingAnnouncementType = ModelType<typeof PendingAnnouncements>;
 
 export default PendingAnnouncements;

--- a/imports/lib/models/Puzzles.ts
+++ b/imports/lib/models/Puzzles.ts
@@ -31,6 +31,7 @@ const Puzzle = withCommon(
 const Puzzles = new SoftDeletedModel("jr_puzzles", Puzzle);
 Puzzles.addIndex({ deleted: 1, hunt: 1 });
 Puzzles.addIndex({ url: 1 });
+Puzzles.addIndex({ hunt: 1 });
 export type PuzzleType = ModelType<typeof Puzzles>;
 
 export default Puzzles;

--- a/imports/lib/models/Tags.ts
+++ b/imports/lib/models/Tags.ts
@@ -13,6 +13,7 @@ const Tag = withCommon(
 
 const Tags = new SoftDeletedModel("jr_tags", Tag);
 Tags.addIndex({ deleted: 1, hunt: 1, name: 1 });
+Tags.addIndex({ hunt: 1 });
 export type TagType = ModelType<typeof Tags>;
 
 export default Tags;

--- a/imports/lib/models/mediasoup/Rooms.ts
+++ b/imports/lib/models/mediasoup/Rooms.ts
@@ -18,6 +18,7 @@ const Room = withCommon(
 const Rooms = new SoftDeletedModel("jr_mediasoup_rooms", Room);
 Rooms.addIndex({ call: 1 }, { unique: true });
 Rooms.addIndex({ routedServer: 1 });
+Rooms.addIndex({ hunt: 1 });
 export type RoomType = ModelType<typeof Rooms>;
 
 export default Rooms;

--- a/imports/lib/models/mediasoup/Routers.ts
+++ b/imports/lib/models/mediasoup/Routers.ts
@@ -18,6 +18,7 @@ const Routers = new SoftDeletedModel("jr_mediasoup_routers", Router);
 Routers.addIndex({ call: 1 }, { unique: true });
 Routers.addIndex({ routerId: 1 });
 Routers.addIndex({ createdServer: 1 });
+Routers.addIndex({ hunt: 1 });
 export type RouterType = ModelType<typeof Routers>;
 
 export default Routers;

--- a/imports/lib/permission_stubs.ts
+++ b/imports/lib/permission_stubs.ts
@@ -304,6 +304,14 @@ export function userMayUpdateHunt(
   return isAdmin(user);
 }
 
+export function userMayPurgeHunt(
+  user: Pick<Meteor.User, "roles"> | null | undefined,
+  _hunt: Pick<HuntType, "_id"> | null | undefined,
+): boolean {
+  // TODO: make this driven by if you're an owner of the hunt in question
+  return isAdmin(user);
+}
+
 export function userMayJoinCallsForHunt(
   user: Pick<Meteor.User, "roles" | "hunts"> | null | undefined,
   hunt: Pick<HuntType, "_id"> | null | undefined,

--- a/imports/methods/purgeHunt.ts
+++ b/imports/methods/purgeHunt.ts
@@ -1,0 +1,3 @@
+import TypedMethod from "./TypedMethod";
+
+export default new TypedMethod<{ huntId: string }, void>("Hunts.methods.purge");

--- a/imports/server/gdrive.ts
+++ b/imports/server/gdrive.ts
@@ -137,6 +137,17 @@ export async function moveDocument(id: string, newParentId: string) {
   });
 }
 
+export async function deleteDocument(id: string) {
+  await checkClientOk();
+  if (!GoogleClient.drive) {
+    throw new Meteor.Error(500, "Google integration is disabled");
+  }
+
+  await GoogleClient.drive.files.delete({
+    fileId: id,
+  });
+}
+
 export async function huntFolderName(huntName: string) {
   return `${huntName}: ${await getTeamName()}`;
 }

--- a/imports/server/jobs/index.ts
+++ b/imports/server/jobs/index.ts
@@ -1,2 +1,3 @@
 import "./discordSyncRole";
+import "./purgeHunt";
 import "./framework/jobWorker";

--- a/imports/server/jobs/purgeHunt.ts
+++ b/imports/server/jobs/purgeHunt.ts
@@ -1,0 +1,287 @@
+import { setTimeout } from "node:timers/promises";
+import { Meteor } from "meteor/meteor";
+import {
+  DeleteObjectsCommand,
+  paginateListObjectsV2,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { z } from "zod";
+import Flags from "../../Flags";
+import Logger from "../../Logger";
+import Announcements from "../../lib/models/Announcements";
+import APIKeys from "../../lib/models/APIKeys";
+import BlobMappings from "../../lib/models/BlobMappings";
+import BookmarkNotifications from "../../lib/models/BookmarkNotifications";
+import Bookmarks from "../../lib/models/Bookmarks";
+import ChatMessages from "../../lib/models/ChatMessages";
+import ChatNotifications from "../../lib/models/ChatNotifications";
+import { foreignKey } from "../../lib/models/customTypes";
+import DiscordCache from "../../lib/models/DiscordCache";
+import DiscordRoleGrants from "../../lib/models/DiscordRoleGrants";
+import DocumentActivities from "../../lib/models/DocumentActivities";
+import Documents from "../../lib/models/Documents";
+import FeatureFlags from "../../lib/models/FeatureFlags";
+import FolderPermissions from "../../lib/models/FolderPermissions";
+import Guesses from "../../lib/models/Guesses";
+import Hunts from "../../lib/models/Hunts";
+import InvitationCodes from "../../lib/models/InvitationCodes";
+import Jobs from "../../lib/models/Jobs";
+import type Model from "../../lib/models/Model";
+import { AllModels } from "../../lib/models/Model";
+import CallHistories from "../../lib/models/mediasoup/CallHistories";
+import ConnectAcks from "../../lib/models/mediasoup/ConnectAcks";
+import ConnectRequests from "../../lib/models/mediasoup/ConnectRequests";
+import ConsumerAcks from "../../lib/models/mediasoup/ConsumerAcks";
+import Consumers from "../../lib/models/mediasoup/Consumers";
+import MonitorConnectAcks from "../../lib/models/mediasoup/MonitorConnectAcks";
+import MonitorConnectRequests from "../../lib/models/mediasoup/MonitorConnectRequests";
+import PeerRemoteMutes from "../../lib/models/mediasoup/PeerRemoteMutes";
+import Peers from "../../lib/models/mediasoup/Peers";
+import ProducerClients from "../../lib/models/mediasoup/ProducerClients";
+import ProducerServers from "../../lib/models/mediasoup/ProducerServers";
+import Rooms from "../../lib/models/mediasoup/Rooms";
+import Routers from "../../lib/models/mediasoup/Routers";
+import TransportRequests from "../../lib/models/mediasoup/TransportRequests";
+import TransportStates from "../../lib/models/mediasoup/TransportStates";
+import Transports from "../../lib/models/mediasoup/Transports";
+import PendingAnnouncements from "../../lib/models/PendingAnnouncements";
+import Puzzles from "../../lib/models/Puzzles";
+import Servers from "../../lib/models/Servers";
+import Settings from "../../lib/models/Settings";
+import Tags from "../../lib/models/Tags";
+import { deleteDocument } from "../gdrive";
+import Blobs from "../models/Blobs";
+import CallActivities from "../models/CallActivities";
+import DriveActivityLatests from "../models/DriveActivityLatests";
+import HuntFolders from "../models/HuntFolders";
+import LatestDeploymentTimestamps from "../models/LatestDeploymentTimestamps";
+import Locks from "../models/Locks";
+import Subscribers from "../models/Subscribers";
+import UploadTokens from "../models/UploadTokens";
+import defineJob from "./framework/defineJob";
+
+const COLLECTIONS_TO_PURGE = [
+  // Delete Puzzles first, because most things do a decent job of handling nonexistent puzzle ids,
+  // and once the Puzzle object doesn't exist we reject a lot of other writes, so we're less likely
+  // to leak objects and leave a mess
+  Puzzles,
+  // Other than that, try to mostly maintain referential integrity
+  ChatNotifications,
+  ChatMessages,
+  Peers,
+  Rooms,
+  Routers,
+  CallActivities,
+  CallHistories,
+  PendingAnnouncements,
+  Announcements,
+  DocumentActivities,
+  Documents,
+  Guesses,
+  BookmarkNotifications,
+  Bookmarks,
+  Tags,
+];
+
+// In the fullness of time, it would be nice if we only had to list models
+// that have a hunt foreignKey, but that involves a lot of walking zod schema
+// objects and we're likely to have to rewrite any such code
+const COLLECTIONS_EXPLICITLY_LEFT_UNTOUCHED = [
+  // References hunt and should be left alone
+  InvitationCodes,
+
+  // Doesn't reference hunt but it was easier to write this enforcement around
+  APIKeys,
+  BlobMappings,
+  Blobs,
+  DiscordCache,
+  DiscordRoleGrants,
+  DriveActivityLatests,
+  FeatureFlags,
+  FolderPermissions,
+  Hunts, // We don't want to touch the Hunts collection.
+  HuntFolders,
+  Jobs,
+  LatestDeploymentTimestamps,
+  Locks,
+  Servers,
+  Settings,
+  Subscribers,
+  UploadTokens,
+  // mediasoup
+  ConnectAcks,
+  ConnectRequests,
+  ConsumerAcks,
+  Consumers,
+  MonitorConnectAcks,
+  MonitorConnectRequests,
+  PeerRemoteMutes,
+  ProducerClients,
+  ProducerServers,
+  TransportRequests,
+  TransportStates,
+  Transports,
+];
+
+Meteor.startup(() => {
+  // Check that we have classified every Model above, so we don't add a new
+  // collection that references a hunt and forget to add it to the purge list.
+  const knownCollections = new Set([
+    ...COLLECTIONS_TO_PURGE,
+    ...COLLECTIONS_EXPLICITLY_LEFT_UNTOUCHED,
+  ]);
+  for (const model of AllModels) {
+    if (model.name.startsWith("test_schema")) {
+      // These are randomly generated by the unit test suite, ignore them
+      continue;
+    }
+    if (!knownCollections.has(model)) {
+      throw new Error(
+        `Please classify the ${model.name} collection as needing purging or not in imports/servers/jobs/purgeHunt.ts`,
+      );
+    }
+  }
+});
+
+const DAYS_MSEC = 24 * 60 * 60 * 1000;
+
+const purgeHuntJob = defineJob(
+  "hunt.purgeHunt",
+  z.object({
+    huntId: foreignKey,
+  }),
+  {
+    result: z.object({
+      itemsTotal: z.number(), // How many total units of work do we need to complete?
+      itemsCompleted: z.number(), // How many units of work have we completed so far?
+      currentItemTotal: z.optional(z.number()), // Within the current unit of work, how many substeps are involved?
+      currentItemCompleted: z.optional(z.number()), // And how many have we completed so far?
+    }),
+    maxAttempts: 3,
+    deleteAfter: () => {
+      return new Date(Date.now() + 30 * DAYS_MSEC);
+    },
+    async run(args, { signal, setResult }) {
+      // Verify that hunt exists
+      const hunt = await Hunts.findOneAsync(args.huntId);
+      if (!hunt) {
+        Logger.info("Hunt does not exist", { huntId: args.huntId });
+        return;
+      }
+
+      const itemsTotal = 3 + COLLECTIONS_TO_PURGE.length;
+      let itemsCompleted = 0;
+      await setResult({ itemsTotal, itemsCompleted });
+
+      // Remove all the Puzzles.  We do this first because once puzzle IDs no longer refer to a valid Puzzle,
+      // we stop allowing insertion of other documents which reference that puzzle, which means we can expect
+      // writes to quiesce and better guarantee that we don't leak documents due to clients making additional
+      // requests.
+      await Puzzles.removeAsync({ hunt: args.huntId });
+      itemsCompleted += 1;
+      await setResult({ itemsTotal, itemsCompleted });
+
+      // Delete any Documents from the Google Drive
+      if (await Flags.activeAsync("disable.google")) {
+        Logger.info(
+          "Skipping Document deletion because Google is disabled by feature flag",
+          { huntId: args.huntId },
+        );
+      } else {
+        const docs = await Documents.findAllowingDeleted({
+          hunt: args.huntId,
+        }).fetchAsync();
+        const currentItemTotal = docs.length;
+        let currentItemCompleted = 0;
+        for (const doc of docs) {
+          signal.throwIfAborted();
+          Logger.info("Remove Google drive document", {
+            id: doc._id,
+            fileId: doc.value.id,
+          });
+          await deleteDocument(doc.value.id);
+          await Documents.removeAsync(doc._id);
+          currentItemCompleted += 1;
+          await setResult({
+            itemsTotal,
+            itemsCompleted,
+            currentItemTotal,
+            currentItemCompleted,
+          });
+          // Avoid tripping on Drive's rate limits
+          await setTimeout(500);
+        }
+      }
+      itemsCompleted += 1;
+      await setResult({ itemsTotal, itemsCompleted });
+
+      // If an s3 bucket is configured, delete everything in the /{huntId} key prefix of that bucket
+      const s3BucketSettings = await Settings.findOneAsync({
+        name: "s3.image_bucket",
+      });
+      if (s3BucketSettings?.value) {
+        const s3 = new S3Client({
+          region: s3BucketSettings.value.bucketRegion,
+        });
+
+        const paginator = paginateListObjectsV2(
+          { client: s3, pageSize: 500 },
+          {
+            Bucket: s3BucketSettings.value.bucketName,
+            Prefix: `${args.huntId}/`,
+          },
+        );
+
+        // We don't know the total number of pages without reading them, so we'll just track pages completed
+        let currentItemCompleted = 0;
+        for await (const page of paginator) {
+          signal.throwIfAborted();
+          if (page.Contents) {
+            const keysToDelete = page.Contents.map((o) => {
+              return {
+                Key: o.Key,
+              };
+            });
+            if (keysToDelete.length > 0) {
+              await s3.send(
+                new DeleteObjectsCommand({
+                  Bucket: s3BucketSettings.value.bucketName,
+                  Delete: {
+                    Objects: keysToDelete,
+                    Quiet: true,
+                  },
+                }),
+              );
+            }
+            currentItemCompleted += 1;
+            await setResult({
+              itemsTotal,
+              itemsCompleted,
+              currentItemCompleted,
+            });
+          }
+        }
+      }
+      itemsCompleted += 1;
+
+      // Purge all collections
+      for (const collection of COLLECTIONS_TO_PURGE) {
+        signal.throwIfAborted();
+        Logger.info("purgeHunt: removing from collection", {
+          collection: collection.name,
+        });
+        const castCollection = collection as unknown as Model<
+          z.ZodObject<{ hunt: z.ZodString }>
+        >;
+        await castCollection.removeAsync({ hunt: args.huntId });
+        itemsCompleted += 1;
+        await setResult({
+          itemsTotal,
+          itemsCompleted,
+        });
+      }
+    },
+  },
+);
+
+export default purgeHuntJob;

--- a/imports/server/methods/index.ts
+++ b/imports/server/methods/index.ts
@@ -54,6 +54,7 @@ import "./postAnnouncement";
 import "./promoteOperator";
 import "./provisionFirstUser";
 import "./provisionScreenshotData";
+import "./purgeHunt";
 import "./removePuzzleAnswer";
 import "./removePuzzleTag";
 import "./renameTag";

--- a/imports/server/methods/purgeHunt.ts
+++ b/imports/server/methods/purgeHunt.ts
@@ -1,0 +1,20 @@
+import { check } from "meteor/check";
+import MeteorUsers from "../../lib/models/MeteorUsers";
+import { checkAdmin } from "../../lib/permission_stubs";
+import purgeHunt from "../../methods/purgeHunt";
+import purgeHuntJob from "../jobs/purgeHunt";
+import defineMethod from "./defineMethod";
+
+defineMethod(purgeHunt, {
+  validate(arg) {
+    check(arg, { huntId: String });
+    return arg;
+  },
+
+  async run({ huntId }) {
+    check(this.userId, String);
+    checkAdmin(await MeteorUsers.findOneAsync(this.userId));
+
+    await purgeHuntJob.enqueue({ huntId });
+  },
+});


### PR DESCRIPTION
Some teams like to set up a new Hunt and invite users and let them poke around at the Jolly Roger UI to familiarize themselves with features, but then would like to wipe any data generated in that hunt.

This change adds:

* a new async job purgeHunt, which deletes nearly everything within a Hunt, including Google documents and files on S3 associated with that hunt, but not the Hunt object itself (nor its membership, roles, or InvitationCodes).
* indexes to collections that the purgeHunt job will query
* a new TypedMethod purgeHunt which queues an instance of that job
* a new button & modal on the HuntListPage for admins to be able to call the purgeHunt method

The general strategy is: delete Google documents from Google, delete S3 files from S3, and then for every collection that has a foreign key on Hunt, except InvitationCodes, remove everything from that collection.

To avoid the risk of new collections with hunt foreign keys being added to the codebase but not to the list of collections to purge in purgeHunt, we exhaustively list collections and (at server startup, once all Models should have been imported) verify that we have classified all collections as "to be purged" or "explicitly ignored".

In the fullness of time, it would be nice to only need to classify collections that have a hunt foreignKey, but 1) the code to do that would be a little annoying since it'd have to walk all the schemas, and 2) that code would be tied to zod 3, which we're trying to upgrade away from.  So for now we'll just make ourselves classify every Model.