### PR TITLE
Bump @biomejs/biome from 2.3.15 to 2.4.3

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -40,13 +40,15 @@
         // Explicit function declarations can be easier to read
         "useArrowFunction": "off",
         // Useless switch cases are good for exhaustiveness
-        "noUselessSwitchCase": "off"
+        "noUselessSwitchCase": "off",
+        "noUselessCatchBinding": "error"
       },
       "correctness": {
         // We don't use imports with extensions
         "useImportExtensions": "off",
-        // This doesn't know about Meteor packages and there's no way to teach it
+        // These don't know about Meteor packages and there's no way to teach them
         "noUndeclaredDependencies": "off",
+        "noUnresolvedImports": "off",
 
         "noNestedComponentDefinitions": "error",
 
@@ -64,11 +66,8 @@
         }
       },
       "nursery": {
-        "noDeprecatedImports": "warn",
         "noFloatingPromises": "error",
         "noMisusedPromises": "error",
-        "noUnusedExpressions": "error",
-        "noUselessCatchBinding": "error",
         "useExhaustiveSwitchCases": "error"
       },
       "security": {
@@ -101,6 +100,8 @@
       "suspicious": {
         // This is a good idea, but isn't type aware so complains even if the lambda returns void
         "useIterableCallbackReturn": "off",
+        // Pre-existing import cycles in the hooks system; fixing requires architectural refactoring
+        "noImportCycles": "off",
         // This rule seems flawed - TypeScript is perfectly capable of inferring types in let declarations
         "noImplicitAnyLet": "off",
         "noConsole": "warn",
@@ -109,7 +110,9 @@
         // We use any too often to account for unknown types
         "noExplicitAny": "off",
         // We use void in various generics and intermediate types for its actual meaning of a function return type
-        "noConfusingVoidType": "off"
+        "noConfusingVoidType": "off",
+        "noDeprecatedImports": "warn",
+        "noUnusedExpressions": "error"
       }
     },
     "domains": {

--- a/docs/google-drive.md
+++ b/docs/google-drive.md
@@ -35,7 +35,7 @@ files:
   - imports/server/setup.ts
   - private/google-script/cookie-test.html
   - private/google-script/main.js
-updated: 2026-02-18T00:00:00Z
+updated: 2026-02-20T00:00:00Z
 ---
 
 # Google Drive Integration

--- a/imports/client/components/FancyEditor.tsx
+++ b/imports/client/components/FancyEditor.tsx
@@ -169,7 +169,7 @@ const EditableMentionRenderer = ({
       name = element.roleId;
       break;
     default:
-      // biome-ignore lint/nursery/noUnusedExpressions: exhaustive check
+      // biome-ignore lint/suspicious/noUnusedExpressions: exhaustive check
       element satisfies never;
   }
   const Elem = selected && focused ? SelectedMentionSpan : MentionSpan;
@@ -377,7 +377,7 @@ const MatchCandidate = ({
         </MatchCandidateRow>
       );
     default:
-      // biome-ignore lint/nursery/noUnusedExpressions: exhaustive check
+      // biome-ignore lint/suspicious/noUnusedExpressions: exhaustive check
       mention satisfies never;
       return null;
   }
@@ -929,7 +929,7 @@ const FancyEditor = ({
                 break;
               }
               default:
-                // biome-ignore lint/nursery/noUnusedExpressions: exhaustive check
+                // biome-ignore lint/suspicious/noUnusedExpressions: exhaustive check
                 mention satisfies never;
             }
             setCompletionAnchorRange(undefined);
@@ -1020,7 +1020,7 @@ const FancyEditor = ({
           insertRoleMention(editor, m.roleId);
           break;
         default:
-          // biome-ignore lint/nursery/noUnusedExpressions: exhaustive check
+          // biome-ignore lint/suspicious/noUnusedExpressions: exhaustive check
           m satisfies never;
       }
       setCompletionAnchorRange(undefined);

--- a/imports/server/hooks/ChatNotificationHooks.ts
+++ b/imports/server/hooks/ChatNotificationHooks.ts
@@ -76,7 +76,7 @@ const ChatNotificationHooks: Hookset = {
               });
             }
           } else {
-            // biome-ignore lint/nursery/noUnusedExpressions: exhaustive check
+            // biome-ignore lint/suspicious/noUnusedExpressions: exhaustive check
             roleId satisfies never;
           }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
