### PR TITLE
Break last remaining import cycle and ban cycles

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -123,6 +123,7 @@
 
     // ── Import ──────────────────────────────────────────────────────────
     "import/default": "off",
+    "import/no-cycle": "error",
     "import/no-named-as-default": "off",
     "import/no-named-as-default-member": "off",
     "import/no-named-default": "error",

--- a/imports/server/GlobalHooks.ts
+++ b/imports/server/GlobalHooks.ts
@@ -1,17 +1,8 @@
-import BookmarkNotificationHooks from "./hooks/BookmarkNotificationHooks";
-import ChatHooks from "./hooks/ChatHooks";
-import ChatNotificationHooks from "./hooks/ChatNotificationHooks";
-import DiscordHooks from "./hooks/DiscordHooks";
 import HooksRegistry from "./hooks/HooksRegistry";
-import TagCleanupHooks from "./hooks/TagCleanupHooks";
 
 // Instantiate the application-global hookset list.
 const GlobalHooks = new HooksRegistry();
-// Add all hooksets.
-GlobalHooks.addHookSet(DiscordHooks);
-GlobalHooks.addHookSet(ChatNotificationHooks);
-GlobalHooks.addHookSet(TagCleanupHooks);
-GlobalHooks.addHookSet(ChatHooks);
-GlobalHooks.addHookSet(BookmarkNotificationHooks);
+
+// To avoid import cycles, we register hook sets separately in register-hooks.ts
 
 export default GlobalHooks;

--- a/imports/server/register-hooks.ts
+++ b/imports/server/register-hooks.ts
@@ -1,0 +1,17 @@
+import GlobalHooks from "./GlobalHooks";
+import BookmarkNotificationHooks from "./hooks/BookmarkNotificationHooks";
+import ChatHooks from "./hooks/ChatHooks";
+import ChatNotificationHooks from "./hooks/ChatNotificationHooks";
+import DiscordHooks from "./hooks/DiscordHooks";
+import TagCleanupHooks from "./hooks/TagCleanupHooks";
+
+// Some hook implementations may themselves need to trigger other hooks. To
+// avoid import cycles, hook registration is isolated to this file which is
+// imported for its side-effects.
+
+// Add all hooksets.
+GlobalHooks.addHookSet(DiscordHooks);
+GlobalHooks.addHookSet(ChatNotificationHooks);
+GlobalHooks.addHookSet(TagCleanupHooks);
+GlobalHooks.addHookSet(ChatHooks);
+GlobalHooks.addHookSet(BookmarkNotificationHooks);

--- a/server/main.ts
+++ b/server/main.ts
@@ -20,6 +20,9 @@ import "../imports/server/migrations/all";
 // Set up multi-process load balancer
 import "../imports/server/loadBalance";
 
+// Register hooks which methods may call
+import "../imports/server/register-hooks";
+
 // Import methods and publications
 import "../imports/server/methods/index";
 import "../imports/server/publications/index";


### PR DESCRIPTION
ChatHooks is both a Hookset implementation and needs to trigger hook execution, so it cannot be imported by GlobalHooks and also import GlobalHooks without creating an import cycle.  Extract hook registration to register-hooks.ts (imported explicitly in main) to break the cycle, then enable the oxlint rule to ban import cycles in the future.