### PR TITLE
Prepare for a hopeful eventual Meteor 3.5 upgrade

### DIFF
--- a/tests/lib/waitForAssertion.ts
+++ b/tests/lib/waitForAssertion.ts
@@ -1,0 +1,21 @@
+import { setImmediate } from "node:timers/promises";
+
+// Polls an assertion until it stops throwing. Once the wall-clock deadline
+// passes, a final attempt runs outside the try, so the assertion's own error
+// is what propagates. The default deadline stays below mocha's 2000ms test
+// timeout so that error, not mocha's generic timeout, is what reports.
+export default async function waitForAssertion(
+  assertion: () => void,
+  timeoutMs = 1500,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      assertion();
+      return;
+    } catch {
+      await setImmediate();
+    }
+  }
+  assertion();
+}

--- a/tests/lib/withWriteFence.ts
+++ b/tests/lib/withWriteFence.ts
@@ -1,0 +1,13 @@
+import { DDPServer } from "meteor/ddp-server";
+
+// Runs fn inside a DDP write fence, then waits for every observer interested in
+// those writes to process them. Uses the same mechanism that Meteor methods do,
+// so even though it's using internals, should be somewhat robust to future
+// observer implementation changes (e.g. switching from oplog to change streams)
+export default async function withWriteFence(
+  fn: () => Promise<void>,
+): Promise<void> {
+  const fence = new DDPServer._WriteFence();
+  await DDPServer._CurrentWriteFence.withValue(fence, fn);
+  await fence.armAndWait();
+}

--- a/tests/unit/imports/server/Flags.ts
+++ b/tests/unit/imports/server/Flags.ts
@@ -1,32 +1,9 @@
-import { setImmediate } from "node:timers/promises";
 import { Accounts } from "meteor/accounts-base";
-import { MongoInternals } from "meteor/mongo";
 import { assert } from "chai";
 import Flags from "../../../../imports/Flags";
 import FeatureFlags from "../../../../imports/lib/models/FeatureFlags";
 import { USER_EMAIL, USER_PASSWORD } from "../../../acceptance/lib";
