### PR TITLE
Add two more externals to rspack.config.js

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -57,7 +57,9 @@ module.exports = defineConfig((Meteor) => {
       fallback: Meteor.isClient ? fallbackClient : fallbackServer,
     },
     externals: {
+      express: "commonjs express",
       mediasoup: "commonjs mediasoup",
+      slate: "commonjs slate",
     },
   };
 });


### PR DESCRIPTION
Another couple packages appear to misbehave when loaded as ES modules, but (annoyingly) only when production-bundled.  This patch tells rspack to consume them as commonjs.

To wit: without this configuration, rendering the PuzzlePage would crash only in production builds with an error thrown by slate about being passed a non-numeric path index.  When tracing through locals in a debugger, at some point the [] from an Editor.start(editor, []) used to render our placeholder got turned into `[[]]` when the expected argument would have been a number[].

I didn't fully pin down what caused this but believe it likely resulted from some sort of scope shadowing error, where one context may have had `path` or `Editor` as the result of an import, and another had it as a local variable, or var-scoping hoisted a binding somewhere unexpected.

Additionally, express would, in the context of dispatching a Meteor WebApp route, wind up calling a local binding `n` that was not a function.  Poking at the source, it looks like the `n` on that line was expected to be the result of `require("is-promise")`.

In both cases, it looked like the production-bundled code might have wound up with a minified value either not getting loaded or getting the incorrect context, so I decided to try telling the bundler to load the code as commonjs rather than ES modules.  This appears to restore the expected behavior.