### PR TITLE
Create a bookmarklet to add puzzles from puzzle pages

### DIFF
--- a/imports/client/components/AddPuzzlePage.tsx
+++ b/imports/client/components/AddPuzzlePage.tsx
@@ -1,8 +1,13 @@
 import { Meteor } from "meteor/meteor";
 import { useTracker } from "meteor/react-meteor-data";
-import { useCallback, useMemo, useRef } from "react";
+import { useCallback, useMemo } from "react";
 import Alert from "react-bootstrap/Alert";
+import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
+import FormGroup from "react-bootstrap/FormGroup";
+import FormLabel from "react-bootstrap/FormLabel";
+import FormSelect from "react-bootstrap/FormSelect";
+import Row from "react-bootstrap/Row";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router";
 import inferPuzzleTitle from "../../lib/inferPuzzleTitle";
@@ -17,10 +22,7 @@ import { useAddPuzzleLastSelectedHuntId } from "../hooks/persisted-state";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import useTypedSubscribe from "../hooks/useTypedSubscribe";
 import Loading from "./Loading";
-import type {
-  PuzzleModalFormHandle,
-  PuzzleModalFormSubmitPayload,
-} from "./PuzzleModalForm";
+import type { PuzzleModalFormSubmitPayload } from "./PuzzleModalForm";
 import PuzzleModalForm from "./PuzzleModalForm";
 
 /**
@@ -83,8 +85,6 @@ const AddPuzzlePage = () => {
     }
     return Tags.find({ hunt: selectedHuntId }).fetch();
   }, [selectedHuntId, loadingTags]);
-
-  const addModalRef = useRef<PuzzleModalFormHandle>(null);
 
   const isPopup = Boolean(window.opener);
 
@@ -166,17 +166,38 @@ const AddPuzzlePage = () => {
   return (
     <Container className="p-3">
       <PuzzleModalForm
-        ref={addModalRef}
         huntId={selectedHuntId}
         tags={huntTags}
         initialTitle={inferredTitle}
         initialUrl={urlParam}
-        hunts={writableHunts}
-        onHuntChange={onHuntChange}
         onSubmit={onSubmit}
         onHide={onHide}
         inline
-      />
+      >
+        {writableHunts.length > 1 && (
+          <FormGroup
+            as={Row}
+            className="mb-3"
+            controlId="add-puzzle-hunt-select"
+          >
+            <FormLabel column xs={3}>
+              {t("puzzle.edit.hunt", "Hunt")}
+            </FormLabel>
+            <Col xs={9}>
+              <FormSelect
+                value={selectedHuntId}
+                onChange={(e) => onHuntChange(e.currentTarget.value)}
+              >
+                {writableHunts.map((h) => (
+                  <option key={h._id} value={h._id}>
+                    {h.name}
+                  </option>
+                ))}
+              </FormSelect>
+            </Col>
+          </FormGroup>
+        )}
+      </PuzzleModalForm>
     </Container>
   );
 };

--- a/imports/client/components/AddPuzzlePage.tsx
+++ b/imports/client/components/AddPuzzlePage.tsx
@@ -1,0 +1,184 @@
+import { Meteor } from "meteor/meteor";
+import { useTracker } from "meteor/react-meteor-data";
+import { useCallback, useMemo, useRef } from "react";
+import Alert from "react-bootstrap/Alert";
+import Container from "react-bootstrap/Container";
+import { useTranslation } from "react-i18next";
+import { useNavigate, useSearchParams } from "react-router";
+import inferPuzzleTitle from "../../lib/inferPuzzleTitle";
+import Hunts from "../../lib/models/Hunts";
+import Tags from "../../lib/models/Tags";
+import { userMayWritePuzzlesForHunt } from "../../lib/permission_stubs";
+import huntsAll from "../../lib/publications/huntsAll";
+import tagsForHunt from "../../lib/publications/tagsForHunt";
+import createPuzzle from "../../methods/createPuzzle";
+import { useBreadcrumb } from "../hooks/breadcrumb";
+import { useAddPuzzleLastSelectedHuntId } from "../hooks/persisted-state";
+import useDocumentTitle from "../hooks/useDocumentTitle";
+import useTypedSubscribe from "../hooks/useTypedSubscribe";
+import Loading from "./Loading";
+import type {
+  PuzzleModalFormHandle,
+  PuzzleModalFormSubmitPayload,
+} from "./PuzzleModalForm";
+import PuzzleModalForm from "./PuzzleModalForm";
+
+/**
+ * Standalone page for adding a puzzle to a hunt, designed for use with
+ * the bookmarklet. Allows selecting the target hunt and prepopulates
+ * the title and URL from query parameters.
+ */
+const AddPuzzlePage = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  const urlParam = searchParams.get("url") ?? undefined;
+  const titleParam = searchParams.get("title") ?? undefined;
+  const inferredTitle = useMemo(
+    () => inferPuzzleTitle(titleParam, urlParam),
+    [titleParam, urlParam],
+  );
+
+  const [lastSelectedHuntId, setLastSelectedHuntId] =
+    useAddPuzzleLastSelectedHuntId();
+
+  const huntsLoading = useTypedSubscribe(huntsAll);
+  const loadingHunts = huntsLoading();
+
+  const user = useTracker(() => Meteor.user(), []);
+  const writableHunts = useTracker(() => {
+    if (loadingHunts) {
+      return [];
+    }
+    const allHunts = Hunts.find({}, { sort: { createdAt: -1 } }).fetch();
+    return allHunts.filter((h) => userMayWritePuzzlesForHunt(user, h));
+  }, [loadingHunts, user]);
+
+  const selectedHuntId = useMemo(() => {
+    if (
+      lastSelectedHuntId &&
+      writableHunts.some((h) => h._id === lastSelectedHuntId)
+    ) {
+      return lastSelectedHuntId;
+    }
+    return writableHunts[0]?._id;
+  }, [lastSelectedHuntId, writableHunts]);
+
+  const onHuntChange = useCallback(
+    (newHuntId: string) => {
+      setLastSelectedHuntId(newHuntId);
+    },
+    [setLastSelectedHuntId],
+  );
+
+  const tagsLoading = useTypedSubscribe(tagsForHunt, {
+    huntId: selectedHuntId ?? "",
+  });
+  const loadingTags = Boolean(selectedHuntId && tagsLoading());
+
+  const huntTags = useTracker(() => {
+    if (!selectedHuntId || loadingTags) {
+      return [];
+    }
+    return Tags.find({ hunt: selectedHuntId }).fetch();
+  }, [selectedHuntId, loadingTags]);
+
+  const addModalRef = useRef<PuzzleModalFormHandle>(null);
+
+  const isPopup = Boolean(window.opener);
+
+  const closePopup = useCallback(() => {
+    // Defer closing until the next tick so Meteor's in-flight method queue
+    // settles, preventing close.ts from triggering an uncommitted changes alert.
+    Meteor.defer(() => {
+      window.close();
+    });
+  }, []);
+
+  const onSubmit = useCallback(
+    (
+      payload: PuzzleModalFormSubmitPayload,
+      callback: (error?: Error) => void,
+    ) => {
+      const { docType, ...rest } = payload;
+      if (!docType) {
+        callback(new Error("No docType provided"));
+        return;
+      }
+
+      createPuzzle.call({ docType, ...rest }, (error) => {
+        callback(error);
+        if (!error) {
+          if (isPopup) {
+            closePopup();
+          } else if (payload.huntId) {
+            void navigate(`/hunts/${payload.huntId}/puzzles`);
+          }
+        }
+      });
+    },
+    [navigate, isPopup, closePopup],
+  );
+
+  const onHide = useCallback(() => {
+    if (isPopup) {
+      closePopup();
+    } else if (window.history.length > 1) {
+      void navigate(-1);
+    } else if (selectedHuntId) {
+      void navigate(`/hunts/${selectedHuntId}/puzzles`);
+    } else {
+      void navigate("/hunts");
+    }
+  }, [navigate, selectedHuntId, isPopup, closePopup]);
+
+  useBreadcrumb({
+    title: t("puzzle.edit.addPuzzle", "Add puzzle"),
+    path: "/hunts/addpuzzle",
+  });
+
+  useDocumentTitle(
+    `${t("puzzle.edit.addPuzzle", "Add puzzle")} :: Jolly Roger`,
+  );
+
+  if (loadingHunts) {
+    return <Loading />;
+  }
+
+  if (writableHunts.length === 0) {
+    return (
+      <Container className="p-3">
+        <Alert variant="warning">
+          {t(
+            "addPuzzle.noHuntsAvailable",
+            "You do not have permission to add puzzles to any hunts. Please join a hunt or contact an operator.",
+          )}
+        </Alert>
+      </Container>
+    );
+  }
+
+  if (!selectedHuntId || loadingTags) {
+    return <Loading />;
+  }
+
+  return (
+    <Container className="p-3">
+      <PuzzleModalForm
+        ref={addModalRef}
+        huntId={selectedHuntId}
+        tags={huntTags}
+        initialTitle={inferredTitle}
+        initialUrl={urlParam}
+        hunts={writableHunts}
+        onHuntChange={onHuntChange}
+        onSubmit={onSubmit}
+        onHide={onHide}
+        inline
+      />
+    </Container>
+  );
+};
+
+export default AddPuzzlePage;

