### PR TITLE
Add Chinese translation for purge hunt, add/delete/verify email strings

### DIFF
--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -311,6 +311,7 @@ const EmailSection = ({ user }: { user: Meteor.User }) => {
           variant="outline-primary"
           onClick={handleAddEmail}
           disabled={busy || !newEmail.trim()}
+          style={{ whiteSpace: "nowrap" }}
         >
           {t("profile.emails.add", "Add")}
         </Button>

--- a/imports/locales/zh.json
+++ b/imports/locales/zh.json
@@ -342,6 +342,18 @@
       "label": "显示名称",
       "help": "为了以防跟其他人混淆，请尽量使用有辨识性的名字。"
     },
+    "emails": {
+      "label": "电子邮箱",
+      "primary": "主要邮箱",
+      "verified": "已验证",
+      "unverified": "未验证",
+      "makePrimary": "设为主要邮箱",
+      "remove": "删除",
+      "resendVerification": "重新发送验证邮件",
+      "addPlaceholder": "添加电子邮箱地址",
+      "add": "添加",
+      "conflict": "这个邮箱地址已经被另一个账户使用了。如果你想合并账户，请联系管理员。"
+    },
     "phoneNumber": {
       "label": "电话号码（可选）",
       "help": "在我们需要通过电话联系你时使用。"
@@ -465,6 +477,16 @@
         "title": "删除解谜活动",
         "submit": "删除",
         "text": "确定要删除解谜活动 {{huntName}} 吗？这将同时删除所有谜题及相关状态。"
+      }
+    },
+    "purge": {
+      "title": "清除活动数据",
+      "confirm": {
+        "title": "清除解谜活动数据",
+        "submit": "清除",
+        "text": "确定要清除解谜活动 {{huntName}} 的所有数据吗？这会删除所有谜题及其相关状态，以及与本次解谜活动相关的 Google 文档以及存储在 S3 中的文件。",
+        "warning": "此操作不可逆。",
+        "instructions": "在下方输入 <code>{{huntName}}</code> 以确认"
       }
     },
     "edit": {


### PR DESCRIPTION
Added Chinese translations for the purge hunt module, and the strings related to add/delete/verify email.

The style override (whitespace: nowrap) on button is to prevent it from line-break in the middle of a Chinese word. Without this 添加 (Add) was displayed as

添
加