### PR TITLE
Fix PR builds from forks (and also fix required status checks)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,17 +139,35 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  # The merge check is a gate on the rest of CI passing. For PRs and non-main
+  # builds, it does virtually nothing, but fails if any of the dependencies
+  # fail. Since it's configured as a required status check, this makes PRs
+  # unmergeable.
+  #
+  # On main, it merges the platform-specific images into a single multi-arch
+  # manifest and pushes it. If the earlier CI steps fail, though, it fails
+  # before a potentially broken image can get pushed to the registry.
   merge:
     name: Merge Docker image manifests
     needs:
       - build
       # Don't merge if tests failed
       - test
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
+      - name: Require build and test to have succeeded
+        env:
+          BUILD: ${{ needs.build.result }}
+          TEST: ${{ needs.test.result }}
+        run: |
+          if [[ "$BUILD" != success || "$TEST" != success ]]; then
+            echo "::error::build=$BUILD test=$TEST; both must succeed to merge"
+            exit 1
+          fi
       - name: Download digests
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,11 @@ jobs:
           cache-from: |
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.cache-tag }}-${{ steps.cache-ref.outputs.ref }}
             type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.cache-tag }}-main
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ matrix.cache-tag }}-${{ steps.cache-ref.outputs.ref }},mode=max
+          # With PRs from forks, the GITHUB_TOKEN gets downgraded to packages:
+          # read, so don't push to the build cache, since it will fail. (Note
+          # that github.event.pull_request is null for non-PR events, hence the
+          # dual check.)
+          cache-to: ${{ (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && format('type=registry,ref={0}/{1}:{2}-{3},mode=max', env.REGISTRY, env.IMAGE_NAME, matrix.cache-tag, steps.cache-ref.outputs.ref) || '' }}
           build-args: |
             METEOR_GIT_COMMIT_HASH=${{ github.sha }}
       - name: Export digest


### PR DESCRIPTION
Two issues, detailed more in comments and the commit messages:

* PRs from forks were failing to build due to fallout from #2836 - the builds were trying to populate a cache that they didn't have write access to
* The "merge" job was configured as a required status check with the intention of blocking merges if the build failed, but actually it didn't do that

(Does this actually work? My best guess is yes, but we may have to wait until we see it in action to know for sure)