### PR TITLE
Better third-party cookie blocking detection

### DIFF
--- a/private/google-script/cookie-test.html
+++ b/private/google-script/cookie-test.html
@@ -3,60 +3,22 @@
   <head><title>Cookie Test</title></head>
   <body>
     <script>
-      /* biome-ignore-all lint/suspicious/noDocumentCookie: intentionally testing cookie access */
-      function cookieTest() {
-        let ok = false;
-        try {
-          document.cookie = "jr_test=1; SameSite=None; Secure";
-          ok = document.cookie.indexOf("jr_test=1") !== -1;
-          document.cookie = "jr_test=; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=None; Secure";
-        } catch {
-          return false;
-        }
-        return ok;
-      }
-
-      document.hasStorageAccess().then(function(hasAccess) {
-        if (hasAccess) {
-          // Unpartitioned cookie access confirmed — no problem
-          window.top.postMessage({
-            type: "jr-cookie-check",
-            ok: true,
-            detail: "hasStorageAccess granted",
-          }, "*");
-          return;
-        }
-
-        const canSetCookie = cookieTest();
-        if (!canSetCookie) {
-          // Can't even set cookies — full blocking (e.g. Safari ITP)
-          window.top.postMessage({
-            type: "jr-cookie-check",
-            ok: false,
-            detail: "cookies fully blocked",
-          }, "*");
-          return;
-        }
-
-        // Ambiguous: cookies work but hasStorageAccess is false.
-        // Could be Firefox TCP (problem) or Safari ITP off (fine).
-        // Try requestStorageAccess without gesture to disambiguate.
-        document.requestStorageAccess().then(function() {
-          // Resolved without gesture — no real restriction (Safari ITP off)
-          window.top.postMessage({
-            type: "jr-cookie-check",
-            ok: true,
-            detail: "requestStorageAccess auto-granted",
-          }, "*");
-        }).catch(function() {
-          // Rejected — real restriction in effect (Firefox TCP)
-          window.top.postMessage({
-            type: "jr-cookie-check",
-            ok: false,
-            detail: "cookies partitioned",
-          }, "*");
-        });
-      });
+      // The Apps Script doGet() evaluates if
+      // Session.getTemporaryActiveUserKey() is empty and replaces the
+      // placeholder below with true (not empty) or false (empty). A non-empty
+      // key means Google could identify the user from the HTTP request
+      // (authentication cookies are flowing). An empty key means either the
+      // user isn't logged into Google in this browser, or something is blocking
+      // cookies (browser tracking protection, a privacy extension stripping
+      // Cookie/Set-Cookie headers, etc.).
+      const ok = "{{ok}}";
+      window.top.postMessage(
+        {
+          type: "jr-cookie-check",
+          ok: ok === "true",
+        },
+        "*",
+      );
     </script>
   </body>
 </html>

--- a/private/google-script/main.js
+++ b/private/google-script/main.js
@@ -147,9 +147,13 @@ const METHODS = {
 
 // biome-ignore lint/correctness/noUnusedVariables: This is part of the Apps Script API
 function doGet() {
-  return HtmlService.createHtmlOutputFromFile(
-    "cookie-test",
-  ).setXFrameOptionsMode(HtmlService.XFrameOptionsMode.ALLOWALL);
+  const userKey = Session.getTemporaryActiveUserKey();
+  const ok = userKey !== "";
+  const output = HtmlService.createHtmlOutputFromFile("cookie-test");
+  const html = output.getContent().replace("{{ok}}", ok ? "true" : "false");
+  return HtmlService.createHtmlOutput(html).setXFrameOptionsMode(
+    HtmlService.XFrameOptionsMode.ALLOWALL,
+  );
 }
 
 // biome-ignore lint/correctness/noUnusedVariables: This is part of the Apps Script API


### PR DESCRIPTION
Previously, the cookie detection page used a three-step client-side algorithm (hasStorageAccess, document.cookie, requestStorageAccess) to detect when browsers block third-party cookies. However, privacy extensions like Privacy Badger strip Cookie and Set-Cookie headers at the HTTP network level without affecting JavaScript cookie APIs, so the client-side checks reported cookies as working when they weren't.

Instead, the Apps Script doGet() handler now calls Session.getTemporaryActiveUserKey() server-side and embeds the result into the page. This API returns a non-empty key when Google can identify the user from the HTTP request - which requires authentication cookies to be present. If empty, something is preventing cookies from reaching the server, whether that's browser-level tracking protection (Firefox ETP, Safari ITP, Chrome settings) or an extension stripping HTTP headers. This catches all known blocking mechanisms with a single check.

Also adds a 10-second timeout on the postMessage response so that if the iframe is blocked entirely (e.g. by an extension or network issue), we still warn the user rather than waiting indefinitely. Updates the warning tips to mention both browser settings and extensions for all browsers.

Fixes #2782.