### PR TITLE
Extract serverId from garbage-collection

### DIFF
--- a/imports/server/configureLogger.ts
+++ b/imports/server/configureLogger.ts
@@ -3,8 +3,8 @@ import { Meteor } from "meteor/meteor";
 import logfmt from "logfmt";
 import { format, transports } from "winston";
 import { logger } from "../Logger";
-import { serverId } from "./garbage-collection";
 import { workersCount } from "./loadBalance";
+import serverId from "./serverId";
 
 const userIdSymbol = Symbol("userId");
 

--- a/imports/server/garbage-collection.ts
+++ b/imports/server/garbage-collection.ts
@@ -10,8 +10,7 @@ import { gracePeriod, refreshIntervalBase } from "../lib/garbageCollection";
 import Servers from "../lib/models/Servers";
 import ignoringDuplicateKeyErrors from "./ignoringDuplicateKeyErrors";
 import onExit from "./onExit";
-
-const serverId = Random.id();
+import serverId from "./serverId";
 
 // Global registry of callbacks to run when we determine that a backend is dead.
 const globalGCHooks: ((deadServers: string) => void | Promise<void>)[] = [];
@@ -150,4 +149,4 @@ Meteor.startup(() => {
   });
 });
 
-export { serverId, registerPeriodicCleanupHook };
+export { registerPeriodicCleanupHook };

--- a/imports/server/jobs/framework/jobWorker.ts
+++ b/imports/server/jobs/framework/jobWorker.ts
@@ -4,11 +4,9 @@ import { DDP } from "meteor/ddp";
 import { Meteor } from "meteor/meteor";
 import Logger from "../../../Logger";
 import Jobs, { type JobType } from "../../../lib/models/Jobs";
-import {
-  registerPeriodicCleanupHook,
-  serverId,
-} from "../../garbage-collection";
+import { registerPeriodicCleanupHook } from "../../garbage-collection";
 import onExit from "../../onExit";
+import serverId from "../../serverId";
 import { getHandler } from "./defineJob";
 
 interface WorkerEvents {

--- a/imports/server/mediasoup-api.ts
+++ b/imports/server/mediasoup-api.ts
@@ -21,8 +21,9 @@ import Transports from "../lib/models/mediasoup/Transports";
 import Puzzles from "../lib/models/Puzzles";
 import Servers from "../lib/models/Servers";
 import { checkAdmin, userMayJoinCallsForHunt } from "../lib/permission_stubs";
-import { registerPeriodicCleanupHook, serverId } from "./garbage-collection";
+import { registerPeriodicCleanupHook } from "./garbage-collection";
 import ignoringDuplicateKeyErrors from "./ignoringDuplicateKeyErrors";
+import serverId from "./serverId";
 import withLock from "./withLock";
 
 registerPeriodicCleanupHook(async (deadServer) => {

--- a/imports/server/mediasoup.ts
+++ b/imports/server/mediasoup.ts
@@ -39,11 +39,11 @@ import throttle from "../lib/throttle";
 import {
   cleanupDeadServer,
   registerPeriodicCleanupHook,
-  serverId,
 } from "./garbage-collection";
 import ignoringDuplicateKeyErrors from "./ignoringDuplicateKeyErrors";
 import CallActivities from "./models/CallActivities";
 import onExit from "./onExit";
+import serverId from "./serverId";
 
 const mediaCodecs: types.RouterRtpCodecCapability[] = [
   {

--- a/imports/server/methods/mediasoupAckConsumer.ts
+++ b/imports/server/methods/mediasoupAckConsumer.ts
@@ -4,7 +4,7 @@ import Flags from "../../Flags";
 import ConsumerAcks from "../../lib/models/mediasoup/ConsumerAcks";
 import Consumers from "../../lib/models/mediasoup/Consumers";
 import mediasoupAckConsumer from "../../methods/mediasoupAckConsumer";
-import { serverId } from "../garbage-collection";
+import serverId from "../serverId";
 import defineMethod from "./defineMethod";
 
 defineMethod(mediasoupAckConsumer, {

--- a/imports/server/methods/mediasoupConnectTransport.ts
+++ b/imports/server/methods/mediasoupConnectTransport.ts
@@ -4,7 +4,7 @@ import Flags from "../../Flags";
 import ConnectRequests from "../../lib/models/mediasoup/ConnectRequests";
 import Transports from "../../lib/models/mediasoup/Transports";
 import mediasoupConnectTransport from "../../methods/mediasoupConnectTransport";
-import { serverId } from "../garbage-collection";
+import serverId from "../serverId";
 import defineMethod from "./defineMethod";
 
 defineMethod(mediasoupConnectTransport, {

--- a/imports/server/serverId.ts
+++ b/imports/server/serverId.ts
@@ -1,0 +1,5 @@
+import { Random } from "meteor/random";
+
+const serverId = Random.id();
+
+export default serverId;

--- a/imports/server/subscribers.ts
+++ b/imports/server/subscribers.ts
@@ -8,8 +8,9 @@
 
 import { check, Match } from "meteor/check";
 import { Meteor } from "meteor/meteor";
-import { registerPeriodicCleanupHook, serverId } from "./garbage-collection";
+import { registerPeriodicCleanupHook } from "./garbage-collection";
 import Subscribers from "./models/Subscribers";
+import serverId from "./serverId";
 
 // Clean up leaked subscribers from dead servers periodically.
 async function cleanupHook(deadServer: string) {


### PR DESCRIPTION
Code which runs very early in startup needs to be very careful about minimizing imports and avoiding unintentional side-effects through imported symbols living in the same file as side-effectful functions.

`configureLogger.ts` was importing serverId from garbage-collection very early on in process startup.  This had the result of registering the garbage-collection Meteor.startup() function very early in the process's lifecycle, which has the effect of running the Servers insertion before doing things like schema updates, index creation, or running migrations.

This is potentially problematic because it results in us issuing mongo-schema-checked writes against a version of the schema that existed in the database rather than the one that we would attach based on the current version of the code.

This is especially problematic for the Servers collection because it results in the server running, but no other servers in the cluster knowing that it exists.  This prevents them from connecting over the webrtc heartbeat channel, which leads the primary server instance to believe that all the children it has spawned are unresponsive, so it marks them for deletion 10 seconds after spawning them and continues to do this in a loop indefinitely.