--- a/imports/client/components/ModalForm.tsx
+++ b/imports/client/components/ModalForm.tsx
@@ -32,9 +32,11 @@ const ModalForm = (props: {
   submitDisabled?: boolean;
   closeDisabled?: boolean;
   onSubmit: (callback: () => void) => void;
+  onHide?: () => void;
   children: React.ReactNode;
   ref: React.Ref<ModalFormHandle>;
 }) => {
+  const { onHide, onSubmit } = props;
   const [isShown, setIsShown] = useState(false);
   const dontTryToHide = useRef(false);
 
@@ -44,7 +46,8 @@ const ModalForm = (props: {
 
   const hide = useCallback(() => {
     setIsShown(false);
-  }, []);
+    onHide?.();
+  }, [onHide]);
 
   useImperativeHandle(props.ref, () => ({
     show,
@@ -58,7 +61,6 @@ const ModalForm = (props: {
     };
   }, []);
 
-  const { onSubmit } = props;
   const submit = useCallback(
     (e: React.SubmitEvent<HTMLFormElement>) => {
       e.preventDefault();

--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -2,7 +2,9 @@ import { Meteor } from "meteor/meteor";
 import { OAuth } from "meteor/oauth";
 import { useTracker } from "meteor/react-meteor-data";
 import { ServiceConfiguration } from "meteor/service-configuration";
-import { useCallback, useId, useMemo, useState } from "react";
+import { faBookmark } from "@fortawesome/free-solid-svg-icons/faBookmark";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useCallback, useId, useMemo, useRef, useState } from "react";
 import Alert from "react-bootstrap/Alert";
 import Badge from "react-bootstrap/Badge";
 import Button from "react-bootstrap/Button";
@@ -380,6 +382,71 @@ const APIKeysSection = ({ apiKeys }: { apiKeys?: APIKeyType[] }) => {
   );
 };
 
+const BookmarkletSection = () => {
+  const { t } = useTranslation();
+  const origin = window.location.origin;
+  const bookmarkletHref = useMemo(() => {
+    const code = `
+      (function () {
+        const title = encodeURIComponent(document.title);
+        const url = encodeURIComponent(window.location.href);
+        const target = "${origin}/hunts/addpuzzle?url=" + url + "&title=" + title;
+        window.open(target, "jr_addpuzzle", "width=550,height=700,scrollbars=yes");
+      })();
+    `;
+    return `javascript:${code.replaceAll(/\s+/g, " ").trim()}`;
+  }, [origin]);
+
+  // React blocks javascript: URLs in href attributes as a security precaution.
+  // We set the href directly on the DOM element via a ref to bypass this.
+  const linkRef = useRef<HTMLAnchorElement | null>(null);
+  const setLinkRef = useCallback(
+    (node: HTMLAnchorElement | null) => {
+      linkRef.current = node;
+      if (node) {
+        node.setAttribute("href", bookmarkletHref);
+      }
+    },
+    [bookmarkletHref],
+  );
+
+  const preventClick = useCallback(
+    (e: React.SyntheticEvent) => e.preventDefault(),
+    [],
+  );
+
+  return (
+    <section className="mb-4">
+      <h3>{t("profile.bookmarklet.title", "Add Puzzle Bookmarklet")}</h3>
+      <p>
+        {t(
+          "profile.bookmarklet.help",
+          "Drag this button to your bookmarks bar. When viewing a puzzle on an external site, click the bookmarklet to quickly add it to Jolly Roger with the title and URL prepopulated.",
+        )}
+      </p>
+      <div>
+        {/* The href is set via ref to bypass React's javascript: URL blocking.
+            We keep href="#" here so the <a> is valid for a11y linting. */}
+        {/* oxlint-disable-next-line jsx-a11y/anchor-is-valid -- must be an <a> with href for bookmarklet drag-to-bookmarks-bar; onClick only prevents in-page navigation */}
+        <a
+          ref={setLinkRef}
+          href="#"
+          className="btn btn-outline-primary"
+          onClick={preventClick}
+          onKeyDown={preventClick}
+          title={t(
+            "profile.bookmarklet.dragHelp",
+            "Drag me to your bookmarks bar!",
+          )}
+        >
+          <FontAwesomeIcon icon={faBookmark} className="me-2" />
+          {t("profile.bookmarklet.button", "+ Jolly Roger Puzzle")}
+        </a>
+      </div>
+    </section>
+  );
+};
+
 const OwnProfilePage = ({
   initialUser,
   apiKeys,
@@ -551,6 +618,7 @@ const OwnProfilePage = ({
 
       <section className="mt-3">
         <h2>{t("profile.advanced", "Advanced")}</h2>
+        <BookmarkletSection />
         <APIKeysSection apiKeys={apiKeys} />
       </section>
     </Container>

--- a/imports/client/components/OwnProfilePage.tsx
+++ b/imports/client/components/OwnProfilePage.tsx
@@ -384,18 +384,18 @@ const APIKeysSection = ({ apiKeys }: { apiKeys?: APIKeyType[] }) => {
 
 const BookmarkletSection = () => {
   const { t } = useTranslation();
-  const origin = window.location.origin;
   const bookmarkletHref = useMemo(() => {
+    const targetUrl = Meteor.absoluteUrl("/hunts/addpuzzle");
     const code = `
       (function () {
         const title = encodeURIComponent(document.title);
         const url = encodeURIComponent(window.location.href);
-        const target = "${origin}/hunts/addpuzzle?url=" + url + "&title=" + title;
+        const target = "${targetUrl}?url=" + url + "&title=" + title;
         window.open(target, "jr_addpuzzle", "width=550,height=700,scrollbars=yes");
       })();
     `;
-    return `javascript:${code.replaceAll(/\s+/g, " ").trim()}`;
-  }, [origin]);
+    return `javascript:${encodeURIComponent(code)}`;
+  }, []);
 
   // React blocks javascript: URLs in href attributes as a security precaution.
   // We set the href directly on the DOM element via a ref to bypass this.
@@ -411,7 +411,7 @@ const BookmarkletSection = () => {
   );
 
   const preventClick = useCallback(
-    (e: React.SyntheticEvent) => e.preventDefault(),
+    (e: React.MouseEvent<HTMLAnchorElement>) => e.preventDefault(),
     [],
   );
 
@@ -433,7 +433,6 @@ const BookmarkletSection = () => {
           href="#"
           className="btn btn-outline-primary"
           onClick={preventClick}
-          onKeyDown={preventClick}
           title={t(
             "profile.bookmarklet.dragHelp",
             "Drag me to your bookmarks bar!",

--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -17,11 +17,13 @@ import type { FormControlProps } from "react-bootstrap/FormControl";
 import FormControl from "react-bootstrap/FormControl";
 import FormGroup from "react-bootstrap/FormGroup";
 import FormLabel from "react-bootstrap/FormLabel";
+import FormSelect from "react-bootstrap/FormSelect";
 import Row from "react-bootstrap/Row";
 import { useTranslation } from "react-i18next";
 import type { ActionMeta } from "react-select";
 import { useTheme } from "styled-components";
 import type { GdriveMimeTypesType } from "../../lib/GdriveMimeTypes";
+import type { HuntType } from "../../lib/models/Hunts";
 import type { PuzzleType } from "../../lib/models/Puzzles";
 import type { TagType } from "../../lib/models/Tags";
 import { useAddPuzzleHuntRecentTags } from "../hooks/persisted-state";
@@ -59,14 +61,7 @@ export type PuzzleModalFormHandle = {
   show: () => void;
 };
 
-const PuzzleModalForm = ({
-  huntId,
-  puzzle,
-  tags: propsTags,
-  onSubmit,
-  showOnMount,
-  ref,
-}: {
+export interface PuzzleModalFormProps {
   huntId: string;
   puzzle?: PuzzleType;
   // All known tags for this hunt
@@ -76,8 +71,30 @@ const PuzzleModalForm = ({
     callback: (error?: Error) => void,
   ) => void;
   showOnMount?: boolean;
+  /** When true, renders as a full-page form instead of inside a modal dialog. */
+  inline?: boolean;
+  initialTitle?: string;
+  initialUrl?: string;
+  hunts?: HuntType[];
+  onHuntChange?: (huntId: string) => void;
+  onHide?: () => void;
   ref: React.Ref<PuzzleModalFormHandle>;
-}) => {
+}
+
+const PuzzleModalForm = ({
+  huntId,
+  puzzle,
+  tags: propsTags,
+  onSubmit,
+  showOnMount,
+  inline,
+  initialTitle,
+  initialUrl,
+  hunts,
+  onHuntChange,
+  onHide,
+  ref,
+}: PuzzleModalFormProps) => {
   const tagNamesForIds = useCallback(
     (tagIds: string[]) => {
       const tagNames: Record<string, string> = {};
@@ -89,8 +106,8 @@ const PuzzleModalForm = ({
     [propsTags],
   );
 
-  const [title, setTitle] = useState(puzzle?.title ?? "");
-  const [url, setUrl] = useState(puzzle?.url ?? "");
+  const [title, setTitle] = useState(puzzle?.title ?? initialTitle ?? "");
+  const [url, setUrl] = useState(puzzle?.url ?? initialUrl ?? "");
   const [tags, setTags] = useState(puzzle ? tagNamesForIds(puzzle.tags) : []);
   const [docType, setDocType] = useState<GdriveMimeTypesType | undefined>(
     puzzle ? undefined : "spreadsheet",
@@ -208,7 +225,7 @@ const PuzzleModalForm = ({
   const { t } = useTranslation();
 
   const onFormSubmit = useCallback(
-    (callback: () => void) => {
+    (callback?: () => void) => {
       setSubmitState(PuzzleModalFormSubmitState.SUBMITTING);
       const payload: PuzzleModalFormSubmitPayload = {
         huntId,
@@ -256,7 +273,7 @@ const PuzzleModalForm = ({
           setConfirmingDuplicateUrl(false);
           setAllowDuplicateUrls(false);
           addPuzzleHuntRecentTags(tags);
-          callback();
+          callback?.();
         }
       });
     },
@@ -282,12 +299,15 @@ const PuzzleModalForm = ({
   }, []);
 
   const reset = useCallback(() => {
-    setTitle("");
-    setUrl("");
+    setTitle(initialTitle ?? "");
+    setUrl(initialUrl ?? "");
     setTags([]);
     setExpectedAnswerCount(1);
     setDocType("spreadsheet");
-  }, []);
+    setTitleDirty(false);
+    setUrlDirty(false);
+    setTagsDirty(false);
+  }, [initialTitle, initialUrl]);
 
   const currentTitle = useMemo(() => {
     if (!titleDirty && puzzle) {
@@ -414,6 +434,169 @@ const PuzzleModalForm = ({
 
   const theme = useTheme();
 
+  const formTitle = puzzle
+    ? t("puzzle.edit.editPuzzle", "Edit puzzle")
+    : t("puzzle.edit.addPuzzle", "Add puzzle");
+
+  const formFields = (
+    <>
+      {hunts && hunts.length > 1 && onHuntChange && (
+        <FormGroup
+          as={Row}
+          className="mb-3"
+          controlId={`${idPrefix}-hunt-select`}
+        >
+          <FormLabel column xs={3}>
+            {t("puzzle.edit.hunt", "Hunt")}
+          </FormLabel>
+          <Col xs={9}>
+            <FormSelect
+              value={huntId}
+              disabled={disableForm}
+              onChange={(e) => onHuntChange(e.currentTarget.value)}
+            >
+              {hunts.map((h) => (
+                <option key={h._id} value={h._id}>
+                  {h.name}
+                </option>
+              ))}
+            </FormSelect>
+          </Col>
+        </FormGroup>
+      )}
+
+      <FormGroup
+        as={Row}
+        className="mb-3"
+        controlId={`${idPrefix}-new-puzzle-title`}
+      >
+        <FormLabel column xs={3}>
+          {t("puzzle.edit.title", "Title")}
+        </FormLabel>
+        <Col xs={9}>
+          <FormControl
+            type="text"
+            autoFocus
+            disabled={disableForm}
+            onChange={onTitleChange}
+            value={currentTitle}
+          />
+        </Col>
+      </FormGroup>
+
+      <FormGroup
+        as={Row}
+        className="mb-3"
+        controlId={`${idPrefix}-new-puzzle-url`}
+      >
+        <FormLabel column xs={3}>
+          {t("puzzle.edit.url", "URL")}
+        </FormLabel>
+        <Col xs={9}>
+          <FormControl
+            type="text"
+            disabled={disableForm}
+            onChange={onUrlChange}
+            value={currentUrl}
+          />
+          {allowDuplicateUrlsCheckbox}
+        </Col>
+      </FormGroup>
+
+      <FormGroup
+        as={Row}
+        className="mb-3"
+        controlId={`${idPrefix}-new-puzzle-tags`}
+      >
+        <FormLabel column xs={3}>
+          {t("puzzle.edit.tags", "Tags")}
+        </FormLabel>
+        <Col xs={9}>
+          <Creatable
+            id={`${idPrefix}-new-puzzle-tags`}
+            theme={theme.reactSelectTheme}
+            options={selectOptions}
+            isMulti
+            isDisabled={disableForm}
+            onChange={onTagsChange}
+            value={currentTags.map((t) => {
+              return { label: t, value: t };
+            })}
+          />
+          {unselectedRecentTags.length > 0 && (
+            <div className="mt-1 d-flex flex-wrap gap-1 align-items-center">
+              <small className="text-muted me-1">
+                {t("puzzle.edit.recentTags", "Recent:")}
+              </small>
+              {unselectedRecentTags.map((recentTag) => (
+                <Button
+                  key={recentTag}
+                  variant="outline-secondary"
+                  size="sm"
+                  className="py-0 px-1"
+                  style={{ fontSize: "0.8rem" }}
+                  disabled={disableForm}
+                  onClick={() => addTag(recentTag)}
+                >
+                  +{recentTag}
+                </Button>
+              ))}
+            </div>
+          )}
+        </Col>
+      </FormGroup>
+
+      {docTypeSelector}
+
+      <FormGroup
+        as={Row}
+        className="mb-3"
+        controlId={`${idPrefix}-new-puzzle-expected-answer-count`}
+      >
+        <FormLabel column xs={3}>
+          {t("puzzle.edit.answerCount", "Expected # of answers")}
+        </FormLabel>
+        <Col xs={9}>
+          <FormControl
+            type="number"
+            disabled={disableForm}
+            onChange={onExpectedAnswerCountChange}
+            value={currentExpectedAnswerCount}
+            min={0}
+            step={1}
+          />
+        </Col>
+      </FormGroup>
+
+      {currentExpectedAnswerCount === 0 ? (
+        <FormCheck
+          id={`${idPrefix}-solved-with-no-answers`}
+          label={t(
+            "puzzle.edit.considerSolvedWithNoAnswer",
+            "Consider solved with no answers",
+          )}
+          type="checkbox"
+          checked={currentConsiderCompletedWithNoAnswer}
+          disabled={disableForm}
+          onChange={onConsiderSolvedWithNoAnswerChange}
+          className="mt-1"
+        />
+      ) : undefined}
+
+      {submitState === PuzzleModalFormSubmitState.FAILED && (
+        <Alert variant="danger">{errorMessage}</Alert>
+      )}
+    </>
+  );
+
+  const inlineSubmit = useCallback(
+    (e: React.SubmitEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      onFormSubmit();
+    },
+    [onFormSubmit],
+  );
+
   return (
     <Suspense
       fallback={
@@ -422,138 +605,32 @@ const PuzzleModalForm = ({
         </div>
       }
     >
-      <ModalForm
-        ref={formRef}
-        title={
-          puzzle
-            ? t("puzzle.edit.editPuzzle", "Edit puzzle")
-            : t("puzzle.edit.addPuzzle", "Add puzzle")
-        }
-        onSubmit={onFormSubmit}
-        submitDisabled={disableForm}
-      >
-        <FormGroup
-          as={Row}
-          className="mb-3"
-          controlId={`${idPrefix}-new-puzzle-title`}
-        >
-          <FormLabel column xs={3}>
-            {t("puzzle.edit.title", "Title")}
-          </FormLabel>
-          <Col xs={9}>
-            <FormControl
-              type="text"
-              autoFocus
-              disabled={disableForm}
-              onChange={onTitleChange}
-              value={currentTitle}
-            />
-          </Col>
-        </FormGroup>
-
-        <FormGroup
-          as={Row}
-          className="mb-3"
-          controlId={`${idPrefix}-new-puzzle-url`}
-        >
-          <FormLabel column xs={3}>
-            {t("puzzle.edit.url", "URL")}
-          </FormLabel>
-          <Col xs={9}>
-            <FormControl
-              type="text"
-              disabled={disableForm}
-              onChange={onUrlChange}
-              value={currentUrl}
-            />
-            {allowDuplicateUrlsCheckbox}
-          </Col>
-        </FormGroup>
-
-        <FormGroup
-          as={Row}
-          className="mb-3"
-          controlId={`${idPrefix}-new-puzzle-tags`}
-        >
-          <FormLabel column xs={3}>
-            {t("puzzle.edit.tags", "Tags")}
-          </FormLabel>
-          <Col xs={9}>
-            <Creatable
-              id={`${idPrefix}-new-puzzle-tags`}
-              theme={theme.reactSelectTheme}
-              options={selectOptions}
-              isMulti
-              isDisabled={disableForm}
-              onChange={onTagsChange}
-              value={currentTags.map((t) => {
-                return { label: t, value: t };
-              })}
-            />
-            {unselectedRecentTags.length > 0 && (
-              <div className="mt-1 d-flex flex-wrap gap-1 align-items-center">
-                <small className="text-muted me-1">
-                  {t("puzzle.edit.recentTags", "Recent:")}
-                </small>
-                {unselectedRecentTags.map((recentTag) => (
-                  <Button
-                    key={recentTag}
-                    variant="outline-secondary"
-                    size="sm"
-                    className="py-0 px-1"
-                    style={{ fontSize: "0.8rem" }}
-                    disabled={disableForm}
-                    onClick={() => addTag(recentTag)}
-                  >
-                    +{recentTag}
-                  </Button>
-                ))}
-              </div>
+      {inline ? (
+        <form className="form-horizontal" onSubmit={inlineSubmit}>
+          <h4 className="mb-3">{formTitle}</h4>
+          {formFields}
+          <div className="d-flex justify-content-end gap-2 mt-3">
+            {onHide && (
+              <Button variant="light" onClick={onHide} disabled={disableForm}>
+                {t("common.close", "Close")}
+              </Button>
             )}
-          </Col>
-        </FormGroup>
-
-        {docTypeSelector}
-
-        <FormGroup
-          as={Row}
-          className="mb-3"
-          controlId={`${idPrefix}-new-puzzle-expected-answer-count`}
+            <Button variant="primary" type="submit" disabled={disableForm}>
+              {t("common.save", "Save")}
+            </Button>
+          </div>
+        </form>
+      ) : (
+        <ModalForm
+          ref={formRef}
+          title={formTitle}
+          onSubmit={onFormSubmit}
+          onHide={onHide}
+          submitDisabled={disableForm}
         >
-          <FormLabel column xs={3}>
-            {t("puzzle.edit.answerCount", "Expected # of answers")}
-          </FormLabel>
-          <Col xs={9}>
-            <FormControl
-              type="number"
-              disabled={disableForm}
-              onChange={onExpectedAnswerCountChange}
-              value={currentExpectedAnswerCount}
-              min={0}
-              step={1}
-            />
-          </Col>
-        </FormGroup>
-
-        {currentExpectedAnswerCount === 0 ? (
-          <FormCheck
-            id={`${idPrefix}-solved-with-no-answers`}
-            label={t(
-              "puzzle.edit.considerSolvedWithNoAnswer",
-              "Consider solved with no answers",
-            )}
-            type="checkbox"
-            checked={currentConsiderCompletedWithNoAnswer}
-            disabled={disableForm}
-            onChange={onConsiderSolvedWithNoAnswerChange}
-            className="mt-1"
-          />
-        ) : undefined}
-
-        {submitState === PuzzleModalFormSubmitState.FAILED && (
-          <Alert variant="danger">{errorMessage}</Alert>
-        )}
-      </ModalForm>
+          {formFields}
+        </ModalForm>
+      )}
     </Suspense>
   );
 };

--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -10,6 +10,7 @@ import React, {
   useState,
 } from "react";
 import Alert from "react-bootstrap/Alert";
+import Button from "react-bootstrap/Button";
 import Col from "react-bootstrap/Col";
 import FormCheck from "react-bootstrap/FormCheck";
 import type { FormControlProps } from "react-bootstrap/FormControl";
@@ -23,6 +24,7 @@ import { useTheme } from "styled-components";
 import type { GdriveMimeTypesType } from "../../lib/GdriveMimeTypes";
 import type { PuzzleType } from "../../lib/models/Puzzles";
 import type { TagType } from "../../lib/models/Tags";
+import { useAddPuzzleHuntRecentTags } from "../hooks/persisted-state";
 import LabelledRadioGroup from "./LabelledRadioGroup";
 import Loading from "./Loading";
 import type { ModalFormHandle } from "./ModalForm";
@@ -116,6 +118,9 @@ const PuzzleModalForm = ({
     setConsiderCompletedWithNoAnswerDirty,
   ] = useState(false);
 
+  const [recentTags, addPuzzleHuntRecentTags] =
+    useAddPuzzleHuntRecentTags(huntId);
+
   const formRef = useRef<ModalFormHandle>(null);
 
   const onTitleChange: NonNullable<FormControlProps["onChange"]> = useCallback(
@@ -158,6 +163,14 @@ const PuzzleModalForm = ({
     },
     [],
   );
+
+  const addTag = useCallback((tag: string) => {
+    setTags((prev) => {
+      if (prev.includes(tag)) return prev;
+      setTagsDirty(true);
+      return [...prev, tag];
+    });
+  }, []);
 
   const onDocTypeChange = useCallback((newValue: string) => {
     setDocType(newValue as GdriveMimeTypesType);
@@ -242,6 +255,7 @@ const PuzzleModalForm = ({
           setConsiderCompletedWithNoAnswerDirty(false);
           setConfirmingDuplicateUrl(false);
           setAllowDuplicateUrls(false);
+          addPuzzleHuntRecentTags(tags);
           callback();
         }
       });
@@ -256,6 +270,7 @@ const PuzzleModalForm = ({
       docType,
       allowDuplicateUrls,
       considerCompletedWithNoAnswer,
+      addPuzzleHuntRecentTags,
       t,
     ],
   );
@@ -342,6 +357,11 @@ const PuzzleModalForm = ({
     .map((t) => {
       return { value: t, label: t };
     });
+
+  const unselectedRecentTags = useMemo(
+    () => recentTags.filter((rt) => !currentTags.includes(rt)),
+    [recentTags, currentTags],
+  );
 
   const idPrefix = useId();
 
@@ -470,6 +490,26 @@ const PuzzleModalForm = ({
                 return { label: t, value: t };
               })}
             />
+            {unselectedRecentTags.length > 0 && (
+              <div className="mt-1 d-flex flex-wrap gap-1 align-items-center">
+                <small className="text-muted me-1">
+                  {t("puzzle.edit.recentTags", "Recent:")}
+                </small>
+                {unselectedRecentTags.map((recentTag) => (
+                  <Button
+                    key={recentTag}
+                    variant="outline-secondary"
+                    size="sm"
+                    className="py-0 px-1"
+                    style={{ fontSize: "0.8rem" }}
+                    disabled={disableForm}
+                    onClick={() => addTag(recentTag)}
+                  >
+                    +{recentTag}
+                  </Button>
+                ))}
+              </div>
+            )}
           </Col>
         </FormGroup>
 

--- a/imports/client/components/PuzzleModalForm.tsx
+++ b/imports/client/components/PuzzleModalForm.tsx
@@ -17,13 +17,11 @@ import type { FormControlProps } from "react-bootstrap/FormControl";
 import FormControl from "react-bootstrap/FormControl";
 import FormGroup from "react-bootstrap/FormGroup";
 import FormLabel from "react-bootstrap/FormLabel";
-import FormSelect from "react-bootstrap/FormSelect";
 import Row from "react-bootstrap/Row";
 import { useTranslation } from "react-i18next";
 import type { ActionMeta } from "react-select";
 import { useTheme } from "styled-components";
 import type { GdriveMimeTypesType } from "../../lib/GdriveMimeTypes";
-import type { HuntType } from "../../lib/models/Hunts";
 import type { PuzzleType } from "../../lib/models/Puzzles";
 import type { TagType } from "../../lib/models/Tags";
 import { useAddPuzzleHuntRecentTags } from "../hooks/persisted-state";
@@ -75,10 +73,9 @@ export interface PuzzleModalFormProps {
   inline?: boolean;
   initialTitle?: string;
   initialUrl?: string;
-  hunts?: HuntType[];
-  onHuntChange?: (huntId: string) => void;
   onHide?: () => void;
-  ref: React.Ref<PuzzleModalFormHandle>;
+  ref?: React.Ref<PuzzleModalFormHandle>;
+  children?: React.ReactNode;
 }
 
 const PuzzleModalForm = ({
@@ -90,10 +87,9 @@ const PuzzleModalForm = ({
   inline,
   initialTitle,
   initialUrl,
-  hunts,
-  onHuntChange,
   onHide,
   ref,
+  children,
 }: PuzzleModalFormProps) => {
   const tagNamesForIds = useCallback(
     (tagIds: string[]) => {
@@ -272,13 +268,16 @@ const PuzzleModalForm = ({
           setConsiderCompletedWithNoAnswerDirty(false);
           setConfirmingDuplicateUrl(false);
           setAllowDuplicateUrls(false);
-          addPuzzleHuntRecentTags(tags);
+          if (!puzzle) {
+            addPuzzleHuntRecentTags(tags);
+          }
           callback?.();
         }
       });
     },
     [
       onSubmit,
+      puzzle,
       huntId,
       title,
       url,
@@ -440,31 +439,6 @@ const PuzzleModalForm = ({
 
   const formFields = (
     <>
-      {hunts && hunts.length > 1 && onHuntChange && (
-        <FormGroup
-          as={Row}
-          className="mb-3"
-          controlId={`${idPrefix}-hunt-select`}
-        >
-          <FormLabel column xs={3}>
-            {t("puzzle.edit.hunt", "Hunt")}
-          </FormLabel>
-          <Col xs={9}>
-            <FormSelect
-              value={huntId}
-              disabled={disableForm}
-              onChange={(e) => onHuntChange(e.currentTarget.value)}
-            >
-              {hunts.map((h) => (
-                <option key={h._id} value={h._id}>
-                  {h.name}
-                </option>
-              ))}
-            </FormSelect>
-          </Col>
-        </FormGroup>
-      )}
-
       <FormGroup
         as={Row}
         className="mb-3"
@@ -608,6 +582,7 @@ const PuzzleModalForm = ({
       {inline ? (
         <form className="form-horizontal" onSubmit={inlineSubmit}>
           <h4 className="mb-3">{formTitle}</h4>
+          {children}
           {formFields}
           <div className="d-flex justify-content-end gap-2 mt-3">
             {onHide && (
@@ -628,6 +603,7 @@ const PuzzleModalForm = ({
           onHide={onHide}
           submitDisabled={disableForm}
         >
+          {children}
           {formFields}
         </ModalForm>
       )}

--- a/imports/client/components/Routes.tsx
+++ b/imports/client/components/Routes.tsx
@@ -7,6 +7,7 @@ import { BreadcrumbsProvider } from "../hooks/breadcrumb";
 import { useAppThemeState } from "../hooks/persisted-state";
 import useDocumentTitle from "../hooks/useDocumentTitle";
 import { darkTheme, lightTheme } from "../theme";
+import AddPuzzlePage from "./AddPuzzlePage";
 import AllProfileListPage from "./AllProfileListPage";
 import AnnouncementsPage from "./AnnouncementsPage";
 import { AuthenticatedPage, UnauthenticatedPage } from "./authentication";
@@ -43,6 +44,7 @@ export const AuthenticatedRouteList: RouteObject[] = [
     path: "/hunts",
     element: <HuntListApp />,
     children: [
+      { path: "addpuzzle", element: <AddPuzzlePage /> },
       {
         path: ":huntId",
         element: <HuntApp />,

--- a/imports/client/hooks/persisted-state.ts
+++ b/imports/client/hooks/persisted-state.ts
@@ -171,6 +171,13 @@ export const useHuntPuzzleListCollapseGroup = (
   ] as const;
 };
 
+export const useAddPuzzleLastSelectedHuntId = () => {
+  return useLocalStorage<string | undefined>(
+    "addPuzzleLastSelectedHuntId",
+    undefined,
+  );
+};
+
 const ADD_PUZZLE_RECENT_TAGS_LIMIT = 10;
 
 export const useAddPuzzleHuntRecentTags = (huntId?: string) => {

--- a/imports/client/hooks/persisted-state.ts
+++ b/imports/client/hooks/persisted-state.ts
@@ -170,3 +170,34 @@ export const useHuntPuzzleListCollapseGroup = (
     ),
   ] as const;
 };
+
+const ADD_PUZZLE_RECENT_TAGS_LIMIT = 10;
+
+export const useAddPuzzleHuntRecentTags = (huntId?: string) => {
+  const [allRecentTags, setAllRecentTags] = useLocalStorage<
+    Record<string /* huntId */, string[]>
+  >("huntRecentTags", {});
+
+  const recentTags = (huntId ? allRecentTags?.[huntId] : undefined) ?? [];
+
+  const addPuzzleHuntRecentTags = useCallback(
+    (newTags: string[]) => {
+      if (!huntId || newTags.length === 0) return;
+      setAllRecentTags((prev) => {
+        const prevHuntTags = prev?.[huntId] ?? [];
+        // Newly added tags at the beginning, followed by previous tags excluding new ones, truncated to limit
+        const combined = [
+          ...newTags,
+          ...prevHuntTags.filter((t) => !newTags.includes(t)),
+        ].slice(0, ADD_PUZZLE_RECENT_TAGS_LIMIT);
+        return {
+          ...prev,
+          [huntId]: combined,
+        };
+      });
+    },
+    [setAllRecentTags, huntId],
+  );
+
+  return [recentTags, addPuzzleHuntRecentTags] as const;
+};

--- a/imports/lib/inferPuzzleTitle.ts
+++ b/imports/lib/inferPuzzleTitle.ts
@@ -27,7 +27,8 @@ export default function inferPuzzleTitle(
   const pathname = parsedUrl.pathname.toLowerCase();
 
   if (
-    hostname.includes("pandamagazine.com") &&
+    (hostname === "pandamagazine.com" ||
+      hostname.endsWith(".pandamagazine.com")) &&
     pathname.includes("island") &&
     trimmedTitle.includes(" | ")
   ) {
@@ -36,7 +37,8 @@ export default function inferPuzzleTitle(
   }
 
   if (
-    hostname.includes("puzzlehunt.azurewebsites.net") &&
+    (hostname === "puzzlehunt.azurewebsites.net" ||
+      hostname.endsWith(".puzzlehunt.azurewebsites.net")) &&
     trimmedTitle.includes(" - ")
   ) {
     // Microsoft Puzzle Server: e.g. "Puzzle Title - Microsoft Puzzle Server" -> "Puzzle Title"

--- a/imports/lib/inferPuzzleTitle.ts
+++ b/imports/lib/inferPuzzleTitle.ts
@@ -1,0 +1,47 @@
+/**
+ * Given a puzzle page title and URL, infer the puzzle title.
+ *
+ * Strips out redundant information like hunt titles for known puzzle hunt sites.
+ */
+export default function inferPuzzleTitle(
+  pageTitle: string | undefined | null,
+  pageUrl?: string | null,
+): string {
+  if (!pageTitle) {
+    return "";
+  }
+
+  const trimmedTitle = pageTitle.trim();
+  if (!pageUrl) {
+    return trimmedTitle;
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(pageUrl);
+  } catch {
+    return trimmedTitle;
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+  const pathname = parsedUrl.pathname.toLowerCase();
+
+  if (
+    hostname.includes("pandamagazine.com") &&
+    pathname.includes("island") &&
+    trimmedTitle.includes(" | ")
+  ) {
+    // Puzzle Boats: e.g. "Puzzle Boat X | Puzzle Title" -> "Puzzle Title"
+    return trimmedTitle.slice(trimmedTitle.indexOf(" | ") + 3).trim();
+  }
+
+  if (
+    hostname.includes("puzzlehunt.azurewebsites.net") &&
+    trimmedTitle.includes(" - ")
+  ) {
+    // Microsoft Puzzle Server: e.g. "Puzzle Title - Microsoft Puzzle Server" -> "Puzzle Title"
+    return trimmedTitle.slice(0, trimmedTitle.lastIndexOf(" - ")).trim();
+  }
+
+  return trimmedTitle;
+}

--- a/imports/lib/publications/tagsForHunt.ts
+++ b/imports/lib/publications/tagsForHunt.ts
@@ -1,0 +1,3 @@
+import TypedPublication from "./TypedPublication";
+
+export default new TypedPublication<{ huntId: string }>("tagsForHunt");

--- a/imports/server/publications/index.ts
+++ b/imports/server/publications/index.ts
@@ -24,3 +24,4 @@ import "./puzzlesForHunt";
 import "./puzzlesForPuzzleList";
 import "./settingsAll";
 import "./settingsByName";
+import "./tagsForHunt";

--- a/imports/server/publications/tagsForHunt.ts
+++ b/imports/server/publications/tagsForHunt.ts
@@ -1,0 +1,27 @@
+import { check } from "meteor/check";
+import MeteorUsers from "../../lib/models/MeteorUsers";
+import Tags from "../../lib/models/Tags";
+import tagsForHunt from "../../lib/publications/tagsForHunt";
+import definePublication from "./definePublication";
+
+definePublication(tagsForHunt, {
+  validate(arg) {
+    check(arg, {
+      huntId: String,
+    });
+    return arg;
+  },
+
+  async run({ huntId }) {
+    if (!this.userId) {
+      return [];
+    }
+
+    const user = await MeteorUsers.findOneAsync(this.userId);
+    if (!user?.hunts?.includes(huntId)) {
+      return [];
+    }
+
+    return [Tags.find({ hunt: huntId })];
+  },
+});

--- a/tests/client-main.ts
+++ b/tests/client-main.ts
@@ -4,6 +4,7 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 
 import "./unit/imports/lib/calendarTimeFormat";
+import "./unit/imports/lib/inferPuzzleTitle";
 import "./unit/imports/lib/puzzle-sort-and-group";
 import "./unit/imports/lib/relativeTimeFormat";
 import "./unit/imports/lib/ValidateShape";

--- a/tests/server-main.ts
+++ b/tests/server-main.ts
@@ -6,6 +6,7 @@ import chaiAsPromised from "chai-as-promised";
 chai.use(chaiAsPromised);
 
 import "./unit/imports/lib/calendarTimeFormat";
+import "./unit/imports/lib/inferPuzzleTitle";
 import "./unit/imports/lib/puzzle-sort-and-group";
 import "./unit/imports/lib/relativeTimeFormat";
 import "./unit/imports/lib/ValidateShape";

--- a/tests/unit/imports/lib/inferPuzzleTitle.ts
+++ b/tests/unit/imports/lib/inferPuzzleTitle.ts
@@ -1,0 +1,56 @@
+import { assert } from "chai";
+import inferPuzzleTitle from "../../../../imports/lib/inferPuzzleTitle";
+
+describe("inferPuzzleTitle", function () {
+  it("returns empty string for empty/null/undefined input", function () {
+    assert.strictEqual(inferPuzzleTitle(""), "");
+    assert.strictEqual(inferPuzzleTitle(undefined), "");
+    assert.strictEqual(inferPuzzleTitle(null), "");
+  });
+
+  it("infers titles correctly without custom hunt match", function () {
+    assert.strictEqual(inferPuzzleTitle("  Puzzle Title  "), "Puzzle Title");
+    assert.strictEqual(
+      inferPuzzleTitle("Puzzle Title", "https://example.com/puzzles/123"),
+      "Puzzle Title",
+    );
+    assert.strictEqual(
+      inferPuzzleTitle("Puzzle Boat 9 | Puzzle Title", "not a valid url"),
+      "Puzzle Boat 9 | Puzzle Title",
+    );
+  });
+
+  it("infers Puzzle Boats titles correctly", function () {
+    assert.strictEqual(
+      inferPuzzleTitle(
+        "Puzzle Boat 9 | Puzzle Title",
+        "https://pandamagazine.com/island/boat9/puzzle42",
+      ),
+      "Puzzle Title",
+    );
+    assert.strictEqual(
+      inferPuzzleTitle(
+        "Puzzle Boat 8 | Puzzle Name | With Pipe",
+        "https://pandamagazine.com/island/boat8/puzzle1",
+      ),
+      "Puzzle Name | With Pipe",
+    );
+  });
+
+  it("infers Microsoft Puzzle Server titles correctly", function () {
+    assert.strictEqual(
+      inferPuzzleTitle(
+        "Puzzle Title - Microsoft Puzzle Server",
+        "https://puzzlehunt.azurewebsites.net/puzzles/crossword",
+      ),
+      "Puzzle Title",
+    );
+    assert.strictEqual(
+      inferPuzzleTitle(
+        "Puzzle Name - With Hyphen - Microsoft Puzzle Server",
+        "https://puzzlehunt.azurewebsites.net/puzzles/meta",
+      ),
+      "Puzzle Name - With Hyphen",
+    );
+  });
+});


### PR DESCRIPTION
This is modeled off of #2392, but as a bookmarklet rather than a browser extension for a simpler installation, security, and maintenance story.

The bookmarklet is linked from the advanced section of the user's profile page, next to API keys. It launches a popup modal of a standalone Add Puzzle form, sharing most logic with the existing form. A hunt dropdown is added, and the most recently-selected hunt is saved in local storage. The current page's title and URL are prepopulated in the form, and we apply some rough heuristics to strip out redundant information from the title (which can be updated for new hunts as they arise).

In addition, for both the bookmarklet popup as well as the regular Add Puzzle form, we add easy links to add any of the ten most recently used tags for the selected hunt.

See #237