### PR TITLE
Fix Apps Script cookie check for Workspace accounts

### DIFF
--- a/docs/google-drive.md
+++ b/docs/google-drive.md
@@ -35,7 +35,7 @@ files:
   - imports/server/setup.ts
   - private/google-script/cookie-test.html
   - private/google-script/main.js
-updated: 2026-06-14T12:04:50Z
+updated: 2026-07-17T05:54:51Z
 ---
 
 # Google Drive Integration
@@ -302,17 +302,18 @@ without credentials wouldn't send cookies at all.
 The result is posted back to the parent via `postMessage` with a message of type
 `jr-cookie-check`.
 
-On the client side, the `googleScriptInfo` publication (in
-`imports/server/setup.ts`) exposes the Apps Script `endpointUrl` to all
-authenticated users (not just admins). For users who have a linked Google
-account, `NotificationCenter` embeds the detection page in a hidden iframe and
-listens for the result. The result is cached in a module-level variable so the
-check is not re-run during SPA navigations, but does re-run on full page reload
-(so it picks up changes to tracking protection settings). If the check indicates
-cookies are blocked, a toast notification warns the user and provides
-browser-specific instructions for fixing the issue. On mobile-width screens
-(below `MinimumDesktopWidth` from `PuzzlePage`), the check is skipped entirely
-because we show a link to the Google Doc rather than embedding it in an iframe.
+We publish a set of URLs for the client to try in `googleScriptInfo`, and
+`NotificationCenter` races those URLs against each other in hidden iframes. We
+publish multiple due to some complexity in how Google Apps Script redirects
+based on whether the user is in a multi-login session, a Google Workspace domain
+session, etc. We don't care about which session they're in, just about whether
+or not we can see the cookies. The result is cached in a module-level variable
+so the check is not re-run during SPA navigations, but does re-run on full page
+reload (so it picks up changes to tracking protection settings). If cookies are
+blocked, a toast notification warns the user with browser-specific fix
+instructions. On mobile-width screens (below `MinimumDesktopWidth` from
+`PuzzlePage`), the check is skipped entirely because we show a link to the
+Google Doc rather than embedding it in an iframe.
 
 ## Utility Meteor methods
 

--- a/imports/client/GoogleScriptInfo.ts
+++ b/imports/client/GoogleScriptInfo.ts
@@ -7,7 +7,9 @@ const GoogleScriptInfo = new Mongo.Collection<{
   /* only exposed to admins */
   outOfDate?: boolean;
 
-  endpointUrl?: string;
+  // Candidate URLs for the third-party cookie check; the client races them and
+  // accepts whichever resolves. See googleScriptCookieCheckUrls in setup.ts.
+  cookieCheckUrls?: string[];
 }>("googleScriptInfo");
 
 export default GoogleScriptInfo;