-        "@biomejs/biome": "2.3.15",
+        "@biomejs/biome": "2.4.3",
         "@swc/plugin-styled-components": "^8.0.4",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
@@ -1403,9 +1403,9 @@
       }
     },
     "node_modules/@biomejs/biome": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.3.15.tgz",
-      "integrity": "sha512-u+jlPBAU2B45LDkjjNNYpc1PvqrM/co4loNommS9/sl9oSxsAQKsNZejYuUztvToB5oXi1tN/e62iNd6ESiY3g==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.3.tgz",
+      "integrity": "sha512-cBrjf6PNF6yfL8+kcNl85AjiK2YHNsbU0EvDOwiZjBPbMbQ5QcgVGFpjD0O52p8nec5O8NYw7PKw3xUR7fPAkQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "bin": {
@@ -1419,20 +1419,20 @@
         "url": "https://opencollective.com/biome"
       },
       "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "2.3.15",
-        "@biomejs/cli-darwin-x64": "2.3.15",
-        "@biomejs/cli-linux-arm64": "2.3.15",
-        "@biomejs/cli-linux-arm64-musl": "2.3.15",
-        "@biomejs/cli-linux-x64": "2.3.15",
-        "@biomejs/cli-linux-x64-musl": "2.3.15",
-        "@biomejs/cli-win32-arm64": "2.3.15",
-        "@biomejs/cli-win32-x64": "2.3.15"
+        "@biomejs/cli-darwin-arm64": "2.4.3",
+        "@biomejs/cli-darwin-x64": "2.4.3",
+        "@biomejs/cli-linux-arm64": "2.4.3",
+        "@biomejs/cli-linux-arm64-musl": "2.4.3",
+        "@biomejs/cli-linux-x64": "2.4.3",
+        "@biomejs/cli-linux-x64-musl": "2.4.3",
+        "@biomejs/cli-win32-arm64": "2.4.3",
+        "@biomejs/cli-win32-x64": "2.4.3"
       }
     },
     "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.3.15.tgz",
-      "integrity": "sha512-SDCdrJ4COim1r8SNHg19oqT50JfkI/xGZHSyC6mGzMfKrpNe/217Eq6y98XhNTc0vGWDjznSDNXdUc6Kg24jbw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.3.tgz",
+      "integrity": "sha512-eOafSFlI/CF4id2tlwq9CVHgeEqvTL5SrhWff6ZORp6S3NL65zdsR3ugybItkgF8Pf4D9GSgtbB6sE3UNgOM9w==",
       "cpu": [
         "arm64"
       ],
@@ -1447,9 +1447,9 @@
       }
     },
     "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.3.15.tgz",
-      "integrity": "sha512-RkyeSosBtn3C3Un8zQnl9upX0Qbq4E3QmBa0qjpOh1MebRbHhNlRC16jk8HdTe/9ym5zlfnpbb8cKXzW+vlTxw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.3.tgz",
+      "integrity": "sha512-V2+av4ilbWcBMNufTtMMXVW00nPwyIjI5qf7n9wSvUaZ+tt0EvMGk46g9sAFDJBEDOzSyoRXiSP6pCvKTOEbPA==",
       "cpu": [
         "x64"
       ],
@@ -1464,9 +1464,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.3.15.tgz",
-      "integrity": "sha512-FN83KxrdVWANOn5tDmW6UBC0grojchbGmcEz6JkRs2YY6DY63sTZhwkQ56x6YtKhDVV1Unz7FJexy8o7KwuIhg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.3.tgz",
+      "integrity": "sha512-0m+O0x9FgK99FAwDK+fiDtjs2wnqq7bvfj17KJVeCkTwT/liI+Q9njJG7lwXK0iSJVXeFNRIxukpVI3SifMYAA==",
       "cpu": [
         "arm64"
       ],
