### PR TITLE
Add formerHunts field to user model

### DIFF
--- a/imports/lib/models/User.ts
+++ b/imports/lib/models/User.ts
@@ -9,6 +9,9 @@ declare module "meteor/meteor" {
     interface User {
       lastLogin?: Date;
       hunts?: string[];
+      // Hunts the user was removed from. We keep this so their display name
+      // and avatar remain resolvable in historical chat messages, guesses, etc.
+      formerHunts?: string[];
       huntTermsAcceptedAt?: Record<string, Date>;
       roles?: Record<string, string[]>; // scope -> roles
       displayName?: string;
@@ -47,6 +50,7 @@ export const User = z.object({
   profile: z.object({}).optional(),
   roles: z.record(z.string(), nonEmptyString.array()).optional(),
   hunts: foreignKey.array().optional(),
+  formerHunts: foreignKey.array().optional(),
   huntTermsAcceptedAt: z.record(z.string(), z.date()).optional(),
   displayName: nonEmptyString.optional(),
   googleAccount: nonEmptyString.optional(),

--- a/imports/server/migrations/53-former-hunts-index.ts
+++ b/imports/server/migrations/53-former-hunts-index.ts
@@ -1,0 +1,10 @@
+import MeteorUsers from "../../lib/models/MeteorUsers";
+import Migrations from "./Migrations";
+
+Migrations.add({
+  version: 53,
+  name: "Add index on formerHunts",
+  async up() {
+    await MeteorUsers.createIndexAsync({ formerHunts: 1 });
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -51,3 +51,4 @@ import "./49-schema-fixups";
 import "./50-upconvert-chatmessage-content";
 import "./51-backfill-updated-at";
 import "./52-remove-discord-discriminator";
+import "./53-former-hunts-index";

--- a/imports/server/users.ts
+++ b/imports/server/users.ts
@@ -129,8 +129,17 @@ Meteor.publish("displayNames", async function (huntId: unknown) {
       return undefined;
     }
 
+    // Include former hunt members so their display names remain resolvable
+    // in historical chat messages, guesses, and other records. Other
+    // publications (allProfiles, huntProfiles, huntRoles) intentionally
+    // don't do this -- they should only show current members.
+    //
+    // We don't need formerHunts in the projection above because that
+    // projection watches the *subscribing* user's fields (to re-run the
+    // access check), while the cursor itself is reactive to changes in
+    // other users' documents.
     return MeteorUsers.find(
-      { hunts: huntId },
+      { $or: [{ hunts: huntId }, { formerHunts: huntId }] },
       { projection: { displayName: 1 } },
     );
   });
@@ -150,8 +159,9 @@ Meteor.publish("avatars", async function (huntId: unknown) {
       return undefined;
     }
 
+    // See comment in displayNames above.
     return MeteorUsers.find(
-      { hunts: huntId },
+      { $or: [{ hunts: huntId }, { formerHunts: huntId }] },
       { projection: { discordAccount: 1 } },
     );
   });


### PR DESCRIPTION
When a user is removed from a hunt, their hunt ID will move from `hunts` to `formerHunts`. This keeps their display name and avatar resolvable in historical chat messages, guesses, and other records that reference them via createdBy/updatedBy — rather than showing as anonymous.

The displayNames and avatars publications query both arrays so that current members can still see former members' names. Other publications (allProfiles, huntProfiles, huntRoles) intentionally query only `hunts`, since they represent active membership.

This is data-model groundwork for both #2734 (removing users from hunts) and #296 (merging user accounts) — both need a way to preserve historical attribution after a user's active hunt membership changes.