### PR TITLE
Specify an npm version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A website for organizing puzzle hunters",
   "author": "Evan Broder, Drew Fisher, Grant Elliott",
   "license": "MIT",
+  "packageManager": "npm@10.9.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/deathandmayhem/jolly-roger"


### PR DESCRIPTION
> Some combination of Dependabot switching to NPM v11 by default and us switching to rspack with the new Meteor release seems to be causing issues with Dependabot updates - it's removing (or hoisting?) packages from the package-lock.json file that NPM v10 thinks are still necessary.
> 
> Some amount of looking through docs and code seem to suggest that specifying the `packageManager` field in package.json should encourage Dependabot to use the older version of NPM that Meteor still depends on, although it's a little unclear whether or not this will actually work.
> 
> In any case, it's an accurate description of the behavior we want so seems at worst mostly harmless.

I figure we merge it, and ask Dependabot to recreate its PRs, and see if it helps. If it doesn't, I'm kind of indifferent on leaving vs. reverting