### PR TITLE
Force node-gyp to use C++17 when building Meteor's bcrypt.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -120,12 +120,15 @@ EOF
 
 # Install server dependencies
 WORKDIR /built_app/bundle/programs/server
-
-# Force node-gyp to use C++17 for legacy Meteor binary dependencies
-ENV CXXFLAGS="-std=c++17"
-ENV CFLAGS="-std=c++17"
-
-RUN --mount=type=cache,target=/root/.npm meteor npm install --omit=dev
+RUN --mount=type=cache,target=/root/.npm <<'EOF'
+#!/bin/bash
+set -eux
+set -o pipefail
+# meteor prints junk about running as root to stdout, so capture this over stderr *sigh*
+NODE_PATH=$(cd /app && meteor node -e 'console.error(process.execPath);' 2>&1 1>/dev/null)
+export PATH="$(dirname "$NODE_PATH"):$PATH"
+npm install --omit=dev
+EOF
 
 # Production image
 # (Be careful about creating as few layers as possible)

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,11 @@ EOF
 
 # Install server dependencies
 WORKDIR /built_app/bundle/programs/server
+
+# Force node-gyp to use C++17 for legacy Meteor binary dependencies
+ENV CXXFLAGS="-std=c++17"
+ENV CFLAGS="-std=c++17"
+
 RUN --mount=type=cache,target=/root/.npm meteor npm install --omit=dev
 
 # Production image


### PR DESCRIPTION
Fixes build error when bcrypt 5.0.1 is built locally as no arm64 prebuilt is available.