### PR TITLE
Skip third-party cookie detection on mobile

### DIFF
--- a/docs/google-drive.md
+++ b/docs/google-drive.md
@@ -35,7 +35,7 @@ files:
   - imports/server/setup.ts
   - private/google-script/cookie-test.html
   - private/google-script/main.js
-updated: 2026-02-14T21:00:00Z
+updated: 2026-02-17T21:00:00Z
 ---
 
 # Google Drive Integration
@@ -310,7 +310,9 @@ listens for the result. The result is cached in a module-level variable so the
 check is not re-run during SPA navigations, but does re-run on full page reload
 (so it picks up changes to tracking protection settings). If the check indicates
 cookies are blocked, a toast notification warns the user and provides
-browser-specific instructions for fixing the issue.
+browser-specific instructions for fixing the issue. On mobile-width screens
+(below `MinimumDesktopWidth` from `PuzzlePage`), the check is skipped entirely
+because we show a link to the Google Doc rather than embedding it in an iframe.
 
 ## Utility Meteor methods
 

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -17,6 +17,7 @@ import { Trans, useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import ReactTextareaAutosize from "react-textarea-autosize";
 import styled from "styled-components";
+import { useMediaQuery } from "usehooks-ts";
 import Flags from "../../Flags";
 import { calendarTimeFormat } from "../../lib/calendarTimeFormat";
 import isAdmin from "../../lib/isAdmin";
@@ -60,7 +61,10 @@ import CopyToClipboardButton from "./CopyToClipboardButton";
 import { GuessConfidence, GuessDirection } from "./guessDetails";
 import Markdown from "./Markdown";
 import PuzzleAnswer from "./PuzzleAnswer";
+import { MinimumDesktopWidth } from "./PuzzlePage";
 import SpinnerTimer from "./SpinnerTimer";
+
+const desktopQuery = `(min-width: ${MinimumDesktopWidth}px)`;
 
 // How long to keep showing guess notifications after actioning.
 // Note that this cannot usefully exceed the linger period implemented by the
@@ -779,10 +783,13 @@ let cookieCheckCache: boolean | undefined;
 const useCookieCheck = (
   endpointUrl: string | undefined,
 ): boolean | undefined => {
+  // On mobile we show a link to the Google Doc rather than embedding it in an
+  // iframe, so third-party cookie support doesn't matter.
+  const isDesktop = useMediaQuery(desktopQuery);
   const [result, setResult] = useState<boolean | undefined>(cookieCheckCache);
 
   useEffect(() => {
-    if (!endpointUrl || result !== undefined) return undefined;
+    if (!endpointUrl || !isDesktop || result !== undefined) return undefined;
 
     let timeout: ReturnType<typeof setTimeout> | undefined;
 
@@ -814,8 +821,9 @@ const useCookieCheck = (
       window.removeEventListener("message", onMessage);
       clearTimeout(timeout);
     };
-  }, [endpointUrl, result]);
+  }, [endpointUrl, isDesktop, result]);
 
+  if (!isDesktop) return true;
   if (!endpointUrl || result !== undefined) return result;
 
   // Return undefined (still loading) — the iframe will be rendered by the component

--- a/imports/client/components/PuzzlePage.tsx
+++ b/imports/client/components/PuzzlePage.tsx
@@ -143,7 +143,7 @@ const MinimumSidebarWidth = 176;
 const MinimumDocumentWidth = 400;
 const DefaultSidebarWidth = 300;
 
-const MinimumDesktopWidth = MinimumSidebarWidth + MinimumDocumentWidth;
+export const MinimumDesktopWidth = MinimumSidebarWidth + MinimumDocumentWidth;
 
 // PuzzlePage has some pretty unique properties:
 //


### PR DESCRIPTION
On mobile-width screens, PuzzlePage shows a link to the Google Doc rather than embedding it in an iframe, so third-party cookie support is irrelevant. Previously, useCookieCheck ran unconditionally, which could pop up a warning toast that dominates the screen on mobile for no reason.