-
-declare module "meteor/mongo" {
-  namespace MongoInternals {
-    interface MongoConnection {
-      _oplogHandle: {
-        waitUntilCaughtUp: () => Promise<void>;
-      } | null;
-    }
-  }
-}
-
-async function waitUntilOplogCaughtUp() {
-  const oplogHandle =
-    MongoInternals.defaultRemoteCollectionDriver().mongo._oplogHandle;
-  if (!oplogHandle) {
-    throw new Error("Oplog handle not found");
-  }
-  await oplogHandle.waitUntilCaughtUp();
-
-  // Wait an extra tick to ensure any observers have fired
-  await setImmediate();
-}
+import withWriteFence from "../../../lib/withWriteFence";
 
 describe("Flags", function () {
   describe("observeChanges", function () {
@@ -57,16 +34,17 @@ describe("Flags", function () {
       };
       const observer = await Flags.observeChangesAsync("test", cb);
 
-      await FeatureFlags.upsertAsync(
-        { name: "test" },
-        {
-          $set: {
-            type: "off",
-            createdBy: userId,
+      await withWriteFence(async () => {
+        await FeatureFlags.upsertAsync(
+          { name: "test" },
+          {
+            $set: {
+              type: "off",
+              createdBy: userId,
+            },
           },
-        },
-      );
-      await waitUntilOplogCaughtUp();
+        );
+      });
       observer.stop();
 
       assert.equal(callCount, 1);
@@ -79,16 +57,17 @@ describe("Flags", function () {
       };
       const observer = await Flags.observeChangesAsync("test", cb);
 
-      await FeatureFlags.upsertAsync(
-        { name: "test" },
-        {
-          $set: {
-            type: "on",
-            createdBy: userId,
+      await withWriteFence(async () => {
+        await FeatureFlags.upsertAsync(
+          { name: "test" },
+          {
+            $set: {
+              type: "on",
+              createdBy: userId,
+            },
           },
-        },
-      );
-      await waitUntilOplogCaughtUp();
+        );
+      });
       observer.stop();
 
       assert.equal(callCount, 2);
@@ -114,11 +93,12 @@ describe("Flags", function () {
       // reset call count
       callCount = 0;
 
-      await FeatureFlags.upsertAsync(
-        { name: "test" },
-        { $set: { type: "on" } },
-      );
-      await waitUntilOplogCaughtUp();
+      await withWriteFence(async () => {
+        await FeatureFlags.upsertAsync(
+          { name: "test" },
+          { $set: { type: "on" } },
+        );
+      });
       observer.stop();
 
       assert.equal(callCount, 1);

--- a/tests/unit/imports/server/publishJoinedQuery.ts
+++ b/tests/unit/imports/server/publishJoinedQuery.ts
@@ -1,4 +1,3 @@
-import { setImmediate } from "node:timers/promises";
 import type { Meteor, Subscription } from "meteor/meteor";
 import { Random } from "meteor/random";
 import { assert } from "chai";
@@ -8,6 +7,8 @@ import Tags from "../../../../imports/lib/models/Tags";
 import makeFixtureHunt from "../../../../imports/server/makeFixtureHunt";
 import publishJoinedQuery from "../../../../imports/server/publishJoinedQuery";
 import resetDatabase from "../../../lib/resetDatabase";
+import waitForAssertion from "../../../lib/waitForAssertion";
+import withWriteFence from "../../../lib/withWriteFence";
 
 class StubSubscription implements Subscription {
   stopHooks: (() => void)[] = [];
@@ -76,6 +77,17 @@ class StubSubscription implements Subscription {
 }
 
 describe("publishJoinedQuery", function () {
+  // Stop observers per-test: a leftover observer would share its multiplexer
+  // with a later test's identical query, seeding it from a cache that can lag
+  // the beforeEach writes rather than from a fresh fetch.
+  let stopFns: (() => void)[] = [];
+  afterEach(function () {
+    stopFns.forEach((fn) => {
+      fn();
+    });
+    stopFns = [];
+  });
+
   beforeEach(async function () {
     await resetDatabase("publishJoinedQuery");
     await makeFixtureHunt(Random.id());
@@ -83,7 +95,7 @@ describe("publishJoinedQuery", function () {
 
   it("can follow a string foreign key", async function () {
     const sub = new StubSubscription();
-    after(() => sub.stop());
+    stopFns.push(() => sub.stop());
 
     const guessId = "obeeKs3ZEkBe3ykeg";
     const puzzleId = "fXchzrh8X9EoSZu6k";
@@ -115,7 +127,7 @@ describe("publishJoinedQuery", function () {
 
   it("can follow an array foreign key", async function () {
     const sub = new StubSubscription();
-    after(() => sub.stop());
+    stopFns.push(() => sub.stop());
 
     const puzzleId = "fXchzrh8X9EoSZu6k";
     const tagIds = ["o5JdfTizW4tGwhRnP", "QeJLufdCqv7rMSSbS"];
@@ -147,7 +159,7 @@ describe("publishJoinedQuery", function () {
 
   it("updates if foreign keys change", async function () {
     const sub = new StubSubscription();
-    after(() => sub.stop());
+    stopFns.push(() => sub.stop());
 
     const puzzleId = "fXchzrh8X9EoSZu6k";
     const newTagIds = ["NwhNGo64jRs384HwN", "27YauwyRpL6yMsCef"];
@@ -168,28 +180,9 @@ describe("publishJoinedQuery", function () {
       { _id: puzzleId },
     );
 
-    const updatePropagated = new Promise<void>((resolve, reject) => {
-      let handleThunk: Meteor.LiveQueryHandle | undefined;
-      Puzzles.find(puzzleId)
-        .observeChangesAsync({
-          changed: () => {
-            if (handleThunk) {
-              handleThunk.stop();
-              handleThunk = undefined;
-              resolve();
-            }
-          },
-        })
-        .then((handle) => {
-          handleThunk = handle;
-        })
-        .catch(reject);
-      after(() => handleThunk?.stop());
+    await withWriteFence(async () => {
+      await Puzzles.updateAsync(puzzleId, { $set: { tags: newTagIds } });
     });
-
-    await Puzzles.updateAsync(puzzleId, { $set: { tags: newTagIds } });
-    // make sure the update has propagated to oplog watchers
-    await updatePropagated;
 
     assert.sameMembers([...sub.data.keys()], [Puzzles.name, Tags.name]);
 
@@ -198,24 +191,11 @@ describe("publishJoinedQuery", function () {
 
     const tagCollection = sub.data.get(Tags.name)!;
 
-    // Give the sub an additional while to process the updated foreign keys,
-    // since we wind up with a bunch of chained promises that have to be
-    // awaited within JoinedObjectObserver to ensure we emit updates in the
-    // right order, and that has to do some async mongo queries.  In local
-    // testing, this generally completes within 10 turns and 2ms.
-    for (let i = 0; i < 1000; i++) {
-      // console.log(`tick ${i}`);
-      await setImmediate();
-      // Exit early if condition is satisfied
-      const observed = [...tagCollection.keys()];
-      const newSortedTagIds = newTagIds.toSorted();
-      if (
-        observed.length === newTagIds.length &&
-        observed.toSorted().every((val, j) => val === newSortedTagIds[j])
-      ) {
-        break;
-      }
-    }
-    assert.sameMembers([...tagCollection.keys()], newTagIds);
+    // The fence guarantees our observer saw the update, but the sub picks up
+    // the new foreign keys through promise chains that run their own mongo
+    // queries, so poll until the join converges.
+    await waitForAssertion(() => {
+      assert.sameMembers([...tagCollection.keys()], newTagIds);
+    });
   });
 });

--- a/types/meteor/ddp-server.d.ts
+++ b/types/meteor/ddp-server.d.ts
@@ -1,0 +1,11 @@
+declare module "meteor/ddp-server" {
+  import type { Meteor } from "meteor/meteor";
+
+  namespace DDPServer {
+    class _WriteFence {
+      armAndWait(): Promise<void>;
+    }
+
+    const _CurrentWriteFence: Meteor.EnvironmentVariable<_WriteFence | null>;
+  }
+}


### PR DESCRIPTION
I was curious if we were actually going to be able to upgrade to Meteor 3.5.1 when it came out and the answer was...mostly. I've filed meteor/meteor#14608, which is a showstopper bug for us, but otherwise Jolly Roger seems to mostly work, although the tests fail.

Why do the tests fail? Because as of 3.5, Meteor defaults to using MongoDB change streams (yay!) but our tests reach into the internals of the oplog driver (boo!).

So here is an anticipatory fix that makes the tests backend-agnostic by using a mechanism that Meteor methods already depend on. It should work against both 3.4 and 3.5. (And for bonus points, might work against the polling backend if for some reason anyone was manually opting into running tests with that? Although I haven't tested and don't especially care - if you want to break your MongoDB you can keep both pieces)

Here's the change, for reference:

> Decouple reactivity tests from the oplog observe driver
> 
> Previously these tests fenced on `_oplogHandle.waitUntilCaughtUp()`, which (obviously) depends on observers being driven by the oplog. With Meteor 3.5, the default switches to change streams; the oplog endpoints still exist but never fire.
> 
> Instead, wrap test writes in a DDP write fence, which resolves once every interested observer has processed them. That's the same guarantee used by Meteor methods (writes that are part of a method are pushed before the method itself returns), so we can rely on all drivers to support it.
> 
> The publishJoinedQuery tests also leaked their subscriptions until the end of the suite (`after()` inside `it()` registers a suite-level hook), letting a later identical query seed itself from an earlier test's stale multiplexer cache; they now stop in `afterEach`. Their convergence loop counted `setImmediate` turns, which bounds nothing under a driver with real network latency; it now polls a wall-clock deadline.
> 
> The full suite passes under both drivers (3.4.1 oplog, release-3.5.1 change streams).