### PR TITLE
Record call presence, not just speech, in CallActivities

### DIFF
--- a/imports/server/jobs/mergeUsers.ts
+++ b/imports/server/jobs/mergeUsers.ts
@@ -245,6 +245,16 @@ const ADDITIONAL_FK_UPDATES = new Map<{ name: string }, FKUpdateFn>([
         source,
         target,
         signal,
+        // speaking is sticky per bucket: if the source spoke, keep the merged
+        // record speaking rather than letting the collision delete downgrade it.
+        async (doc, raw) => {
+          if (doc.speaking) {
+            await raw.updateOne(
+              { ts: doc.ts, call: doc.call, user: target },
+              { $set: { speaking: true } },
+            );
+          }
+        },
       );
     },
   ],
@@ -318,6 +328,10 @@ async function reassignUniqueFK(
   sourceUser: string,
   targetUser: string,
   signal: AbortSignal,
+  // On a unique-key collision the source's row is always deleted (the source
+  // user is going away); this runs first so the caller can fold anything worth
+  // keeping from it into the surviving target row.
+  mergeIntoTarget?: (sourceDoc: any, raw: any) => Promise<void>,
 ) {
   const raw = collection.rawCollection();
   const cursor = raw.find({ [field]: sourceUser });
@@ -327,8 +341,9 @@ async function reassignUniqueFK(
       await raw.updateOne({ _id: doc._id }, { $set: { [field]: targetUser } });
     } catch (e) {
       if (!isDuplicateKeyError(e)) throw e;
-      // The target already has an equivalent record — the source's is
-      // redundant, so delete it.
+      // The target already has a record for this unique key, so the source's is
+      // redundant. Let the caller salvage from it first, then drop it.
+      await mergeIntoTarget?.(doc, raw);
       await raw.deleteOne({ _id: doc._id });
     }
   }

--- a/imports/server/mediasoup-api.ts
+++ b/imports/server/mediasoup-api.ts
@@ -23,6 +23,7 @@ import Servers from "../lib/models/Servers";
 import { checkAdmin, userMayJoinCallsForHunt } from "../lib/permission_stubs";
 import { registerPeriodicCleanupHook } from "./garbage-collection";
 import ignoringDuplicateKeyErrors from "./ignoringDuplicateKeyErrors";
+import recordCallPresence from "./recordCallPresence";
 import serverId from "./serverId";
 import withLock from "./withLock";
 
@@ -111,6 +112,7 @@ Meteor.publish("mediasoup:join", async function (hunt, call, tab) {
   if (!this.userId) {
     throw new Meteor.Error(401, "Not logged in");
   }
+  const userId = this.userId;
 
   if (
     !userMayJoinCallsForHunt(
@@ -216,6 +218,14 @@ Meteor.publish("mediasoup:join", async function (hunt, call, tab) {
       }
     });
   });
+
+  // Record presence immediately so that tracking updates before the periodic
+  // sweep (mediasoup.ts) next runs
+  try {
+    await recordCallPresence({ hunt, call, user: userId });
+  } catch (error) {
+    Logger.error("mediasoup recordCallPresence failed", { error, call });
+  }
 
   return [Rooms.find({ call }), Routers.find({ call }), Peers.find({ call })];
 });

--- a/imports/server/mediasoup.ts
+++ b/imports/server/mediasoup.ts
@@ -40,10 +40,14 @@ import {
   cleanupDeadServer,
   registerPeriodicCleanupHook,
 } from "./garbage-collection";
-import ignoringDuplicateKeyErrors from "./ignoringDuplicateKeyErrors";
+import { isDuplicateKeyError } from "./ignoringDuplicateKeyErrors";
 import CallActivities from "./models/CallActivities";
 import onExit from "./onExit";
+import recordCallPresence from "./recordCallPresence";
 import serverId from "./serverId";
