### PR TITLE
Import act from @testing-library/react

### DIFF
--- a/tests/acceptance/authentication.tsx
+++ b/tests/acceptance/authentication.tsx
@@ -1,9 +1,8 @@
 import { promisify } from "node:util";
 import { Meteor } from "meteor/meteor";
-import { cleanup, render } from "@testing-library/react";
+import { act, cleanup, render } from "@testing-library/react";
 import { assert } from "chai";
 import type React from "react";
-import { act } from "react";
 import type { Location, NavigateFunction } from "react-router-dom";
 import {
   MemoryRouter,

--- a/tests/acceptance/smoke.tsx
+++ b/tests/acceptance/smoke.tsx
@@ -1,8 +1,7 @@
 import { promisify } from "node:util";
 import { Meteor } from "meteor/meteor";
-import { render } from "@testing-library/react";
+import { act, render } from "@testing-library/react";
 import type React from "react";
-import { act } from "react";
 import type { Location, NavigateFunction, RouteObject } from "react-router-dom";
 import {
   MemoryRouter,


### PR DESCRIPTION
Previously, these test files imported act directly from "react", which doesn't set IS_REACT_ACT_ENVIRONMENT and causes React to log a warning for every state update inside act(). @testing-library/react's re-export wraps act to set the flag automatically.