--- a/imports/client/components/NotificationCenter.tsx
+++ b/imports/client/components/NotificationCenter.tsx
@@ -781,24 +781,32 @@ const StyledToastContainer = styled(ToastContainer)`
 let cookieCheckCache: boolean | undefined;
 
 const useCookieCheck = (
-  endpointUrl: string | undefined,
-): boolean | undefined => {
+  urls: string[] | undefined,
+): { result: boolean | undefined; frames: React.ReactNode } => {
   // On mobile we show a link to the Google Doc rather than embedding it in an
   // iframe, so third-party cookie support doesn't matter.
   const isDesktop = useMediaQuery(desktopQuery);
   const [result, setResult] = useState(cookieCheckCache);
 
-  useEffect(() => {
-    if (!endpointUrl || !isDesktop || result !== undefined) return undefined;
+  // Use hasUrls to short-circuit and as a dependency for the effect so we don't
+  // have to worry about array identity.
+  const hasUrls = !!urls?.length;
 
+  useEffect(() => {
+    if (!hasUrls || !isDesktop || result !== undefined) return undefined;
     let timeout: ReturnType<typeof setTimeout> | undefined;
+    let settled = false;
 
     function resolve(ok: boolean) {
+      if (settled) return;
+      settled = true;
       if (timeout) clearTimeout(timeout);
       cookieCheckCache = ok;
       setResult(ok);
     }
 
+    // If any iframe successfully posts back, that means the code loaded and we
+    // get a trustworthy result.
     const onMessage = (event: MessageEvent) => {
       const data = event.data;
       if (data?.type === "jr-cookie-check" && typeof data.ok === "boolean") {
@@ -807,9 +815,9 @@ const useCookieCheck = (
     };
     window.addEventListener("message", onMessage);
 
-    // If the iframe never responds (e.g. an extension blocks the request
-    // entirely, or the page gets redirected to a login wall), treat it as
-    // cookies blocked — if the test iframe can't load, the Sheets embed
+    // If no frame ever responds (e.g. every candidate 404s, an extension blocks
+    // the requests, or a frame is redirected to a login wall), treat it as
+    // cookies blocked, since if the test iframes can't load, the Sheets embed
     // won't work either.
     timeout = setTimeout(() => resolve(false), 10000);
 
@@ -817,13 +825,23 @@ const useCookieCheck = (
       window.removeEventListener("message", onMessage);
       clearTimeout(timeout);
     };
-  }, [endpointUrl, isDesktop, result]);
+  }, [hasUrls, isDesktop, result]);
 
-  if (!isDesktop) return true;
-  if (!endpointUrl || result !== undefined) return result;
+  if (!isDesktop) return { result: true, frames: null };
+  if (result !== undefined || !urls?.length) return { result, frames: null };
 
-  // Return undefined (still loading) — the iframe will be rendered by the component
-  return undefined;
+  // Still checking: render one hidden iframe per candidate URL and let the
+  // client accept whichever one resolves.
+  const frames = urls.map((url) => (
+    // oxlint-disable-next-line react/iframe-missing-sandbox -- cross-origin cookie check needs unsandboxed access
+    <iframe
+      key={url}
+      src={url}
+      style={{ display: "none" }}
+      title="Cookie check"
+    />
+  ));
+  return { result: undefined, frames };
 };
 
 const CookieWarningMessage = ({ onDismiss }: { onDismiss: () => void }) => {
@@ -882,11 +900,12 @@ const NotificationCenter = () => {
       : false;
   }, [admin, needsGoogleScriptInfo]);
 
-  const cookieCheckEndpointUrl = useTracker(() => {
+  const cookieCheckUrls = useTracker(() => {
     if (!hasGoogleAccount || !needsGoogleScriptInfo) return undefined;
-    return GoogleScriptInfo.findOne()?.endpointUrl;
+    return GoogleScriptInfo.findOne()?.cookieCheckUrls;
   }, [hasGoogleAccount, needsGoogleScriptInfo]);
-  const cookieCheckResult = useCookieCheck(cookieCheckEndpointUrl);
+  const { result: cookieCheckResult, frames: cookieCheckFrames } =
+    useCookieCheck(cookieCheckUrls);
   const [hideCookieWarning, setHideCookieWarning] = useState(false);
   const onHideCookieWarning = useCallback(() => setHideCookieWarning(true), []);
 
@@ -1202,14 +1221,7 @@ const NotificationCenter = () => {
 
   return (
     <>
-      {cookieCheckEndpointUrl && cookieCheckResult === undefined && (
-        // oxlint-disable-next-line react/iframe-missing-sandbox -- cross-origin cookie check needs unsandboxed access
-        <iframe
-          src={cookieCheckEndpointUrl}
-          style={{ display: "none" }}
-          title="Cookie check"
-        />
-      )}
+      {cookieCheckFrames}
       <StyledToastContainer
         position="bottom-end"
         className="p-3 position-fixed"

--- a/imports/server/setup.ts
+++ b/imports/server/setup.ts
@@ -100,30 +100,40 @@ Meteor.publish("enabledChatImage", async function () {
 });
 
 /**
- * Fix the endpoint URL to work around multilogin issues.
+ * Build the candidate URLs to try for browser-side third-party cookie
+ * detection.
  *
- * When a user's browser is logged into multiple Google accounts, Google may redirect to a broken
- * URL. See https://groups.google.com/g/google-apps-script-community/c/1xrlqlkGEQ0 for more context.
- * Prefixing the path with "/a/~/" works around the issue. This isn't necessary for server-initiated
- * calls since there are no login cookies that would cause redirects.
+ * We extract the deployment ID from the configured URL and build two additional
+ * derived URLs for clients to try. The basic URL should match the configured
+ * URL (but we rebuild it just in case). The URL with "/a/~/" is a workaround
+ * for users who are logged in to a multi-login session (taken from
+ * https://groups.google.com/g/google-apps-script-community/c/1xrlqlkGEQ0). But
+ * we need both because the /a/~/ URL doesn't work with Google Workspace domain
+ * accounts (it redirects to /a/<domain>/a/~/ which 404s).
  */
-function canonicalizeGoogleScriptEndpointUrl(
+function googleScriptCookieCheckUrls(
   endpointUrl: string | undefined,
-): string | undefined {
-  if (!endpointUrl) return endpointUrl;
+): string[] | undefined {
+  if (!endpointUrl) return undefined;
+  let parsedUrl: URL;
   try {
-    const parsedUrl = new URL(endpointUrl);
-    if (
-      parsedUrl.hostname === "script.google.com" &&
-      !parsedUrl.pathname.startsWith("/a/~/")
-    ) {
-      parsedUrl.pathname = `/a/~${parsedUrl.pathname}`;
-      return parsedUrl.toString();
-    }
+    parsedUrl = new URL(endpointUrl);
   } catch {
-    // If the URL is malformed, return it as-is.
+    // Unparseable URL: hand it back as-is and let the client try to load it.
+    return [endpointUrl];
   }
-  return endpointUrl;
+  // Always try the configured URL itself, then additionally construct our two
+  // redirect-workaround variants.
+  const candidates = [parsedUrl.toString()];
+  const match = /\/s\/([^/]+)\/exec(?:\/|$)/.exec(parsedUrl.pathname);
+  if (parsedUrl.hostname === "script.google.com" && match) {
+    const deploymentId = match[1];
+    candidates.push(
+      `${parsedUrl.origin}/macros/s/${deploymentId}/exec`,
+      `${parsedUrl.origin}/a/~/macros/s/${deploymentId}/exec`,
+    );
+  }
+  return [...new Set(candidates)];
 }
 
 Meteor.publish("googleScriptInfo", async function () {
@@ -137,18 +147,16 @@ Meteor.publish("googleScriptInfo", async function () {
   let tracked = false;
   const formatDoc = async (doc: SettingType & { name: "google.script" }) => {
     const configured = !!doc.value.scriptId && !!doc.value.endpointUrl;
-    const endpointUrl = canonicalizeGoogleScriptEndpointUrl(
-      doc.value.endpointUrl,
-    );
+    const cookieCheckUrls = googleScriptCookieCheckUrls(doc.value.endpointUrl);
     if (admin) {
       const { contentHash } = await googleScriptContent(doc.value.sharedSecret);
       return {
         configured,
         outOfDate: doc.value.contentHash !== contentHash,
-        endpointUrl,
+        cookieCheckUrls,
       };
     }
-    return { configured, endpointUrl };
+    return { configured, cookieCheckUrls };
   };
   const handle: Meteor.LiveQueryHandle = await cursor.observeAsync({
     added: (doc) => {


### PR DESCRIPTION
The third-party cookie check embeds the published Apps Script web app in a hidden iframe. 2994ffd worked around a multilogin redirect bug by prefixing the path with `/a/~/`, but that prefix itself 404s for Google Workspace domain accounts (Google redirects it to `/a/<domain>/a/~/...`).

Since the server can't tell which URL form a given browser session needs, stop committing to one. `googleScriptCookieCheckUrls` now publishes the configured URL alongside both redirect variants, and the client loads each in its own hidden iframe and uses whichever reports back first. A frame only responds if it actually loaded, and cookie blocking is per-site, so the first answer is authoritative.

cc @jpd236 since this is a followup from #3000.