+
+// Clamp the sweep interval so we don't hammer the database too much in dev mode
+const presenceSweepInterval = Math.max(2500, ACTIVITY_GRANULARITY / 5);
 
 const mediaCodecs: types.RouterRtpCodecCapability[] = [
   {
@@ -248,6 +252,8 @@ class SFU {
 
   public monitorConnectAcksHandle?: Meteor.LiveQueryHandle;
 
+  public presenceSweepHandle?: number;
+
   private constructor(
     ips: [ListenIp, ...ListenIp[]],
     worker: types.Worker,
@@ -266,7 +272,7 @@ class SFU {
     this.onMonitorRouterCreated(this.monitorRouter);
   }
 
-  async setupDBWatches() {
+  async setup() {
     this.peersHandle = await Peers.find({}).observeChangesAsync({
       // Use this as an opportunity to cleanup data created as part of the
       // transport negotiation
@@ -420,6 +426,12 @@ class SFU {
         });
       },
     });
+
+    this.presenceSweepHandle = Meteor.setInterval(() => {
+      this.sweepCallPresence().catch((error) => {
+        Logger.error("mediasoup sweepCallPresence failed", { error });
+      });
+    }, presenceSweepInterval);
   }
 
   static async create(ips: [ListenIp, ...ListenIp[]]) {
@@ -466,7 +478,7 @@ class SFU {
       heartbeatDirectTransport,
       heartbeatDataProducer,
     );
-    await sfu.setupDBWatches();
+    await sfu.setup();
     return sfu;
   }
 
@@ -482,6 +494,9 @@ class SFU {
     this.transportRequestsHandle?.stop();
     this.localRoomsHandle?.stop();
     this.peersHandle?.stop();
+    if (this.presenceSweepHandle !== undefined) {
+      Meteor.clearInterval(this.presenceSweepHandle);
+    }
     this.worker.close();
 
     // Make a best effort to clean up after ourselves
@@ -502,6 +517,32 @@ class SFU {
     await TransportRequests.removeAsync({ createdServer: serverId });
 
     await Routers.removeAsync({ createdServer: serverId });
+  }
+
+  async sweepCallPresence() {
+    // Sweep all peers, not just the ones assigned to this server. Slight write
+    // amplification, but it's easy and the unique index will protect the data
+    // integrity.
+    const ts = roundedTime(ACTIVITY_GRANULARITY);
+    const peers = await Peers.find({}).fetchAsync();
+    for (const peer of peers) {
+      if (!peer.createdBy) {
+        continue;
+      }
+      try {
+        await recordCallPresence({
+          hunt: peer.hunt,
+          call: peer.call,
+          user: peer.createdBy,
+          ts,
+        });
+      } catch (error) {
+        Logger.error("mediasoup recordCallPresence failed", {
+          error,
+          peer: peer._id,
+        });
+      }
+    }
   }
 
   async createConsumer(
@@ -685,14 +726,23 @@ class SFU {
         const lastWrite = lastWriteByUser.get(user) ?? 0;
         if (lastWrite < Date.now() - 1000) {
           lastWriteByUser.set(user, Date.now());
-          await ignoringDuplicateKeyErrors(async () => {
-            await CallActivities.insertAsync({
-              hunt: observerAppData.hunt,
-              call: observerAppData.call,
-              user,
-              ts: roundedTime(ACTIVITY_GRANULARITY),
+          // Upgrade a presence record to speaking, or insert a fresh speaking
+          // record. If we lose the insert race to a concurrent presence write
+          // (the sweep, or the join in mediasoup-api.ts), the row exists now, so
+          // fall back to a plain update.
+          const ts = roundedTime(ACTIVITY_GRANULARITY);
+          const selector = { call: observerAppData.call, user, ts };
+          try {
+            await CallActivities.upsertAsync(selector, {
+              $set: { speaking: true },
+              $setOnInsert: { hunt: observerAppData.hunt },
             });
-          });
+          } catch (e) {
+            if (!isDuplicateKeyError(e)) throw e;
+            await CallActivities.updateAsync(selector, {
+              $set: { speaking: true },
+            });
+          }
         }
       }
     };

--- a/imports/server/migrations/53-backfill-call-activity-speaking.ts
+++ b/imports/server/migrations/53-backfill-call-activity-speaking.ts
@@ -1,0 +1,15 @@
+import CallActivities from "../models/CallActivities";
+import Migrations from "./Migrations";
+
+Migrations.add({
+  version: 53,
+  name: "Backfill speaking flag on existing call activities",
+  async up() {
+    // Records predating presence tracking were all speech, so mark them speaking.
+    await CallActivities.updateAsync(
+      { speaking: { $exists: false } },
+      { $set: { speaking: true } },
+      { multi: true },
+    );
+  },
+});

--- a/imports/server/migrations/all.ts
+++ b/imports/server/migrations/all.ts
@@ -51,3 +51,4 @@ import "./49-schema-fixups";
 import "./50-upconvert-chatmessage-content";
 import "./51-backfill-updated-at";
 import "./52-remove-discord-discriminator";
+import "./53-backfill-call-activity-speaking";

--- a/imports/server/models/CallActivities.ts
+++ b/imports/server/models/CallActivities.ts
@@ -8,6 +8,7 @@ const CallActivity = z.object({
   hunt: foreignKey,
   call: foreignKey,
   user: foreignKey,
+  speaking: z.boolean(),
 });
 
 const CallActivities = new Model("jr_call_activities", CallActivity);

--- a/imports/server/publications/puzzleActivityForHunt.ts
+++ b/imports/server/publications/puzzleActivityForHunt.ts
@@ -59,8 +59,9 @@ class HuntActivityAggregator {
     const cutoff = new Date(
       Date.now() - ACTIVITY_GRANULARITY * ACTIVITY_SEGMENTS,
     );
-    // All of these are sufficiently immutable that we don't need to observe
-    // changes or removes
+    // We only need to observe adds: doc and chat records are immutable, and a
+    // call record can only ever flip into the speaking: true filter (never out
+    // of it), which also arrives as an add.
     this.initializing = true;
     this.documentActivityPromise = DocumentActivities.find({
       hunt: this.hunt,
@@ -84,6 +85,7 @@ class HuntActivityAggregator {
     this.callActivityPromise = CallActivities.find({
       hunt: this.hunt,
       ts: { $gte: cutoff },
+      speaking: true,
     }).observeChangesAsync({
       added: (_, fields) => {
         const { call: puzzle, ts, user } = fields;

--- a/imports/server/recordCallPresence.ts
+++ b/imports/server/recordCallPresence.ts
@@ -1,0 +1,28 @@
+import { ACTIVITY_GRANULARITY } from "../lib/config/activityTracking";
+import roundedTime from "../lib/roundedTime";
+import ignoringDuplicateKeyErrors from "./ignoringDuplicateKeyErrors";
+import CallActivities from "./models/CallActivities";
+
+// We insert-and-ignore-duplicates rather than upsert so we never clobber a
+// speaking record
+export default async function recordCallPresence({
+  hunt,
+  call,
+  user,
+  ts = roundedTime(ACTIVITY_GRANULARITY),
+}: {
+  hunt: string;
+  call: string;
+  user: string;
+  ts?: Date;
+}): Promise<void> {
+  await ignoringDuplicateKeyErrors(async () => {
+    await CallActivities.insertAsync({
+      hunt,
+      call,
+      user,
+      ts,
+      speaking: false,
+    });
+  });
+}


### PR DESCRIPTION
Previously `CallActivities` only recorded when someone crossed a volume threshold, so we couldn't see who was on a call but just not saying anything. Joining a call is useful as an explicit signal of user engagement on a puzzle, so we should capture it. Therefore, we add a `speaking` flag to `CallActivities`, migrated to `true` for all existing records. Going forward, we track call membership (with `speaking` set to `false`) when a user joins a call and with a new periodic sweep that creates new buckets as time passes. The existing audio observer becomes an upgrade from speaking=false to speaking=true, rather than the only thing that creates those records.

For now, sparklines only look at speakers, matching the current behavior, so none of this has user-visible impact, but it starts us down the road towards richer tracking of user engagement and improves the status quo re #601, even if it doesn't actually solve it.

(I did do some quick local testing and confirm that it appears to write out records with both speaking=false and speaking=true where you'd expect)