### PR TITLE
dependabot ignore @rspack/* and @meteorjs/rspack

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,14 @@ updates:
       # This has tight coupling to the version of SWC, which is provided by
       # Meteor. Assume we'll upgrade this when we take Meteor upgrades.
       - dependency-name: "@swc/plugin-styled-components"
+      # These four all need to stay compatible with the Meteor version.
+      # No currently-released Meteor version is compatible with the rspack
+      # 2.0 series; Meteor will need to update to correctly consume these
+      # deps as ES Modules
+      - dependency-name: "@meteorjs/rspack"
+      - dependency-name: "@rspack/cli"
+      - dependency-name: "@rspack/core"
+      - dependency-name: "@rspack/plugin-react-refresh"
     groups:
       aws:
         patterns:


### PR DESCRIPTION
The rspack 2.0 series no longers supports being consumed as commonjs (vs ESM) but current Meteor releases consume it as commonjs (and in the case of `@rspack/plugin-react-refresh`, fail to access the right named export), so we can't upgrade these deps at the moment.