@@ -1481,9 +1481,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.3.15.tgz",
-      "integrity": "sha512-SSSIj2yMkFdSkXqASzIBdjySBXOe65RJlhKEDlri7MN19RC4cpez+C0kEwPrhXOTgJbwQR9QH1F4+VnHkC35pg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.3.tgz",
+      "integrity": "sha512-QuFzvsGo8BA4Xm7jGX5idkw6BqFblcCPySMTvq0AhGYnhUej5VJIDJbmTKfHqwjHepZiC4fA+T5i6wmiZolZNw==",
       "cpu": [
         "arm64"
       ],
@@ -1498,9 +1498,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.3.15.tgz",
-      "integrity": "sha512-T8n9p8aiIKOrAD7SwC7opiBM1LYGrE5G3OQRXWgbeo/merBk8m+uxJ1nOXMPzfYyFLfPlKF92QS06KN1UW+Zbg==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.3.tgz",
+      "integrity": "sha512-NVqh0saIU0u5OfOp/0jFdlKRE59+XyMvWmtx0f6Nm/2OpdxBl04coRIftBbY9d1gfu+23JVv4CItAqPYrjYh5w==",
       "cpu": [
         "x64"
       ],
@@ -1515,9 +1515,9 @@
       }
     },
     "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.3.15.tgz",
-      "integrity": "sha512-dbjPzTh+ijmmNwojFYbQNMFp332019ZDioBYAMMJj5Ux9d8MkM+u+J68SBJGVwVeSHMYj+T9504CoxEzQxrdNw==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.3.tgz",
+      "integrity": "sha512-qEc0OCpj/uytruQ4wLM0yWNJLZy0Up8H1Er5MW3SrstqM6J2d4XqdNA86xzCy8MQCHpoVZ3lFye3GBlIL4/ljw==",
       "cpu": [
         "x64"
       ],
@@ -1532,9 +1532,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.3.15.tgz",
-      "integrity": "sha512-puMuenu/2brQdgqtQ7geNwQlNVxiABKEZJhMRX6AGWcmrMO8EObMXniFQywy2b81qmC+q+SDvlOpspNwz0WiOA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.3.tgz",
+      "integrity": "sha512-gRO96vrIARilv/Cp2ZnmNNL5LSZg3RO75GPp13hsLO3N4YVpE7saaMDp2bcyV48y2N2Pbit1brkGVGta0yd6VQ==",
       "cpu": [
         "arm64"
       ],
@@ -1549,9 +1549,9 @@
       }
     },
     "node_modules/@biomejs/cli-win32-x64": {
-      "version": "2.3.15",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.3.15.tgz",
-      "integrity": "sha512-kDZr/hgg+igo5Emi0LcjlgfkoGZtgIpJKhnvKTRmMBv6FF/3SDyEV4khBwqNebZIyMZTzvpca9sQNSXJ39pI2A==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.3.tgz",
+      "integrity": "sha512-vSm/vOJe06pf14aGHfHl3Ar91Nlx4YYmohElDJ+17UbRwe99n987S/MhAlQOkONqf1utJor04ChkCPmKb8SWdw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.3.15",
+    "@biomejs/biome": "2.4.3",
     "@swc/plugin-styled-components": "^8.0.4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",

--- a/private/google-script/cookie-test.html
+++ b/private/google-script/cookie-test.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head><title>Cookie Test</title></head>
   <body>
     <script>


### PR DESCRIPTION
Biome 2.4 promoted several nursery rules to stable groups, so this updates the config (via `biome migrate --write`) and fixes five inline suppression comments that still referenced `lint/nursery/noUnusedExpressions` (now `lint/suspicious/noUnusedExpressions`).

Two newly promoted rules are turned off:

- noUnresolvedImports: can't resolve `meteor/...` virtual packages or react-bootstrap's `exports`-field deep imports (same situation as the existing noUndeclaredDependencies exclusion)
- noImportCycles: we have a pre-existing cycle in the hooks registry that would need architectural refactoring to untangle

Also adds `lang="en"` to cookie-test.html for the newly enforced useHtmlLang rule on HTML files.

Supersedes #2822 
