### PR TITLE
Add a link to the README video on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Want to help develop Jolly Roger? Join our Discord server
 - **And more** — bookmarks, announcements, multi-answer puzzles, dark mode, i18n, mobile
 
 <!-- To update this video, re-run scripts/generate_screenshots.mts and follow the instructions it prints. -->
-<video src="https://github.com/user-attachments/assets/037411cd-7826-4979-9f67-4df7412af305" autoplay loop muted playsinline></video>
+[Watch the demo video](https://github.com/user-attachments/assets/d157a122-812a-4038-80ad-0f04b40405a1)
 
 ## Features
 


### PR DESCRIPTION
GitHub will display video embeds on mobile if the video is a user attachment, but it gets scrubbed on mobile, so add a link to the video so that mobile users can still see it.

(Quick followup to #2752 based on @jimsug's observations)