### PR TITLE
Add createdAt to Servers

### DIFF
--- a/imports/lib/garbageCollection.ts
+++ b/imports/lib/garbageCollection.ts
@@ -1,0 +1,8 @@
+// Servers disappearing should be a fairly rare occurrence, so it's
+// OK for the timeouts here to be generous. Servers get 120 seconds
+// to update before their records are GC'd. Should be long enough to
+// account for transients
+export const gracePeriod = 120 * 1000;
+
+// Servers will attempt to refresh their liveness once every 15-30 seconds.
+export const refreshIntervalBase = 15000;

--- a/imports/lib/models/Servers.ts
+++ b/imports/lib/models/Servers.ts
@@ -9,6 +9,10 @@ const Server = z.object({
   // updatedAt is *not* set automatically, because we don't want to update it
   // when other servers are performing garbage collection
   updatedAt: z.date(),
+  // createdAt is also not set automatically.  Optional for migration;
+  // otherwise garbage collection can fail validation on entries that were
+  // inserted without a createdAt set.
+  createdAt: z.date().optional(),
   cleanupInProgressBy: foreignKey.optional(),
 });
 


### PR DESCRIPTION
Sometimes it can be useful to know when a process was started up, so you can see at a glance "is this backend instance one of the ones that I expect to be dying as a new version rolls out to the servers or is this the one that has just started up?"

Take this opportunity to do some UX tweaks to the Servers table: show relative times (with absolute times on hover), track time since last heartbeat until server is eligible for mongo-based GC (usually they get collected via webrtc monitor GC before that anyway), and rework the column spacings based on how much content generally has to fit there.

<img width="1479" height="1515" alt="Screenshot 2026-02-13 at 00 20 26" src="https://github.com/user-attachments/assets/2aab7924-2c83-43c4-8c41-b89e14e1d1b4" />

<img width="1479" height="1515" alt="Screenshot 2026-02-13 at 00 20 42" src="https://github.com/user-attachments/assets/bcabe2b9-aa03-4128-9dd1-e7db3e24011d" />
